### PR TITLE
Fix #48 for unexpected program running

### DIFF
--- a/pyOCD/gdbserver/gdbserver.py
+++ b/pyOCD/gdbserver/gdbserver.py
@@ -338,7 +338,7 @@ class GDBServer(threading.Thread):
         
     def flashOp(self, data):
         ops = data.split(':')[0]
-        #logging.debug("flash op: %s", ops)
+        logging.debug("flash op: %s", ops)
         
         if ops == 'FlashErase':
             self.flash.init()

--- a/pyOCD/target/cortex_m.py
+++ b/pyOCD/target/cortex_m.py
@@ -568,8 +568,7 @@ class CortexM(Target):
         # read address of reset handler
         reset_handler = self.readMemory(4)
 
-        # reset and halt the target
-        self.transport.reset()
+        # halt the target
         self.halt()
 
         # set a breakpoint to the reset handler and reset the target
@@ -587,8 +586,8 @@ class CortexM(Target):
 
     def setTargetState(self, state):
         if state == "PROGRAM":
-            self.reset()
-            self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN)
+            self.resetStopOnReset()
+            self.writeMemory(DHCSR, DBGKEY | C_DEBUGEN | C_HALT)
             self.writeMemory(DEMCR, VC_CORERESET)
             self.writeMemory(NVIC_AIRCR, NVIC_AIRCR_VECTKEY | NVIC_AIRCR_SYSRESETREQ)
             while self.getState() == TARGET_RUNNING:


### PR DESCRIPTION
This patch provide two fix:
1. For the resetStopOnReset function, there's a redundant reset which will lead to the issue that during this function the user program will still run for a while.
2. During the load process, setTargetState need to set C_HALT bit and use resetStopOnReset instead of reset to avoid unexpected running of previous program.
