### PR TITLE
Fix SWD fault when connecting to locked Kinetis

### DIFF
--- a/pyOCD/target/target_kinetis.py
+++ b/pyOCD/target/target_kinetis.py
@@ -43,7 +43,7 @@ class Kinetis(CortexM):
         self.mdm_idr = 0
         
     def init(self):
-        CortexM.init(self, False)
+        CortexM.init(self, False, False)
         
         # check for flash security
         val = self.transport.readAP(MDM_IDR)
@@ -93,6 +93,7 @@ class Kinetis(CortexM):
             raise Exception("Target failed to stay halted during init sequence")
 
         self.setupFPB()
+        self.setupDWT()
         self.readCoreType()
         self.checkForFPU()
 


### PR DESCRIPTION
When initializing a locked Kinetis processor CortexM.init must not
access system registers until the device is unlocked.  This patch
modifies the call to CortexM.init in the Kineits init so it does not
try and initialize data breakpoints.  This fixes a SWD fault when
running blank_test.py.

This problem was introduced in the commit
907940d7d739f8f90aa7c20356cedc520eddddf4 -
"Add support for data breakpoints"
