### PR TITLE
Large memory transfer support

### DIFF
--- a/pyocd/cache/memory.py
+++ b/pyocd/cache/memory.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2019 Arm Limited
+# Copyright (c) 2016-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -224,13 +224,12 @@ class MemoryCache(object):
         return regions[0].is_cacheable
 
     def read_memory(self, addr, transfer_size=32, now=True):
-        # TODO use more optimal underlying read_memory call
+        # TODO use more optimal underlying read_memory calls
         if transfer_size == 8:
             data = self.read_memory_block8(addr, 1)[0]
-        elif transfer_size == 16:
-            data = conversion.byte_list_to_u16le_list(self.read_memory_block8(addr, 2))[0]
-        elif transfer_size == 32:
-            data = conversion.byte_list_to_u32le_list(self.read_memory_block8(addr, 4))[0]
+        else:
+            data = conversion.byte_list_to_nbit_le_list(self.read_memory_block8(addr, transfer_size // 8),
+                    transfer_size)[0]
 
         if now:
             return data
@@ -264,10 +263,8 @@ class MemoryCache(object):
     def write_memory(self, addr, value, transfer_size=32):
         if transfer_size == 8:
             return self.write_memory_block8(addr, [value])
-        elif transfer_size == 16:
-            return self.write_memory_block8(addr, conversion.u16le_list_to_byte_list([value]))
-        elif transfer_size == 32:
-            return self.write_memory_block8(addr, conversion.u32le_list_to_byte_list([value]))
+        else:
+            return self.write_memory_block8(addr, conversion.nbit_le_list_to_byte_list([value], transfer_size))
 
     def write_memory_block8(self, addr, value):
         if len(value) <= 0:

--- a/pyocd/core/memory_interface.py
+++ b/pyocd/core/memory_interface.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018 Arm Limited
+# Copyright (c) 2018-2020 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,6 +39,10 @@ class MemoryInterface(object):
         """! @brief Read an aligned block of 32-bit words."""
         raise NotImplementedError()
   
+    def write64(self, addr, value):
+        """! @brief Shorthand to write a 64-bit word."""
+        self.write_memory(addr, value, 64)
+  
     def write32(self, addr, value):
         """! @brief Shorthand to write a 32-bit word."""
         self.write_memory(addr, value, 32)
@@ -50,6 +54,10 @@ class MemoryInterface(object):
     def write8(self, addr, value):
         """! @brief Shorthand to write a byte."""
         self.write_memory(addr, value, 8)
+
+    def read64(self, addr, now=True):
+        """! @brief Shorthand to read a 64-bit word."""
+        return self.read_memory(addr, 64, now)
 
     def read32(self, addr, now=True):
         """! @brief Shorthand to read a 32-bit word."""

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -103,6 +103,9 @@ CSW_SIZE     =  0x00000007
 CSW_SIZE8    =  0x00000000
 CSW_SIZE16   =  0x00000001
 CSW_SIZE32   =  0x00000002
+CSW_SIZE64   =  0x00000003
+CSW_SIZE128  =  0x00000004
+CSW_SIZE256  =  0x00000005
 CSW_ADDRINC  =  0x00000030
 CSW_NADDRINC =  0x00000000 # No increment
 CSW_SADDRINC =  0x00000010 # Single increment by SIZE field
@@ -121,7 +124,10 @@ DEFAULT_CSW_VALUE = CSW_SADDRINC
 
 TRANSFER_SIZE = {8: CSW_SIZE8,
                  16: CSW_SIZE16,
-                 32: CSW_SIZE32
+                 32: CSW_SIZE32,
+                 64: CSW_SIZE64,
+                 128: CSW_SIZE128,
+                 256: CSW_SIZE256,
                  }
 
 CSW_HPROT_MASK = 0x0f000000 # HPROT[3:0]
@@ -499,6 +505,9 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         ## Mask of addresses. This indicates whether 32-bit or 64-bit addresses are supported.
         self._address_mask = 0xffffffff
         
+        ## Whether the Large Data extension is supported.
+        self._has_large_data = False
+        
         # Ask the probe for an accelerated memory interface for this AP. If it provides one,
         # then bind our memory interface APIs to its methods. Otherwise use our standard
         # memory interface based on AP register accesses.
@@ -529,6 +538,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         
         It performs these checks:
         - Check for Long Address extension.
+        - Check for Large Data extension.
         - (v2 only) Get the auto-increment page size.
         - (v2 only) Determine supported error mode.
         - (v2 only) Get the size of the DAR register window.
@@ -551,6 +561,10 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             # Check for 64-bit address support.
             if cfg & MEM_AP_CFG_LA_MASK:
                 self._address_mask = 0xffffffffffffffff
+        
+            # Check for Large Data extension.
+            if cfg & MEM_AP_CFG_LD_MASK:
+                self._has_large_data = True
         
             # Check v2 MEM-AP CFG fields.
             if self.ap_version == APVersion.APv2:
@@ -577,24 +591,52 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         def _init_transfer_sizes():
             """! @brief Determine supported transfer sizes.
         
-            If the AP_ALL_TX_SZ flag is set, then we know a priori that this AP implementation
-            supports all transfer sizes.
+            If the #AP_ALL_TX_SZ flag is set, then we know a priori that this AP implementation
+            supports 8-, 16- and 32- transfer sizes. If the Large Data extension is implemented, then this
+            flag is ignored.
         
-            Otherwise an attempt to modify CSW_SIZE to a non-32-bit transfer size is made. If CSW_SIZE
-            is successfully changed, then the AP supports both 8- and 16-bit transfers in addition to
-            the required 32-bit.
+            Note in ADIv6: "If a MEM-AP implementation does not support the Large Data Extension, but does
+            support various access sizes, it must support word, halfword, and byte accesses."
+
+            So, if the Large Data extension is present, then we have to individually test each
+            transfer size (aside from the required 32-bit).
+            
+            If Large Data is not present, then only one non-32-bit transfer size needs to be tested to
+            determine if the AP supports both 8- and 16-bit transfers in addition to the required 32-bit.
             """
-           # If AP_ALL_TX_SZ is set, we can skip the test.
-            if (self._flags & AP_ALL_TX_SZ) == 0:
+            # If AP_ALL_TX_SZ is set, we can skip the test. Double check this by ensuring that LD is not
+            # enabled.
+            if (self._flags & AP_ALL_TX_SZ) and not self._has_large_data:
                 self._transfer_sizes = (8, 16, 32)
                 return
+        
+            def _test_transfer_size(sz):
+                """! @brief Utility to verify whether the MEM-AP supports a given transfer size.
+                
+                From ADIv6:
+                If the CSW.Size field is written with a value corresponding to a size that is not supported,
+                or with a reserved value: A read of the field returns a value corresponding to a supported
+                size.
+                """
+                # Write CSW_SIZE to select requested transfer size.
+                AccessPort.write_reg(self, self._reg_offset + MEM_AP_CSW, original_csw & ~CSW_SIZE | sz)
+        
+                # Read back CSW and see if SIZE matches what we wrote.
+                csw_cb = AccessPort.read_reg(self, self._reg_offset + MEM_AP_CSW, now=False)
+                
+                return lambda: (csw_cb() & CSW_SIZE) == sz
+            
+            # Thus if LD ext is not present, we only need to test one size.
 
-            # Write CSW_SIZE to select 16-bit transfer.
-            AccessPort.write_reg(self, self._reg_offset + MEM_AP_CSW, original_csw & ~CSW_SIZE | CSW_SIZE16)
-
-            # Read back CSW and see if SIZE changed.
-            csw = AccessPort.read_reg(self, self._reg_offset + MEM_AP_CSW)
-            if (csw & CSW_SIZE) == CSW_SIZE16:
+            if self._has_large_data:
+                # Need to scan all sizes except 32-bit, which is required.
+                SIZES_TO_TEST = (CSW_SIZE8, CSW_SIZE16, CSW_SIZE64, CSW_SIZE128, CSW_SIZE256)
+                
+                sz_result_cbs = ((sz, _test_transfer_size(sz)) for sz in SIZES_TO_TEST)
+                self._transfer_sizes = ([32] + [(8 * (1 << sz)) for sz, cb in sz_result_cbs if cb()])
+                self._transfer_sizes.sort()
+                
+            elif _test_transfer_size(CSW_SIZE16)():
                 self._transfer_sizes = (8, 16, 32)
 
         def _init_hprot():
@@ -640,10 +682,10 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
                 raise exceptions.TargetError("invalid AP BASE value 0x%08x" % base)
         
         # Run the init tests.
+        _init_cfg()
         _init_transfer_sizes()
         _init_hprot()
         _init_rom_table_base()
-        _init_cfg()
  
         # Restore unmodified value of CSW.
         AccessPort.write_reg(self, self._reg_offset + MEM_AP_CSW, original_csw)
@@ -824,10 +866,18 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             data = data << ((addr & 0x03) << 3)
         elif transfer_size == 16:
             data = data << ((addr & 0x02) << 3)
+        elif transfer_size > 32:
+            # Split the value into a tuple of 32-bit words, least-significant first.
+            data = (((v >> (32 * i)) & 0xffffffff) for i in range(transfer_size // 32))
 
         try:
             self.write_reg(self._reg_offset + MEM_AP_TAR, addr)
-            self.write_reg(self._reg_offset + MEM_AP_DRW, data)
+            
+            if transfer_size <= 32:
+                self.write_reg(self._reg_offset + MEM_AP_DRW, data)
+            else:
+                # Multi-word transfer.
+                self.dp.write_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW, data)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)
@@ -859,7 +909,13 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         try:
             self.write_reg(self._reg_offset + MEM_AP_CSW, self._csw | TRANSFER_SIZE[transfer_size])
             self.write_reg(self._reg_offset + MEM_AP_TAR, addr)
-            result_cb = self.read_reg(self._reg_offset + MEM_AP_DRW, now=False)
+            
+            if transfer_size <= 32:
+                result_cb = self.read_reg(self._reg_offset + MEM_AP_DRW, now=False)
+            else:
+                # Multi-word transfer.
+                result_cb = self.dp.read_ap_multiple(self.address.address + self._reg_offset + MEM_AP_DRW,
+                        transfer_size // 32, now=False)
         except exceptions.TransferFaultError as error:
             # Annotate error with target address.
             self._handle_error(error, num)
@@ -877,6 +933,8 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
                     res = (res >> ((addr & 0x03) << 3) & 0xff)
                 elif transfer_size == 16:
                     res = (res >> ((addr & 0x02) << 3) & 0xffff)
+                elif transfer_size > 32:
+                    res = sum((w << (32 * i)) for i, w in enumerate(res))
                 TRACE.debug("read_mem:%06d %s(ap=0x%x; addr=0x%08x, size=%d) -> 0x%08x }",
                     num, "" if now else "...", self.address.nominal_address, addr, transfer_size, res)
             except exceptions.TransferFaultError as error:
@@ -1053,7 +1111,7 @@ AP_TYPE_AHB5_HPROT = 0x8
 
 # AP flags.
 AP_4K_WRAP = 0x1 # The AP has a 4 kB auto-increment modulus.
-AP_ALL_TX_SZ = 0x2 # The AP is known to support 8-, 16-, and 32-bit transfers.
+AP_ALL_TX_SZ = 0x2 # The AP is known to support 8-, 16-, and 32-bit transfers, *unless* Large Data is implemented.
 AP_MSTRTYPE = 0x4 # The AP is known to support the MSTRTYPE field.
 
 ## Map from AP IDR fields to AccessPort subclass.

--- a/pyocd/debug/elf/elf_reader.py
+++ b/pyocd/debug/elf/elf_reader.py
@@ -56,12 +56,8 @@ class ElfReaderContext(DebugContext):
             data = section.data[addr:addr + length]
             if transfer_size == 8:
                 return data[0]
-            elif transfer_size == 16:
-                return conversion.byte_list_to_u16le_list(data)[0]
-            elif transfer_size == 32:
-                return conversion.byte_list_to_u32le_list(data)[0]
             else:
-                raise ValueError("invalid transfer_size (%d)" % transfer_size)
+                return conversion.byte_list_to_nbit_le_list(data, transfer_size)[0]
 
         if now:
             return read_memory_cb()

--- a/pyocd/utility/hex.py
+++ b/pyocd/utility/hex.py
@@ -68,7 +68,8 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
     @param data The data to print as hex. Can be a `bytes`, `bytearray`, or list of integers.
     @param start_address Address of the first byte of the data. Defaults to 0. If set to None,
         then the address column is not printed.
-    @param width Controls grouping of the hex bytes in the output as described above.
+    @param width Controls grouping of the hex bytes in the output as described above. Must be one of
+        (8, 16, 32, 64).
     @param output Optional file where the output will be written. If not provided, sys.stdout is
         used.
     @param print_ascii Whether to include the printable ASCII column. Defaults to True.
@@ -81,6 +82,8 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
         line_width = 8
     elif width == 32:
         line_width = 4
+    elif width == 64:
+        line_width = 2
     i = 0
     while i < len(data):
         if start_address is not None:
@@ -98,6 +101,8 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
                 output.write("%04x " % d)
             elif width == 32:
                 output.write("%08x " % d)
+            elif width == 64:
+                output.write("%016x " % d)
             if i % line_width == 0:
                 break
         
@@ -109,11 +114,8 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
                 d = data[n]
                 if width == 8:
                     d = [d]
-                elif width == 16:
-                    d = conversion.u16le_list_to_byte_list([d])
-                    d.reverse()
-                elif width == 32:
-                    d = conversion.u32le_list_to_byte_list([d])
+                else:
+                    d = conversion.nbit_le_list_to_byte_list([d], width)
                     d.reverse()
                 s += "".join((chr(b) if (chr(b) in _PRINTABLE) else '.') for b in d)
             output.write("   " + s + "|")

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -71,12 +71,50 @@ def bfx(value, msb, lsb):
     mask = bitmask((msb, lsb))
     return (value & mask) >> lsb
 
+def bfxw(value, lsb, width):
+    """! @brief Extract a value from a bitfield given the LSb and width."""
+    mask = bitmask((lsb + width, lsb))
+    return (value & mask) >> lsb
+
 def bfi(value, msb, lsb, field):
     """! @brief Change a bitfield value."""
     mask = bitmask((msb, lsb))
     value &= ~mask
     value |= (field << lsb) & mask
     return value
+
+class Bitfield(object):
+    """! @brief Represents a bitfield of a register."""
+
+    def __init__(self, msb, lsb=None, name=None):
+        self._msb = msb
+        self._lsb = lsb if (lsb is not None) else msb
+        self._name = name
+        assert self._msb >= self._lsb
+    
+    @property
+    def width(self):
+        return self._msb - self._lsb + 1
+    
+    def get(self, value):
+        """! @brief Extract the bitfield value from a register value.
+        @param self The Bitfield object.
+        @param value Integer register value.
+        @return Integer value of the bitfield extracted from `value`.
+        """
+        return bfx(value, self._msb, self._lsb)
+    
+    def set(self, register_value, field_value):
+        """! @brief Modified the bitfield in a register value.
+        @param self The Bitfield object.
+        @param register_value Integer register value.
+        @param field_value New value for the bitfield. Must not be shifted into place already.
+        @return Integer register value with the bitfield updated to `field_value`.
+        """
+        return bfi(register_value, self._msb, self._lsb, field_value)
+    
+    def __repr__(self):
+        return "<{}@{:x} name={} {}:{}>".format(self.__class__.__name__, id(self), self._name, self._msb, self._lsb)
 
 def msb(n):
     """! @brief Return the bit number of the highest set bit."""

--- a/test/unit/mockcore.py
+++ b/test/unit/mockcore.py
@@ -119,6 +119,8 @@ class MockCore(CoreSightCoreComponent):
             return 0x1234
         elif transfer_size == 32:
             return 0x12345678
+        elif transfer_size == 64:
+            return 0x1234567812345678
 
     def read_memory_block8(self, addr, size):
         for r, m in self.regions:


### PR DESCRIPTION
This patch adds support for the MEM-AP Large Data Extension that enables 64-, 128-, and/or 256-bit transfers, if supported by the MEM-AP on which the transfers is performed. The `supported_transfer_sizes` property on the `MEM_AP` class will tell you what bit sizes are supported. This is primarily intended for testing multicore A+M platforms and other situations, as well as preparing for future Cortex-A support. Few, if any, Cortex-M devices support large memory transfers.

`MemoryInterfaces` gains `read64()` and `write64()` methods.
Similarly, there are new `read64` and `write64` commands.

Included in this patch is a refactoring of the `MEM_AP.init()` method to be slightly more efficient.