### PR TITLE
Fix for older versions of HIDAPI 

### DIFF
--- a/pyOCD/interface/hidapi_backend.py
+++ b/pyOCD/interface/hidapi_backend.py
@@ -78,7 +78,10 @@ class HidApiUSB(Interface):
             new_board.vid = deviceInfo['vendor_id']
             new_board.pid = deviceInfo['product_id']
             new_board.device = dev
-            dev.open(vid, pid)
+            try:
+                dev.open(vid, pid)
+            except AttributeError:
+                pass
 
             boards.append(new_board)
 


### PR DESCRIPTION
Fix for older versions of HIDAPI (still current in homebrew on Mac) which don't support the open method.

See point 3) of this issue: https://github.com/mbedmicro/pyOCD/issues/54
