### PR TITLE
Added Python 2 to 3 conversion as part of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",
     ],
+    use_2to3=True,
     packages=["pyOCD", "pyOCD.flash", "pyOCD.gdbserver", "pyOCD.interface", "pyOCD.target", "pyOCD.transport", "pyOCD.board"]
 )


### PR DESCRIPTION
- This seems to fix a lot of the issues with installing on Python 3, however it will probably need more testing to make sure that it works as it should on all of the supported platforms.
