### PR TITLE
Fix the deadlock in resume function

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -286,6 +286,8 @@ class GDBServer(threading.Thread):
         
         while True:
             sleep(0.01)
+            if self.shutdown_event.isSet():
+                return self.createRSPPacket(val), 0, 0
             
             try:
                 data = self.abstract_socket.read()

--- a/test/gdb_server.py
+++ b/test/gdb_server.py
@@ -55,8 +55,7 @@ else:
                 logging.error("Port number error!")
     except KeyboardInterrupt:
         if gdb != None:
-            gdb.shutdown_event.set()
-            #gdb.stop()       
+            gdb.stop()
     except Exception as e:
         print "uncaught exception: %s" % e
         traceback.print_exc()


### PR DESCRIPTION
In resume method of gdb server, it don't have any check for the shutdown_event event. So when user in put c in their gdb, the gdb server will enter the dead loop of resume function. Crtl + C will set shutdown_event, but there's no way for the gdb server thread to detect it.
