### PR TITLE
Add options to control RTOS thread awareness

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -307,6 +307,21 @@ If True, the GDB server will not exit after GDB disconnects.
 Whether gdb server should report core number as part of the per-thread information.
 </td></tr>
 
+<tr><td>rtos.enable</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Overall enable flag for RTOS aware debugging. By default it's enabled but can be switched off
+if necessary.
+</td></tr>
+
+<tr><td>rtos.name</td>
+<td>str</td>
+<td><i>No default</i></td>
+<td>
+Name of the RTOS plugin to use. If not set, all RTOS plugins are given a chance to load.
+</td></tr>
+
 <tr><td>semihost_console_type</td>
 <td>str</td>
 <td>'telnet'</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -107,6 +107,11 @@ BUILTIN_OPTIONS = [
         "If True, the GDB server will not exit after GDB disconnects."),
     OptionInfo('report_core_number', bool, False,
         "Whether gdb server should report core number as part of the per-thread information."),
+    OptionInfo('rtos.enable', bool, True,
+        "Overall enable flag for RTOS aware debugging. By default it's enabled but can be switched off "
+        "if necessary."),
+    OptionInfo('rtos.name', str, None,
+        "Name of the RTOS plugin to use. If not set, all RTOS plugins are given a chance to load."),
     OptionInfo('semihost_console_type', str, 'telnet',
         "If set to \"telnet\" then the semihosting telnet server will be started, otherwise "
         "semihosting will print to the console."),


### PR DESCRIPTION
These options are added:
- `rtos.enable`: Overall enable flag for RTOS aware debugging. By default it's enabled but can be switched off if you need to.
- `rtos.name`: Name of the RTOS plugin to use. If not set, all RTOS plugins are given a chance to load. To see the plugin names run `pyocd list --plugins`.