### PR TITLE
Several command fixes

### DIFF
--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -22,20 +22,13 @@ import traceback
 from ..core.helpers import ConnectHelper
 from ..core import (exceptions, session)
 from ..utility.cmdline import convert_session_options
-from ..commands.repl import PyocdRepl
+from ..commands.repl import (PyocdRepl, ToolExitException)
 from ..commands.execution_context import CommandExecutionContext
 
 LOG = logging.getLogger(__name__)
 
 ## Default SWD clock in Hz.
 DEFAULT_CLOCK_FREQ_HZ = 1000000
-
-class ToolExitException(Exception):
-    """! @brief Special exception indicating the tool should exit.
-    
-    This exception is only raised by the `exit` command.
-    """
-    pass
 
 class PyOCDCommander(object):
     """! @brief Manages the commander interface.

--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -111,7 +111,7 @@ class PyOCDCommander(object):
             cmd = args[0].lower()
             
             # Handle certain commands without connecting.
-            needs_connect = (cmd not in ('list', 'help'))
+            needs_connect = (cmd not in ('list', 'help', 'exit'))
 
             # For others, connect first.
             if needs_connect and not did_connect:

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -87,7 +87,7 @@ class ExitCommand(CommandBase):
             }
     
     def execute(self):
-        from .commander import ToolExitException
+        from .repl import ToolExitException
         raise ToolExitException()
 
 class StatusCommand(CommandBase):

--- a/pyocd/commands/repl.py
+++ b/pyocd/commands/repl.py
@@ -50,7 +50,6 @@ class PyocdRepl(object):
 
     def __init__(self, command_context):
         self.context = command_context
-        self.last_command = ''
         
         # Enable readline history.
         self._history_path = os.environ.get(self.PYOCD_HISTORY_ENV_VAR,
@@ -95,7 +94,6 @@ class PyocdRepl(object):
             line = line.strip()
             if line:
                 self.context.process_command_line(line)
-                self.last_command = line
         except KeyboardInterrupt:
             print()
         except ValueError:

--- a/pyocd/commands/repl.py
+++ b/pyocd/commands/repl.py
@@ -32,6 +32,13 @@ from ..core import (session, exceptions)
 
 LOG = logging.getLogger(__name__)
 
+class ToolExitException(Exception):
+    """! @brief Special exception indicating the tool should exit.
+    
+    This exception is only raised by the `exit` command.
+    """
+    pass
+
 class PyocdRepl(object):
     """! @brief Read-Eval-Print-Loop for pyOCD commander."""
     
@@ -79,6 +86,8 @@ class PyocdRepl(object):
             # Windows exits with a Ctrl-Z+Return, so there is no need for this.
             if os.name != "nt":
                 print()
+        except ToolExitException:
+            pass
     
     def run_one_command(self, line):
         """! @brief Execute a single command line and handle exceptions."""
@@ -99,7 +108,11 @@ class PyocdRepl(object):
                 traceback.print_exc()
         except exceptions.CommandError as e:
             print("Error:", e)
+        except ToolExitException:
+            # Catch and reraise this exception so it isn't caught by the catchall below.
+            raise
         except Exception as e:
+            # Catch most other exceptions so they don't cause the REPL to exit.
             print("Error:", e)
             if session.Session.get_current().log_tracebacks:
                 traceback.print_exc()

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -993,13 +993,6 @@ class GDBServer(threading.Thread):
             return None
         return symValue
 
-    def handle_remote_command_compatibility(self, cmd):
-        """! @brief Handle certain monitor commands for OpenOCD compatibility."""
-        if cmd.startswith('arm semihosting'):
-            enable = ('enable' in cmd)
-            self.session.options['enable_semihosting'] = enable
-        return False, None
-
     def handle_remote_command(self, cmd):
         """! @brief Pass remote commands to the commander command processor."""
         # Convert the command line to a string.

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2015-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 import logging
+import shlex
+import six
+
 from ..core.target import Target
 from ..core.options import OPTIONS_INFO
 from ..utility.compatibility import to_str_safe
@@ -24,34 +27,12 @@ LOG = logging.getLogger(__name__)
 def split_command_line(cmd_line):
     """! @brief Split command line by whitespace, supporting quoted strings."""
     result = []
-    if type(cmd_line) is str:
+    if isinstance(cmd_line, six.string_types):
         args = [cmd_line]
     else:
         args = cmd_line
     for cmd in args:
-        state = 0
-        word = ''
-        open_quote = ''
-        for c in cmd:
-            if state == 0:
-                if c in (' ', '\t', '\r', '\n'):
-                    if word:
-                        result.append(word)
-                        word = ''
-                elif c in ('"', "'"):
-                    open_quote = c
-                    state = 1
-                else:
-                    word += c
-            elif state == 1:
-                if c == open_quote:
-                    result.append(word)
-                    word = ''
-                    state = 0
-                else:
-                    word += c
-        if word:
-            result.append(word)
+        result += shlex.split(cmd)
     return result
 
 ## Map of vector char characters to masks.

--- a/test/commander_test.py
+++ b/test/commander_test.py
@@ -33,9 +33,7 @@ from test_util import (
     Test,
     TestResult,
     get_session_options,
-    get_target_test_params,
     binary_to_elf_file,
-    get_test_binary_path,
     PYOCD_DIR,
     )
 

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -98,7 +98,6 @@ def commands_test(board_id):
         context.attach_session(session)
         
         COMMANDS_TO_TEST = [
-#                 "list",
                 "status",
                 "reset",
                 "reset halt",
@@ -118,13 +117,13 @@ def commands_test(board_id):
                 "write32 0x%08x 0x11223344 0x55667788" % ram_base,
                 "write16 0x%08x 0xabcd" % (ram_base + 8),
                 "write8 0x%08x 0 1 2 3 4 5 6" % (ram_base + 10),
-                "savemem 0x%08x 128 %s" % (boot_start_addr, temp_bin_file),
-                "loadmem 0x%08x %s" % (ram_base, temp_bin_file),
-                "loadmem 0x%08x %s" % (boot_start_addr, binary_file),
-                "load %s" % temp_test_hex_name,
-                "load %s 0x%08x" % (binary_file, boot_start_addr),
-                "compare 0x%08x %s" % (ram_base, temp_bin_file),
-                "compare 0x%08x 32 %s" % (ram_base, temp_bin_file),
+                "savemem 0x%08x 128 '%s'" % (boot_start_addr, temp_bin_file),
+                "loadmem 0x%08x '%s'" % (ram_base, temp_bin_file),
+                "loadmem 0x%08x '%s'" % (boot_start_addr, binary_file),
+                "load '%s'" % temp_test_hex_name,
+                "load '%s' 0x%08x" % (binary_file, boot_start_addr),
+                "compare 0x%08x '%s'" % (ram_base, temp_bin_file),
+                "compare 0x%08x 32 '%s'" % (ram_base, temp_bin_file),
                 "fill 0x%08x 128 0xa5" % ram_base,
                 "fill 16 0x%08x 64 0x55aa" % (ram_base + 64),
                 "find 0x%08x 128 0xaa 0x55" % ram_base, # find that will pass
@@ -184,8 +183,17 @@ def commands_test(board_id):
                 "set step-into-interrupts 1",
                 "set log info",
                 "set frequency %d" % test_params['test_clock'],
+                
+                # Semicolon-separated commands.
+                'rw 0x%08x ; rw 0x%08x' % (ram_base, ram_base + 4),
+                
+                # Python and system commands.
+                '$2+ 2',
+                '!echo hello',
+                '!echo hi \; echo there', # using escaped semicolon in a sytem command
 
                 # Commands not tested:
+#                 "list",
 #                 "erase", # chip erase
 #                 "unlock",
 #                 "exit",

--- a/test/unit/test_cmdline.py
+++ b/test/unit/test_cmdline.py
@@ -45,6 +45,17 @@ class TestSplitCommandLine(object):
         assert split_command_line('a\rb') == ['a', 'b']
         assert split_command_line('a\nb') == ['a', 'b']
         assert split_command_line('a   \tb') == ['a', 'b']
+    
+    @pytest.mark.parametrize(("input", "result"), [
+        (r'\h\e\l\l\o', ['hello']),
+        (r'"\"hello\""', ['"hello"']),
+        ('x "a\\"b" y', ['x', 'a"b', 'y']),
+        ('hello"there"', ['hellothere']),
+        (r"'raw\string'", [r'raw\string']),
+        ('"foo said \\"hi\\"" and \'C:\\baz\'', ['foo said "hi"', 'and', 'C:\\baz'])
+        ])
+    def test_em(self, input, result):
+        assert split_command_line(input) == result
 
 class TestConvertVectorCatch(object):
     def test_none_str(self):


### PR DESCRIPTION
- Fix `quit`/`exit` command.
- Removed broken support for executing core register names as commands that print their value.
- Allow semicolons that normally separate multiple commands in a single command line to be escaped. Mostly useful for system commands.
- Code refactoring and cleanup.
