### PR TITLE
Temporary fix addressing issue #48

### DIFF
--- a/pyOCD/target/target_nrf51822.py
+++ b/pyOCD/target/target_nrf51822.py
@@ -48,8 +48,8 @@ class NRF51822(CortexM):
         # read address of reset handler
         reset_handler = self.readMemory(4)
         
-        # reset and halt the target
-        self.reset()
+        # halt the target
+        #self.reset()
         self.halt()
         
         # set a breakpoint to the reset handler and reset the target


### PR DESCRIPTION
reset before halt is removed in order to avoid short periods of code
execution before flashing of a new bin file.
