### PR TITLE
truncated unused bytes of a command buffer.

### DIFF
--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018-2020 Arm Limited
+# Copyright (c) 2020 Koji Kitayama
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -312,7 +312,7 @@ class _Command(object):
                     buf[pos] = (write_list[write_pos] >> (8 * 3)) & 0xff
                     pos += 1
                     write_pos += 1
-        return buf
+        return buf[:pos]
 
     def _check_response(self, response):
         """! @brief Check the response status byte from CMSIS-DAP transfer commands.
@@ -402,7 +402,7 @@ class _Command(object):
                     buf[pos] = (write_list[write_pos] >> (8 * 3)) & 0xff
                     pos += 1
                     write_pos += 1
-        return buf
+        return buf[:pos]
 
     def _decode_transfer_block_data(self, data):
         """! @brief Take a byte array and extract the data from it


### PR DESCRIPTION
I found that DAP_TRANSFER and DAP_TRANSFER_BLOCK send packets with endpoint size when using CMSIS-DAP v2.
I think that it's better to remove unused bytes.