### PR TITLE
[PackTarget] Automaticlly select target type instead of using generic cortex_m

### DIFF
--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -22,7 +22,7 @@ LOG = logging.getLogger(__name__)
 
 class MbedBoard(Board):
     """! @brief Mbed board class.
-    
+
     This class inherits from Board and is specific to mbed boards. Particularly, this class
     will dynamically determine the type of connected board based on the board ID encoded in
     the debug probe's serial number. If the board ID is all "0" characters, it indicates the
@@ -30,7 +30,7 @@ class MbedBoard(Board):
     """
     def __init__(self, session, target=None, board_id=None):
         """! @brief Constructor.
-        
+
         This constructor attempts to use the board ID from the serial number to determine
         the target type. See #BOARD_ID_TO_INFO.
         """
@@ -38,7 +38,7 @@ class MbedBoard(Board):
         unique_id = session.probe.unique_id
         if board_id is None:
             board_id = unique_id[0:4]
-        
+
         # Check for null board ID. This indicates a standalone probe or generic firmware.
         if board_id == "0000":
             board_info = None

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -31,7 +31,7 @@ LOG = logging.getLogger(__name__)
 
 class ManagedPacks(object):
     """! @brief Namespace for managed CMSIS-Pack utilities.
-    
+
     By managed, we mean managed by the cmsis-pack-manager package. All the methods on this class
     apply only to those packs managed by cmsis-pack-manager, not any targets from packs specified
     by the user.
@@ -46,7 +46,7 @@ class ManagedPacks(object):
         for pack in cache.packs_for_devices(cache.index.values()):
             # Generate full path to the .pack file.
             pack_path = os.path.join(cache.data_path, pack.get_pack_name())
-            
+
             # If the .pack file exists, the pack is installed.
             if os.path.isfile(pack_path):
                 results.append(pack)
@@ -107,6 +107,9 @@ class _PackTargetMethods(object):
 
 class PackTargets(object):
     """! @brief Namespace for CMSIS-Pack target generation utilities. """
+
+    # store targets defined in PDSC.
+    supported_targets = list()
 
     @staticmethod
     def _find_family_class(dev):
@@ -171,6 +174,8 @@ class PackTargets(object):
             # Make sure there isn't a duplicate target name.
             if part not in TARGET:
                 TARGET[part] = tgt
+                PackTargets.supported_targets.append(part)
+
         except (MalformedCmsisPackError, FileNotFoundError_) as err:
             LOG.warning(err)
 


### PR DESCRIPTION
pyocd always use generic cortex_m when board id is not defined in board_ids.py.
This make pyocd cannot works for new board with a DFP pack.
This PR could make pyocd default select the first target in CMSIS-Pack, or user can pass an exists target in DFP pack with option "-t".

Signed-off-by: Haley Guo <hui.guo@nxp.com>