### PR TITLE
Fix Atmel-ICE compatibility issue

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -279,7 +279,7 @@ class MatchCmsisDapv1Interface(object):
             ]
 
             # Possible combinations of endpoints
-            endpoint_attrs_allowed = [
+            ENDPOINT_ATTRS_ALLOWED = [
                 # One interrupt endpoint IN
                 [(usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR)],
                 # Two interrupt endpoints, first one IN, second one OUT
@@ -289,8 +289,8 @@ class MatchCmsisDapv1Interface(object):
                 [(usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_INTR),
                  (usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR)],
             ]
-            if endpoint_attrs not in endpoint_attrs_allowed:
-                return false
+            if endpoint_attrs not in ENDPOINT_ATTRS_ALLOWED:
+                return False
         
             # All checks passed, this is a CMSIS-DAPv2 interface!
             return True

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -271,15 +271,26 @@ class MatchCmsisDapv1Interface(object):
             # Must have either 1 or 2 endpoints.
             if interface.bNumEndpoints not in (1, 2):
                 return False
-        
-            # Endpoint 0 must be interrupt in.
-            if not check_ep(interface, 0, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR):
-                return False
-        
-            # Endpoint 1 is optional. If present it must be interrupt out.
-            if (interface.bNumEndpoints == 2) \
-                and not check_ep(interface, 1, usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_INTR):
-                return False
+
+            endpoint_attrs = [
+                (usb.util.endpoint_direction(ep.bEndpointAddress),
+                 usb.util.endpoint_type(ep.bmAttributes))
+                 for ep in interface
+            ]
+
+            # Possible combinations of endpoints
+            endpoint_attrs_allowed = [
+                # One interrupt endpoint IN
+                [(usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR)],
+                # Two interrupt endpoints, first one IN, second one OUT
+                [(usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR),
+                 (usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_INTR)],
+                # Two interrupt endpoints, first one OUT, second one IN
+                [(usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_INTR),
+                 (usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_INTR)],
+            ]
+            if endpoint_attrs not in endpoint_attrs_allowed:
+                return false
         
             # All checks passed, this is a CMSIS-DAPv2 interface!
             return True

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2020 Patrick Huesmann
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/udev/50-cmsis-dap.rules
+++ b/udev/50-cmsis-dap.rules
@@ -7,3 +7,5 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="c251", ATTR{idProduct}=="2750", MODE:="666"
 # 1fc9:0090 NXP LPC-LinkII
 SUBSYSTEM=="usb", ATTR{idVendor}=="1fc9", ATTR{idProduct}=="0090", MODE:="666"
 
+# 03eb:2141 Atmel-ICE CMSIS-DAP
+SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2141", MODE:="666"


### PR DESCRIPTION
The `MatchCmsisDapv1Interface` class, which is used for finding CMSIS-DAPv1 interfaces, expects the first endpoint of the probe to be an _interrupt in_, the second one (optional) to be an _interrupt out_.
The Atmel-ICE CMSIS-DAP probe (`03eb:2141`) has its endpoints laid out the other way around: first one _interrupt out_, second one _interrupt in_ - so it fails this test.

The code in `pyusb_backend.py` that uses the probe, doesn't actually care about the sequence order of endpoints - it [just uses any "in" endpoint as ep_in and the other one as ep_out](https://github.com/pyocd/pyOCD/blob/9ab3891de8edecc43568a04bc56188ed3252d5e6/pyocd/probe/pydapaccess/interface/pyusb_backend.py#L90). Therefore I think the sequence order requirement in `MatchCmsisDapv1Interface` is too strict. The proposed patch creates a list of attributes (direction, type per endpoint) and compares that against a list of allowed combinations.

Verified to work with Atmel-ICE CMSIS-DAP (`03eb:2141`) and connected Cortex-4M MCU (`atsam4ls8c`).

Fixes #963.