### PR TITLE
Check if dev has "open" method.

### DIFF
--- a/pyOCD/interface/hidapi_backend.py
+++ b/pyOCD/interface/hidapi_backend.py
@@ -78,8 +78,8 @@ class HidApiUSB(Interface):
             new_board.vid = deviceInfo['vendor_id']
             new_board.pid = deviceInfo['product_id']
             new_board.device = dev
-            dev.open(vid, pid)
-
+            if hasattr(dev, "open"):
+                dev.open(vid, pid)
             boards.append(new_board)
 
         return boards


### PR DESCRIPTION
Latest version of hidapi requires to call "open" function.
brew on MacOS still has old version so pyOCD fails.
This patch make it compatible with both versions.
