### PR TITLE
Update README.md to an actively developed fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ $ sudo python setup.py install
 ```
 
 
-* Mac: [hidapi](https://github.com/signal11/hidapi), [cython-hidapi](https://github.com/gbishop/cython-hidapi)
+* Mac: [hidapi](https://github.com/signal11/hidapi), [cython-hidapi](https://github.com/trezor/cython-hidapi)
 ```Shell
 $ brew install hidapi
-$ git clone https://github.com/gbishop/cython-hidapi.git
+$ git clone https://github.com/trezor/cython-hidapi.git
 $ cd cython-hidapi
-$ sudo python setup-mac.py install
+$ sudo python setup.py install
 ```
 
 ### Install pyOCD


### PR DESCRIPTION
This change fixes #77.  The trezor fork of cython-hidapi is actively developed and fixes some problems under Mac OS X.
