### PR TITLE
Fix issue when another process has a J-Link open

### DIFF
--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -35,6 +35,13 @@ class PyOCDCommander(object):
     
     Responsible for connecting the execution context, REPL, and commands, and handles connection.
     
+    Exit codes:
+    - 0 = no errors
+    - 1 = command error
+    - 2 = transfer error
+    - 3 = failed to create session (probe might not exist)
+    - 4 = failed to open probe
+    
     @todo Replace use of args from argparse with something cleaner.
     """
     
@@ -169,7 +176,9 @@ class PyOCDCommander(object):
             self.exit_code = 3
             return False
         
-        self._post_connect()
+        if not self._post_connect():
+            self.exit_code = 4
+            return False
         
         result = self.context.attach_session(self.session)
         if not result:

--- a/pyocd/probe/aggregator.py
+++ b/pyocd/probe/aggregator.py
@@ -51,6 +51,15 @@ class DebugProbeAggregator(object):
         klasses, unique_id, is_explicit = DebugProbeAggregator._get_probe_classes(unique_id)
         
         probes = []
+        
+        # First look for a match against the full ID, as this can be more efficient for certain probes.
+        if unique_id is not None:
+            for cls in klasses:
+                probe = cls.get_probe_with_id(unique_id, is_explicit)
+                if probe is not None:
+                    return [probe]
+        
+        # No full match, so ask probe classes for probes.
         for cls in klasses:
             probes += cls.get_all_connected_probes(unique_id, is_explicit)
         

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -63,10 +63,14 @@ class DebugProbe(object):
     def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
         """! @brief Returns a list of DebugProbe instances.
         
+        To filter the list of returned probes, the `unique_id` parameter may be set to a string with a full or
+        partial unique ID (canonically the serial number). Alternatively, the probe class may simply return all
+        available probes and let the caller handle filtering.
+        
         @param cls The class instance.
-        @param unique_id Optional unique ID value on which probes are being filtered. May be
-            used by the probe to optimize retreiving the probe list.
-        @param is_explicit Whether the probe type was explicitly specified in the unique ID. This
+        @param unique_id String. Optional partial unique ID value used to filter available probes. May be used by the
+            probe to optimize retreiving the probe list; there is no requirement to filter the results.
+        @param is_explicit Boolean. Whether the probe type was explicitly specified in the unique ID. This
             can be used, for instance, to specially interpret the unique ID as an IP address or
             domain name when the probe class was specifically requested but not for general lists
             of available probes.
@@ -78,12 +82,11 @@ class DebugProbe(object):
     def get_probe_with_id(cls, unique_id, is_explicit=False):
         """! @brief Returns a DebugProbe instance for a probe with the given unique ID.
         
-        If no probe is connected with a matching unique ID, then None will be returned.
+        If no probe is connected with a fully matching unique ID, then None will be returned.
         
         @param cls The class instance.
-        @param unique_id Optional unique ID value on which probes are being filtered. May be
-            used by the probe to optimize retreiving the probe list.
-        @param is_explicit Whether the probe type was explicitly specified in the unique ID.
+        @param unique_id Unique ID string to match against probes' full unique ID. No partial matches are allowed.
+        @param is_explicit Boolean. Whether the probe type was explicitly specified in the unique ID.
         @return DebugProbe instance, or None
         """
         raise NotImplementedError()


### PR DESCRIPTION
When at least one J-Link probe was connected and opened by another process, pyOCD would fail with a "J-Link is already open" error even just listing probes or attempting to connect to a non-J-Link probe.

This PR fixes the problem by no longer temporarily opening each J-Link to read product name and OEM strings. It uses another method to get the product name; OEM strings aren't supported anymore (it's not clear when they were used, anyway, as I haven't seen the OEM string ever be non-empty).

Fixes #877 