### PR TITLE
CMSIS-DAP SWO command flush fix and daparg deprecation

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -53,6 +53,14 @@ Whether to use deferred transfers in the CMSIS-DAP probe backend. By disabling d
 all writes take effect immediately. However, performance is negatively affected.
 </td></tr>
 
+<tr><td>cmsis_dap.limit_packets</td>
+<td>bool</td>
+<td>False</td>
+<td>
+Restrict CMSIS-DAP backend to using a single in-flight command at a time. This is useful on some systems
+where USB is problematic, in particular virtual machines.
+</td></tr>
+
 <tr><td>commander.history_length</td>
 <td>int</td>
 <td>1000</td>

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -145,7 +145,7 @@ class PyOCDTool(object):
         commonOptionsNoLogging.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
             help="Set named option.")
         commonOptionsNoLogging.add_argument("-da", "--daparg", dest="daparg", nargs='+',
-            help="Send setting to DAPAccess layer.")
+            help="(Deprecated) Send setting to DAPAccess layer.")
         commonOptionsNoLogging.add_argument("--pack", metavar="PATH", action="append",
             help="Path to a CMSIS Device Family Pack.")
         

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -32,7 +32,9 @@ BUILTIN_OPTIONS = [
         "Whether to perform a chip erase or sector erases when programming flash. The value must be"
         " one of \"auto\", \"sector\", or \"chip\"."),
     OptionInfo('cmsis_dap.deferred_transfers', bool, True,
-        "Whether to use deferred transfers in the CMSIS-DAP probe backend."),
+        "Whether the CMSIS-DAP probe backend will use deferred transfers for improved performance."),
+    OptionInfo('cmsis_dap.limit_packets', bool, False,
+        "Restrict CMSIS-DAP backend to using a single in-flight command at a time."),
     OptionInfo('commander.history_length', int, 1000,
         "Number of entries in the pyOCD Commander command history. Set to -1 for unlimited. Default is 1000."),
     OptionInfo('config_file', str, None,

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -589,7 +589,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         self._interface.open()
         self._protocol = CMSISDAPProtocol(self._interface)
 
-        if DAPSettings.limit_packets:
+        if session.Session.get_current().options['cmsis_dap.limit_packets'] or DAPSettings.limit_packets:
             self._packet_count = 1
             LOG.debug("Limiting packet count to %d", self._packet_count)
         else:


### PR DESCRIPTION
Two little fixes/changes for the CMSIS-DAP probe backend.

1. SWO related methods on `DAPAccessCMSISDAP` flush the command queue as required before sending the SWO command.
2. The `--daparg` command line option has been deprecated (and marked as such in the usage text). Its only use was to set the `limit_packets` flag for CMSIS-DAP, and comes from a time before there were session options. Replaced with a `cmsis_dap.limit_packets` session option that serves the same purpose.