### PR TITLE
pyocd-gdbserver: fix regression preventing the server from starting

### DIFF
--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -297,7 +297,9 @@ class GDBServerTool(object):
                         gdb = GDBServer(session,
                             core=core_number,
                             server_listening_callback=self.server_listening)
+                        session.gdbservers[core_number] = gdb
                         gdbs.append(gdb)
+                        gdb.start()
                     gdb = gdbs[0]
                     while gdb.is_alive():
                         gdb.join(timeout=0.5)


### PR DESCRIPTION
`pyocd-gdbserver` is still required for the Eclipse Embedded CDT (previously GNU MCU Eclipse) pyOCD plugin.