### PR TITLE
Update LPC1768 methods reset and resetStopOnReset.

### DIFF
--- a/pyOCD/target/target_lpc1768.py
+++ b/pyOCD/target/target_lpc1768.py
@@ -32,14 +32,14 @@ class LPC1768(CortexM):
         super(LPC1768, self).__init__(transport)
         self.auto_increment_page_size = 0x1000
         
-    def reset(self):
+    def reset(self, software_reset = False):
         # halt processor
         self.halt()
         # not remap 0x0000-0x0020 to anything but the flash
         self.writeMemory(0x400FC040, 1)
         CortexM.reset(self)
         
-    def resetStopOnReset(self):
+    def resetStopOnReset(self, software_reset = False):
         # halt processor
         self.halt()
         # not remap 0x0000-0x0020 to anything but the flash


### PR DESCRIPTION
When trying to use gdb load command to flash image to LPC1768 board via pyOCD, I got below error:

Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/gdbserver/gdbserver.py", line 168, in run
    [resp, ack, detach] = self.handleMsg(data)
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/gdbserver/gdbserver.py", line 230, in handleMsg
    return self.flashOp(msg[2:]), 1, 0
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/gdbserver/gdbserver.py", line 354, in flashOp
    self.flash.init()
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/flash/flash.py", line 42, in init
    self.target.setTargetState("PROGRAM")
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/target/cortex_m.py", line 592, in setTargetState
    self.resetStopOnReset()
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/target/target_lpc1768.py", line 47, in resetStopOnReset
    CortexM.resetStopOnReset(self)
  File "/usr/local/lib/python2.7/dist-packages/pyOCD/target/cortex_m.py", line 579, in resetStopOnReset
    self.reset(software_reset)
TypeError: reset() takes exactly 1 argument (2 given)

This is caused by inconsistency on method reset and resetStopOnReset between class LPC1768 and  its base class CortexM. This commit can fix the issue.
