### PR TITLE
Change int2float, float2int of cortex_m for 64bits

### DIFF
--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -199,13 +199,13 @@ def word2byte(data):
 
 ## @brief Convert a 32-bit int to an IEEE754 float.
 def int2float(data):
-    d = struct.pack("@L", data)
+    d = struct.pack("@I", data)
     return struct.unpack("@f", d)[0]
 
 ## @brief Convert an IEEE754 float to a 32-bit int.
 def float2int(data):
     d = struct.pack("@f", data)
-    return struct.unpack("@L", d)[0]
+    return struct.unpack("@I", d)[0]
 
 
 class Breakpoint(object):


### PR DESCRIPTION
Change pack/unpack from L to I in int2float and float2int for cortex_m.
L is 8 bytes long on 64 bits amd64 python (2.7.5+ GCC 4.8.1 Linux).
