### PR TITLE
Fix interrupting gdbserver range step

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -418,7 +418,7 @@ class GDBServer(threading.Thread):
                 reply = handler(msg[msgStart:])
             self.lock.release()
 
-            detach = 1 if msg[1:2] in self.DETACH_COMMANDS else 0
+            detach = msg[1:2] in self.DETACH_COMMANDS
             return reply, detach
 
         except Exception as e:
@@ -441,7 +441,6 @@ class GDBServer(threading.Thread):
         if not self.persist:
             self.board.target.set_vector_catch(Target.VectorCatch.NONE)
             self.board.target.resume()
-        return self.create_rsp_packet(b"")
     
     def restart(self, data):
         self.target.reset_and_halt()


### PR DESCRIPTION
Fix for a step hook being able to exit a range step sequence early. This is most visible when gdb uses range step around a loop that never exits (due to polling an event that doesn't occur or something similar), and Ctrl-C didn't interrupt the step command.

Also included a minor fix for the `k` packet that should not have been sending a reply packet.