### PR TITLE
Add built-in support for Arm Musca-B1

### DIFF
--- a/pyocd/board/board_ids.py
+++ b/pyocd/board/board_ids.py
@@ -226,7 +226,7 @@ BOARD_ID_TO_INFO = {
     "5005": BoardInfo(  "Arm V2M-MPS3",         "cortex_m",         None,                   ),
     "5006": BoardInfo(  "Arm Musca-A1",         "musca_a1",         "l1_musca_a1.bin",      ),
     "5007": BoardInfo(  "Arm Musca-B1",         "musca_b1",         "l1_musca_b1.bin",      ),
-    "5009": BoardInfo(  "Arm Musca-S1",         "musca-s1",         None,                   ),
+    "5009": BoardInfo(  "Arm Musca-S1",         "musca_s1",         None,                   ),
     "7402": BoardInfo(  "mbed 6LoWPAN Border Router HAT", "k64f",   "l1_k64f.bin",          ),
     "7778": BoardInfo(  "Teensy 3.1",           "mk20dx256vlh7",    None,                   ),
     "8080": BoardInfo(  "L-Tek FF1705",         "stm32l151cc",      None,                   ),

--- a/pyocd/debug/svd/data/Musca_S1.svd
+++ b/pyocd/debug/svd/data/Musca_S1.svd
@@ -1,0 +1,5338 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2012-2019 Arm Limited. All rights reserved.
+
+  Purpose: System Viewer Description (SVD) Example (Schema Version 1.1)
+           This is a description of a none-existent and incomplete device
+       for demonstration purposes only.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+ -->
+<!-- This file is derivative from IOTKit_CM33.svd -->
+
+<device schemaVersion="1.3" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd" >
+  <vendor>ARM Ltd.</vendor>                                       <!-- device vendor name -->
+  <vendorID>ARM</vendorID>                                        <!-- device vendor short name -->
+  <name>Musca_S1</name>                                           <!-- name of part -->
+  <series>ARMv8-M Mainline</series>                               <!-- device series the device belongs to -->
+  <version>1.0</version>                                          <!-- version of this description, adding CMSIS-SVD 1.1 tags -->
+  <description>ARM 32-bit v8-M Mainline based device</description>
+
+  <licenseText>                                                   <!-- this license text will appear in header file. \n force line breaks -->
+    ARM Limited (ARM) is supplying this software for use with Cortex-M\n
+    processor based microcontroller, but can be equally used for other\n
+    suitable  processor architectures. This file can be freely distributed.\n
+    Modifications to this file shall be clearly marked.\n
+    \n
+    THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED\n
+    OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF\n
+    MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.\n
+    ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR\n
+    CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+  </licenseText>
+
+  <cpu>                                                           <!-- details about the cpu embedded in the device -->
+    <name>CM33</name>
+    <revision>r0p1</revision>
+    <endian>little</endian>
+    <mpuPresent>true</mpuPresent>
+    <fpuPresent>false</fpuPresent>
+    <nvicPrioBits>3</nvicPrioBits>
+    <vendorSystickConfig>false</vendorSystickConfig>
+    <sauNumRegions>8</sauNumRegions>
+  </cpu>
+
+  <addressUnitBits>8</addressUnitBits>                            <!-- byte addressable memory -->
+  <width>32</width>                                               <!-- bus width is 32 bits -->
+  <!-- default settings implicitly inherited by subsequent sections -->
+  <size>32</size>                                                 <!-- default register size for all subsequent registers -->
+  <access>read-write</access>                                     <!-- default access permission for all subsequent registers -->
+  <resetValue>0x00000000</resetValue>                             <!-- by default all bits of the registers are initialized to 0 on reset -->
+  <resetMask>0xFFFFFFFF</resetMask>                               <!-- by default all 32Bits of the registers are used -->
+
+  <peripherals>
+
+    <!-- SAU -->
+    <peripheral>                         <name>SAU</name>
+      <version>1.0</version>
+      <description>Security Attribution Unit</description>
+      <baseAddress>0xE000EDD0</baseAddress>
+
+      <addressBlock>
+          <offset>0</offset>
+          <size>0x20</size>
+          <usage>registers</usage>
+      </addressBlock>
+
+      <registers>
+          <register>          <name>CTRL</name>
+              <description>Control Register</description>
+              <addressOffset>0x00</addressOffset>
+              <fields>
+                  <field>          <name>ENABLE</name>
+                      <description>Enable</description>
+                      <bitRange>[0:0]</bitRange>
+                      <enumeratedValues>
+                          <enumeratedValue>
+                              <name>Disable</name>
+                              <description>SAU is disabled</description>
+                              <value>0</value>
+                          </enumeratedValue>
+                          <enumeratedValue>
+                              <name>Enable</name>
+                              <description>SAU is enabled</description>
+                              <value>1</value>
+                          </enumeratedValue>
+                      </enumeratedValues>
+                  </field>
+                  <field>          <name>ALLNS</name>
+                      <description>Security attribution if SAU disabled</description>
+                      <bitRange>[1:1]</bitRange>
+                      <enumeratedValues>
+                          <enumeratedValue>
+                              <name>Secure</name>
+                              <description>Memory is marked as secure</description>
+                              <value>0</value>
+                          </enumeratedValue>
+                          <enumeratedValue>
+                              <name>Non_Secure</name>
+                              <description>Memory is marked as non-secure</description>
+                              <value>1</value>
+                          </enumeratedValue>
+                      </enumeratedValues>
+                  </field>
+              </fields>
+          </register>
+          <register>          <name>TYPE</name>
+              <description>Type Register</description>
+              <addressOffset>0x04</addressOffset>
+              <access>read-only</access>
+              <fields>
+                  <field>          <name>SREGION</name>
+                      <description>Number of implemented SAU regions</description>
+                      <bitRange>[7:0]</bitRange>
+                  </field>
+              </fields>
+          </register>
+          <register>          <name>RNR</name>
+              <description>Region Number Register</description>
+              <addressOffset>0x08</addressOffset>
+              <fields>
+                  <field>          <name>REGION</name>
+                      <description>Currently selected SAU region</description>
+                      <bitRange>[7:0]</bitRange>
+                  </field>
+              </fields>
+          </register>
+          <register>          <name>RBAR</name>
+              <description>Region Base Address Register</description>
+              <addressOffset>0x0C</addressOffset>
+              <fields>
+                  <field>          <name>BADDR</name>
+                      <description>Base Address</description>
+                      <bitRange>[31:5]</bitRange>
+                  </field>
+              </fields>
+          </register>
+          <register>          <name>RLAR</name>
+              <description>Region Limit Address Register</description>
+              <addressOffset>0x10</addressOffset>
+              <fields>
+                  <field>          <name>LADDR</name>
+                      <description>Limit Address</description>
+                      <bitRange>[31:5]</bitRange>
+                  </field>
+                  <field>          <name>NSC</name>
+                      <description>Non-Secure Callable</description>
+                      <bitRange>[1:1]</bitRange>
+                  </field>
+                  <field>          <name>ENABLE</name>
+                      <description>SAU Region enabled</description>
+                      <bitRange>[0:0]</bitRange>
+                  </field>
+              </fields>
+          </register>
+          <register>          <name>SFSR</name>
+              <description>Secure Fault Status Register</description>
+              <addressOffset>0x14</addressOffset>
+              <fields>
+                  <field>          <name>LSERR</name>
+                      <description>Lazy state error flag</description>
+                      <bitRange>[7:7]</bitRange>
+                  </field>
+                  <field>          <name>SFARVALID</name>
+                      <description>Secure fault address valid</description>
+                      <bitRange>[6:6]</bitRange>
+                  </field>
+                  <field>          <name>LSPERR</name>
+                      <description>Lazy state preservation error flag</description>
+                      <bitRange>[5:5]</bitRange>
+                  </field>
+                  <field>          <name>INVTRAN</name>
+                      <description>Invalid transition flag</description>
+                      <bitRange>[4:4]</bitRange>
+                  </field>
+                  <field>          <name>AUVIOL</name>
+                      <description>Attribution unit violation flag</description>
+                      <bitRange>[3:3]</bitRange>
+                  </field>
+                  <field>          <name>INVER</name>
+                      <description>Invalid exception return flag</description>
+                      <bitRange>[2:2]</bitRange>
+                  </field>
+                  <field>          <name>INVIS</name>
+                      <description>Invalid integrity signature flag</description>
+                      <bitRange>[1:1]</bitRange>
+                  </field>
+                  <field>
+                      <name>INVEP</name>
+                      <description>Invalid entry pointd</description>
+                      <bitRange>[0:0]</bitRange>
+                  </field>
+              </fields>
+          </register>
+      </registers>
+    </peripheral>
+
+    <!-- Timer 0 -->
+    <peripheral>                         <name>TIMER0</name>
+        <version>1.0</version>
+        <description>Timer 0</description>
+        <groupName>Timer</groupName>
+        <baseAddress>0x40000000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x10</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>TIMER0</name>
+            <description>Timer 0</description>
+            <value>3</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>CTRL</name>
+                <description>Control Register</description>
+                <addressOffset>0x000</addressOffset>
+                <fields>
+                    <field>          <name>ENABLE</name>
+                        <description>Enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>EXTIN</name>
+                        <description>External Input as Enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>EXTCLK</name>
+                        <description>External Clock Enable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>INTEN</name>
+                        <description>Interrupt Enable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>VALUE</name>
+                <description>Current Timer Counter Value</description>
+                <addressOffset>0x004</addressOffset>
+            </register>
+            <register>          <name>RELOAD</name>
+                <description>Counter Reload Value</description>
+                <addressOffset>0x008</addressOffset>
+            </register>
+            <register>          <name>INTSTATUS</name>
+                <description>Timer Interrupt status Register</description>
+                <addressOffset>0x00C</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>INTCLEAR</name>
+                <description>Timer Interrupt clear Register</description>
+                <alternateRegister>INTSTATUS</alternateRegister>
+                <addressOffset>0x00C</addressOffset>
+                <access>write-only</access>
+                <modifiedWriteValues>oneToClear</modifiedWriteValues>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- Timer 1 -->
+    <peripheral derivedFrom="TIMER0">    <name>TIMER1</name>
+        <description>Timer 1</description>
+        <groupName>Timer</groupName>
+        <baseAddress>0x40001000</baseAddress>
+
+        <interrupt>
+            <name>TIMER1</name>
+            <description>Timer 1</description>
+            <value>4</value>
+        </interrupt>
+    </peripheral>
+
+    <!-- S32K Timer -->
+    <peripheral derivedFrom="TIMER0">    <name>S32KTIMER</name>
+        <description>S32K Timer</description>
+        <groupName>Timer</groupName>
+        <baseAddress>0x4002F000</baseAddress>
+
+        <interrupt>
+            <name>S32KTIMER</name>
+            <description>Timer 1</description>
+            <value>2</value>
+        </interrupt>
+    </peripheral>
+
+    <!-- Dual Timer-->
+    <peripheral>                         <name>DUALTIMER</name>
+        <version>1.0</version>
+        <description>Dual Timer</description>
+        <groupName>Timer</groupName>
+        <baseAddress>0x40002000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x3C</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>DUALTIMER</name>
+            <description>Dual Timer</description>
+            <value>5</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>TIMER1LOAD</name>
+              <description>Timer 1 Load Register</description>
+              <addressOffset>0x000</addressOffset>
+            </register>
+            <register>          <name>TIMER1VALUE</name>
+              <description>Timer 1 Value Register</description>
+              <addressOffset>0x004</addressOffset>
+              <resetValue>0xFFFFFFFF</resetValue>
+              <access>read-only</access>
+            </register>
+            <register>          <name>TIMER1CONTROL</name>
+              <description>Timer 1 Control Register</description>
+              <addressOffset>0x008</addressOffset>
+              <resetValue>0x20</resetValue>
+                <fields>
+                  <field>          <name>OneShotCount</name>
+                    <description>Selects one-shot or wrapping counter mode</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Wrapping</name>
+                          <description>Wrapping counter mode</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>OneShot</name>
+                          <description>One-shot counter mode</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>TimerSize</name>
+                    <description>Selects 16-bit or 32- bit counter operation</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>16-bit</name>
+                          <description>16-bit counter mode</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>32-bit</name>
+                          <description>32-bit counter mode</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>TimerPre</name>
+                    <description>Timer prescale bits</description>
+                    <bitOffset>2</bitOffset>
+                    <bitWidth>2</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>divided by 1</name>
+                          <description>clock is divided by 1</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>divided by 16</name>
+                          <description>clock is divided by 16</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>divided by 256</name>
+                          <description>clock is divided by 256</description>
+                          <value>2</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>InterruptEnable</name>
+                    <description>Interrupt Enable bit</description>
+                    <bitOffset>5</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Disable</name>
+                          <description>Interrupt is disabled</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Enable</name>
+                          <description>Interrupt is enabled</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>TimerMode</name>
+                    <description>Timer Mode bit</description>
+                    <bitOffset>6</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Free-Running</name>
+                          <description>Free-Running timer mode</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Periodic</name>
+                          <description>Periodic timer mode</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>TimerEnable</name>
+                    <description>Timer Enable Enable bit</description>
+                    <bitOffset>7</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Disable</name>
+                          <description>Timer is disabled</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Enable</name>
+                          <description>Timer is enabled</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                </fields>
+            </register>
+            <register>          <name>TIMER1INTCLR</name>
+              <description>Timer 1 Interrupt Clear Register</description>
+              <addressOffset>0x00C</addressOffset>
+              <access>write-only</access>
+              <fields>
+                <field>                  <name>INT</name>
+                    <description>Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER1RIS</name>
+              <description>Timer 1 Raw Interrupt Status Register</description>
+              <addressOffset>0x010</addressOffset>
+              <access>read-only</access>
+              <fields>
+                <field>          <name>RIS</name>
+                    <description>Raw Timer Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER1MIS</name>
+              <description>Timer 1 Mask Interrupt Status Register</description>
+              <addressOffset>0x014</addressOffset>
+              <access>read-only</access>
+              <fields>
+                <field>          <name>MIS</name>
+                    <description>Masked Timer Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER1BGLOAD</name>
+              <description>Timer 1 Background Load Register</description>
+              <addressOffset>0x018</addressOffset>
+            </register>
+            <register>          <name>TIMER2LOAD</name>
+              <description>Timer 2 Load Register</description>
+              <addressOffset>0x020</addressOffset>
+            </register>
+            <register>          <name>TIMER2VALUE</name>
+              <description>Timer 2 Value Register</description>
+              <addressOffset>0x024</addressOffset>
+              <resetValue>0xFFFFFFFF</resetValue>
+              <access>read-only</access>
+            </register>
+            <register>          <name>TIMER2CONTROL</name>
+              <description>Timer 2 Control Register</description>
+              <addressOffset>0x028</addressOffset>
+              <resetValue>0x20</resetValue>
+                  <fields>
+                    <field>          <name>OneShotCount</name>
+                      <description>Selects one-shot or wrapping counter mode</description>
+                      <bitOffset>0</bitOffset>
+                      <bitWidth>1</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>Wrapping</name>
+                            <description>Wrapping counter mode</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>OneShot</name>
+                            <description>One-shot counter mode</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                    <field>          <name>TimerSize</name>
+                      <description>Selects 16-bit or 32- bit counter operation</description>
+                      <bitOffset>1</bitOffset>
+                      <bitWidth>1</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>16-bit</name>
+                            <description>16-bit counter mode</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>32-bit</name>
+                            <description>32-bit counter mode</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                    <field>          <name>TimerPre</name>
+                      <description>Timer prescale bits</description>
+                      <bitOffset>2</bitOffset>
+                      <bitWidth>2</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>divided by 1</name>
+                            <description>clock is divided by 1</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>divided by 16</name>
+                            <description>clock is divided by 16</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>divided by 256</name>
+                            <description>clock is divided by 256</description>
+                            <value>2</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                    <field>          <name>InterruptEnable</name>
+                      <description>Interrupt Enable bit</description>
+                      <bitOffset>5</bitOffset>
+                      <bitWidth>1</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>Disable</name>
+                            <description>Interrupt is disabled</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>Enable</name>
+                            <description>Interrupt is enabled</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                    <field>          <name>TimerMode</name>
+                      <description>Timer Mode bit</description>
+                      <bitOffset>6</bitOffset>
+                      <bitWidth>1</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>Free-Running</name>
+                            <description>Free-Running timer mode</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>Periodic</name>
+                            <description>Periodic timer mode</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                    <field>          <name>TimerEnable</name>
+                      <description>Timer Enable Enable bit</description>
+                      <bitOffset>7</bitOffset>
+                      <bitWidth>1</bitWidth>
+                      <enumeratedValues>
+                        <enumeratedValue>
+                            <name>Disable</name>
+                            <description>Timer is disabled</description>
+                            <value>0</value>
+                        </enumeratedValue>
+                        <enumeratedValue>
+                            <name>Enable</name>
+                            <description>Timer is enabled</description>
+                            <value>1</value>
+                        </enumeratedValue>
+                      </enumeratedValues>
+                    </field>
+                  </fields>
+            </register>
+            <register>          <name>TIMER2INTCLR</name>
+              <description>Timer 2 Interrupt Clear Register</description>
+              <addressOffset>0x02C</addressOffset>
+              <access>write-only</access>
+              <fields>
+                <field>
+                    <name>INT</name>
+                    <description>Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER2RIS</name>
+              <description>Timer 2 Raw Interrupt Status Register</description>
+              <addressOffset>0x030</addressOffset>
+              <access>read-only</access>
+              <fields>
+                <field>          <name>RIS</name>
+                    <description>Raw Timer Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER2MIS</name>
+              <description>Timer 2 Mask Interrupt Status Register</description>
+              <addressOffset>0x034</addressOffset>
+              <access>read-only</access>
+              <fields>
+                <field>          <name>MIS</name>
+                    <description>Masked Timer Interrupt</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                </field>
+              </fields>
+            </register>
+            <register>          <name>TIMER2BGLOAD</name>
+              <description>Timer 2 Background Load Register</description>
+              <addressOffset>0x038</addressOffset>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- GP Timer -->
+    <peripheral>                         <name>GPTIMER</name>
+        <version>1.0</version>
+        <description>General-Purpose Timer</description>
+        <groupName>Timer</groupName>
+        <baseAddress>0x4010B000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x20</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>GPTIMER</name>
+            <description>General-Purpose Timer Interrupt</description>
+            <value>33</value>
+            <name>GPTIMER_COMP0</name>
+            <description>General-Purpose Timer (Comparator 0)</description>
+            <value>73</value>
+            <name>GPTIMER_COMP1</name>
+            <description>General-Purpose Timer (Comparator 1)</description>
+            <value>72</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>GPTRESET</name>
+                <description>Control Reset Register</description>
+                <addressOffset>0x0000</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>                            <name>GPTRESET</name>
+                        <description>CPU0 interrupt status</description>
+                        <bitRange>[1:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTINTM</name>
+                <description>Masked interrupt status Register</description>
+                <addressOffset>0x0004</addressOffset>
+                <fields>
+                    <field>                            <name>GPTINTM</name>
+                        <description>Current masked status of the Interrupt</description>
+                        <bitRange>[1:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTINTC</name>
+                <description>Interrupt clear Register</description>
+                <addressOffset>0x0008</addressOffset>
+                <fields>
+                    <field>                            <name>GPTINTC</name>
+                        <description>Writing 0b1 disables the ALARM[n] Interrupt</description>
+                        <bitRange>[1:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTALARM0</name>
+                <description>ALARM0 data value Register</description>
+                <addressOffset>0x0010</addressOffset>
+                <fields>
+                    <field>
+                        <name> GPTALARM0_DATA</name>
+                        <description>Value that triggers the ALARM0 interrupt when the counter reaches that value</description>
+                        <bitRange>[31:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTALARM1</name>
+                <description>ALARM1 data value Register</description>
+                <addressOffset>0x0014</addressOffset>
+                <fields>
+                    <field>
+                        <name> GPTALARM1_DATA</name>
+                        <description>Value that triggers the ALARM1 interrupt when the counter reaches that value</description>
+                        <bitRange>[31:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTINTR</name>
+                <description>Raw interrupt status Register</description>
+                <addressOffset>0x0018</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>                            <name>GPTINTR</name>
+                        <description>Raw interrupt state, before masking of GPTINTR Interrupt</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GPTCOUNTER</name>
+                <description>Counter data value Register</description>
+                <addressOffset>0x001C</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>
+                        <name>GPTCOUNTER</name>
+                        <description>Current value of 32-bit Timer Counter</description>
+                        <bitRange>[31:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- Timer 0 (Secure) -->
+    <peripheral derivedFrom="TIMER0">    <name>TIMER0_Secure</name>
+        <description>Timer 0 (Secure)</description>
+        <groupName>Timer (Secure)</groupName>
+        <baseAddress>0x50000000</baseAddress>
+    </peripheral>
+
+    <!-- Timer 1 (Secure) -->
+    <peripheral derivedFrom="TIMER1">    <name>TIMER1_Secure</name>
+        <description>Timer 1 (Secure)</description>
+        <groupName>Timer (Secure)</groupName>
+        <baseAddress>0x50001000</baseAddress>
+    </peripheral>
+
+    <!-- S32K Timer (Secure) -->
+    <peripheral derivedFrom="S32KTIMER"> <name>S32KTIMER_Secure</name>
+        <description>S32K Timer (Secure)</description>
+        <groupName>Timer (Secure)</groupName>
+        <baseAddress>0x5002F000</baseAddress>
+    </peripheral>
+
+    <!-- Dual Timer (Secure) -->
+    <peripheral derivedFrom="DUALTIMER"> <name>DUALTIMER_Secure</name>
+        <description>Dual Timer (Secure)</description>
+        <groupName>Timer (Secure)</groupName>
+        <baseAddress>0x50002000</baseAddress>
+    </peripheral>
+
+    <!-- GP Timer (Secure) -->
+    <peripheral derivedFrom="GPTIMER">   <name>GPTIMER_Secure</name>
+        <description>General-Purpose Timer (Secure)</description>
+        <groupName>Timer (Secure)</groupName>
+        <baseAddress>0x5010B000</baseAddress>
+    </peripheral>
+
+    <!-- GPIO 0-->
+    <peripheral>                         <name>GPIO0</name>
+        <version>1.0</version>
+        <description>General-purpose I/O 0</description>
+        <groupName>GPIO</groupName>
+        <baseAddress>0x40110000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x3C</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>GPIO0</name>
+            <description>GPIO 0 combined</description>
+            <value>68</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>DATA</name>
+                <description>Data Register</description>
+                <addressOffset>0x000</addressOffset>
+            </register>
+            <register>          <name>DATAOUT</name>
+                <description>Data Output Register</description>
+                <addressOffset>0x004</addressOffset>
+            </register>
+            <register>          <name>OUTENSET</name>
+                <description>Ouptut enable set Register</description>
+                <addressOffset>0x010</addressOffset>
+            </register>
+            <register>          <name>OUTENCLR</name>
+               <description>Ouptut enable clear Register</description>
+                <addressOffset>0x014</addressOffset>
+            </register>
+            <register>          <name>ALTFUNCSET</name>
+                <description>Alternate function set Register</description>
+                <addressOffset>0x018</addressOffset>
+            </register>
+            <register>          <name>ALTFUNCCLR</name>
+                <description>Alternate function clear Register</description>
+                <addressOffset>0x01C</addressOffset>
+            </register>
+            <register>          <name>INTENSET</name>
+                <description>Interrupt enable set Register</description>
+                <addressOffset>0x020</addressOffset>
+            </register>
+            <register>          <name>INTENCLR</name>
+                <description>Interrupt enable clear Register</description>
+                <addressOffset>0x024</addressOffset>
+            </register>
+            <register>          <name>INTTYPESET</name>
+                <description>Interrupt type set Register</description>
+                <addressOffset>0x028</addressOffset>
+            </register>
+            <register>          <name>INTTYPECLR</name>
+                <description>Interrupt type clear Register</description>
+                <addressOffset>0x02C</addressOffset>
+            </register>
+            <register>          <name>INTPOLSET</name>
+                <description>Polarity-level, edge interrupt configuration set Register</description>
+                <addressOffset>0x030</addressOffset>
+            </register>
+            <register>          <name>INTPOLCLR</name>
+                <description>Polarity-level, edge interrupt configuration clear Register</description>
+                <addressOffset>0x034</addressOffset>
+            </register>
+            <register>          <name>INTSTATUS</name>
+                <description>Interrupt Status Register</description>
+                <addressOffset>0x038</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>INTCLEAR</name>
+                <description>Interrupt CLEAR Register</description>
+                <alternateRegister>INTSTATUS</alternateRegister>
+                <addressOffset>0x038</addressOffset>
+                <access>write-only</access>
+                <modifiedWriteValues>oneToClear</modifiedWriteValues>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- GPIO 0 (Secure) -->
+    <peripheral derivedFrom="GPIO0">     <name>GPIO0_Secure</name>
+        <description>General-purpose I/O 0 (Secure)</description>
+        <baseAddress>0x50110000</baseAddress>
+        <groupName>GPIO (Secure)</groupName>
+    </peripheral>
+
+    <!-- UART 0 -->
+    <peripheral>                         <name>UART0</name>
+        <version>1.0</version>
+        <description>UART 0</description>
+        <groupName>UART</groupName>
+        <baseAddress>0x40101000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x4C</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>UART_0_RX</name>
+            <description>UART0 Receive FIFO Interrupt</description>
+            <value>39</value>
+            <name>UART_0_TX</name>
+            <description>UART0 Transmit FIFO Interrupt</description>
+            <value>40</value>
+            <name>UART_0_RT</name>
+            <description>UART0 Receive Timeout Interrupt</description>
+            <value>41</value>
+            <name>UART_0_MS</name>
+            <description>UART0 Modem Status Interrupt</description>
+            <value>42</value>
+            <name>UART_0_E</name>
+            <description>UART0 Error Interrupt</description>
+            <value>43</value>
+            <name>UART_0</name>
+            <description>UART0 Interrupt</description>
+            <value>44</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>UARTDR</name>
+                <description>Data Register</description>
+                <addressOffset>0x000</addressOffset>
+                <fields>
+                    <field>          <name>Data</name>
+                        <description>Receive/Transmit data</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                    <field>          <name>FE</name>
+                        <description>Framing error: Indicates the received character did not had a valid stop bit</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>PE</name>
+                        <description>
+                          Parity error: Indicates that the parity of the received data
+                          character does not match the parity selected
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>BE</name>
+                        <description>
+                          Break error: Indicates that the received data input was held LOW
+                          for longer than a full-word transmission time
+                        </description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>OE</name>
+                        <description>
+                          Overrun error: Indicates if data is received and the receive FIFO is already full
+                        </description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTRSR</name>
+                <description>Receive status register/error clear Register</description>
+                <alternateRegister>UARTECR</alternateRegister>
+                <addressOffset>0x004</addressOffset>
+                <fields>
+                    <field>          <name>FE</name>
+                        <description>
+                          Framing error: Indicates the received character did not had a valid stop bit
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>PE</name>
+                        <description>
+                          Parity error: Indicates that the parity of the received data character
+                          does not match the parity selected
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>BE</name>
+                        <description>
+                          Break error: Indicates that the received data input was held LOW
+                          for longer than a full-word transmission time
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>OE</name>
+                        <description>
+                          Overrunerror: Indicates if data is received and the receive FIFO is already full
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTFR</name>
+                <description>Flag Register</description>
+                <addressOffset>0x018</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>CTS</name>
+                        <description>Clear to send</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>DSR</name>
+                        <description>Data set ready</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>DCD</name>
+                        <description>Data carrier detect</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>BUSY</name>
+                        <description>UART busy</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RXFE</name>
+                        <description>Receive FIFO empty</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>TXFF</name>
+                        <description>Transmit FIFO full</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>RXFF</name>
+                        <description>Receive FIFO full</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>TXFE</name>
+                        <description>Transmit FIFO empty</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>RI</name>
+                        <description>Ring indicator</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTILPR</name>
+                <description>IrDA low-power counter Register</description>
+                <addressOffset>0x020</addressOffset>
+                <fields>
+                    <field>          <name>ILPDVSR</name>
+                        <description>8-bit low-power divisor value</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTIBRD</name>
+                <description>Integer baud rate Register</description>
+                <addressOffset>0x024</addressOffset>
+                <fields>
+                    <field>          <name>BAUD_DIVINT</name>
+                        <description>The integer baud rate divisor</description>
+                        <bitRange>[15:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTFBRD</name>
+                <description>Fractional baud rate Register</description>
+                <addressOffset>0x028</addressOffset>
+                <fields>
+                    <field>          <name>BAUD_DIVINT</name>
+                        <description>The integer baud rate divisor</description>
+                        <bitRange>[5:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTLCR_H</name>
+                <description>Line control Register</description>
+                <addressOffset>0x02C</addressOffset>
+                <fields>
+                    <field>          <name>BRK</name>
+                        <description>Send break</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>PEN</name>
+                        <description>Parity enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>EPS</name>
+                        <description>Even parity select</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>STP2</name>
+                      <description>Two stop bits select</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>FEN</name>
+                        <description>Enable FIFOs</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>WLEN</name>
+                        <description>Word length</description>
+                        <bitRange>[6:5]</bitRange>
+                    </field>
+                    <field>          <name>SPS</name>
+                      <description>Stick parity select</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTCR</name>
+                <description>Control Register</description>
+                <addressOffset>0x030</addressOffset>
+                <resetValue>0x00000300</resetValue>
+                <fields>
+                    <field>          <name>UARTEN</name>
+                        <description>UART enable</description>
+                        <bitRange>[0:0]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>UART is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>UART is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>SIREN</name>
+                        <description>SIR enable</description>
+                        <bitRange>[1:1]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>SIR is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>SIR is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>SIRLP</name>
+                        <description>IrDA SIR low power mode</description>
+                        <bitRange>[2:2]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>SIR low power mode is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>SIR low power mode is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>LBE</name>
+                        <description>Loop back enable</description>
+                        <bitRange>[7:7]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>Loop back mode is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>Loop back mode is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>TXE</name>
+                        <description>Transmit enable</description>
+                        <bitRange>[8:8]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>Transmission is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>Transmission is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>RXE</name>
+                        <description>Receive enable</description>
+                        <bitRange>[9:9]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description> Reception is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>Reception is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>DTR</name>
+                        <description>Data transmit ready</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>RTS</name>
+                        <description>Request to send</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>Out1</name>
+                        <description>Complement of the UART Out1</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>          <name>Out2</name>
+                        <description>Complement of the UART Out2</description>
+                        <bitRange>[13:13]</bitRange>
+                    </field>
+                    <field>          <name>RTSEn</name>
+                        <description>RTS hardware flow control enable</description>
+                        <bitRange>[14:14]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>RTS hardware flow control is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>RTS hardware flow control is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>CTSEn</name>
+                        <description>CTS hardware flow control enable</description>
+                        <bitRange>[15:15]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>CTS hardware flow control is disabled</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>CTS hardware flow control is enabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTIFLS</name>
+                <description>Interrupt FIFO level select Register</description>
+                <addressOffset>0x034</addressOffset>
+                <resetValue>0x00000012</resetValue>
+                <fields>
+                    <field>          <name>TXIFLSEL</name>
+                        <description>Transmit interrupt FIFO level select</description>
+                        <bitRange>[2:0]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>1/8 full</name>
+                                <description>Transmit FIFO becomes less than or equal to 1/8 full</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>1/4 full</name>
+                                <description>Transmit FIFO becomes less than or equal to 1/4 full</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>1/2 full</name>
+                                <description>Transmit FIFO becomes less than or equal to 1/2 full</description>
+                                <value>2</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>3/4 full</name>
+                                <description>Transmit FIFO becomes less than or equal to 3/4 full</description>
+                                <value>3</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>7/8 full</name>
+                                <description>Transmit FIFO becomes less than or equal to 7/8 full</description>
+                                <value>4</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>RXIFLSEL</name>
+                        <description>Receive interrupt FIFO level select</description>
+                        <bitRange>[5:3]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>1/8 full</name>
+                                <description>Receive FIFO becomes greater than or equal to 1/8 full</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>1/4 full</name>
+                                <description>Receive FIFO becomes greater than or equal to 1/4 full</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>1/2 full</name>
+                                <description>Receive FIFO becomes greater than or equal to 1/2 full</description>
+                                <value>2</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>3/4 full</name>
+                                <description>Receive FIFO becomes greater than or equal to 3/4 full</description>
+                                <value>3</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>7/8 full</name>
+                                <description>Receive FIFO becomes greater than or equal to 7/8 full</description>
+                                <value>4</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTIMSC</name>
+                <description>Interrupt mask set/clear Register</description>
+                <addressOffset>0x038</addressOffset>
+                <fields>
+                    <field>          <name>RIMIM</name>
+                        <description>nUARTRI modem interrupt mask</description>
+                        <bitRange>[0:0]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>CTSMIM</name>
+                        <description>nUARTCTS modem interrupt mask</description>
+                        <bitRange>[1:1]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>DCDMIM</name>
+                        <description>nUARTDCD modem interrupt mask</description>
+                        <bitRange>[2:2]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>DSRMIM</name>
+                        <description>nUARTDSR modem interrupt mask</description>
+                        <bitRange>[3:3]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>RXIM</name>
+                        <description>Receive interrupt mask</description>
+                        <bitRange>[4:4]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>TXIM</name>
+                        <description>Transmit interrupt mask</description>
+                        <bitRange>[5:5]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>RTIM</name>
+                        <description>Receive timeout interrupt mask</description>
+                        <bitRange>[6:6]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>FEIM</name>
+                        <description>Framing error interrupt mask</description>
+                        <bitRange>[7:7]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>PEIM</name>
+                        <description>Parity error interrupt mask</description>
+                        <bitRange>[8:8]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>BEIM</name>
+                        <description>Break error interrupt mask</description>
+                        <bitRange>[9:9]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>OEIM</name>
+                        <description>Overrun error interrupt mask</description>
+                        <bitRange>[10:10]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Clear</name>
+                                <description>Clears the mask</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Set</name>
+                                <description>Sets the mask</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>UARTRIS</name>
+              <description>Raw interrupt status Register</description>
+              <addressOffset>0x03C</addressOffset>
+              <access>read-only</access>
+                  <fields>
+                    <field>          <name>RIRMIS</name>
+                      <description>nUARTRI modem interrupt status</description>
+                      <bitOffset>0</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>CTSRMIS</name>
+                      <description>nUARTCTS modem interrupt status</description>
+                      <bitOffset>1</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DCDRMIS</name>
+                      <description>nUARTDCD modem interrupt status</description>
+                      <bitOffset>2</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DSRRMIS</name>
+                      <description>nUARTDSR modem interrupt status</description>
+                      <bitOffset>3</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RXRIS</name>
+                      <description>Receive interrupt status</description>
+                      <bitOffset>4</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>TXRIS</name>
+                      <description>Transmit interrupt status</description>
+                      <bitOffset>5</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RTRIS</name>
+                      <description>Receive timeout interrupt status</description>
+                      <bitOffset>6</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>FERIS</name>
+                      <description>Framing error interrupt status</description>
+                      <bitOffset>7</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>PERIS</name>
+                      <description>Parity error interrupt status</description>
+                      <bitOffset>8</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>BERIS</name>
+                      <description>Break error interrupt status</description>
+                      <bitOffset>9</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>OERIS</name>
+                      <description>Overrun error interrupt status</description>
+                      <bitOffset>10</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                  </fields>
+            </register>
+            <register>          <name>UARTMIS</name>
+              <description>Masked interrupt status Register</description>
+              <addressOffset>0x040</addressOffset>
+              <access>read-only</access>
+                  <fields>
+                    <field>          <name>RIMMIS</name>
+                      <description>nUARTRI modem masked interrupt status</description>
+                      <bitOffset>0</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>CTSMMIS</name>
+                      <description>nUARTCTS modem masked interrupt status</description>
+                      <bitOffset>1</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DCDMMIS</name>
+                      <description>nUARTDCD modem masked interrupt status</description>
+                      <bitOffset>2</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DSRMMIS</name>
+                      <description>nUARTDSR modem masked interrupt status</description>
+                      <bitOffset>3</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RXMIS</name>
+                      <description>Receive masked interrupt status</description>
+                      <bitOffset>4</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>TXMIS</name>
+                      <description>Transmit masked interrupt status</description>
+                      <bitOffset>5</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RTMIS</name>
+                      <description>Receive timeout masked interrupt status</description>
+                      <bitOffset>6</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>FEMIS</name>
+                      <description>Framing error masked interrupt status</description>
+                      <bitOffset>7</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>PEMIS</name>
+                      <description>Parity error masked interrupt status</description>
+                      <bitOffset>8</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>BEMIS</name>
+                      <description>Break error masked interrupt status</description>
+                      <bitOffset>9</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>OEMIS</name>
+                      <description>Overrun error masked interrupt status</description>
+                      <bitOffset>10</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                  </fields>
+            </register>
+            <register>          <name>UARTICR</name>
+              <description>Interrupt clear Register</description>
+              <addressOffset>0x044</addressOffset>
+              <access>write-only</access>
+                  <fields>
+                    <field>          <name>RIMIC</name>
+                      <description>nUARTRI modem interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>0</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>CTSMIC</name>
+                      <description>nUARTCTS modem interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>1</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DCDMIC</name>
+                      <description>nUARTDCD modem interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>2</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>DSRIC</name>
+                      <description>nUARTDSR modem interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>3</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RXIC</name>
+                      <description>Receive interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>4</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>TXIC</name>
+                      <description>Transmit interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>5</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>RTIC</name>
+                      <description>Receive timeout interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>6</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>FEIC</name>
+                      <description>Framing error interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>7</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>PEIC</name>
+                      <description>Parity error interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>8</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>BEIC</name>
+                      <description>Break error interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>9</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                    <field>          <name>OEIC</name>
+                      <description>Overrun error interrupt clear, write 1 to clear, write 0 has no effect</description>
+                      <bitOffset>10</bitOffset>
+                      <bitWidth>1</bitWidth>
+                    </field>
+                  </fields>
+            </register>
+            <register>          <name>UARTDMACR</name>
+                <description>DMA control Register</description>
+                <addressOffset>0x048</addressOffset>
+                <fields>
+                  <field>          <name>RXDMAE</name>
+                    <description>Receive DMA enable</description>
+                    <bitOffset>0</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Disable</name>
+                          <description>Receive DMA is disabled</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Enable</name>
+                          <description>Receive DMA is enabled</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>TXDMAE</name>
+                    <description>Transmit DMA enable</description>
+                    <bitOffset>1</bitOffset>
+                    <bitWidth>1</bitWidth>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Disable</name>
+                          <description>Transmit DMA is disabled</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Enable</name>
+                          <description>Transmit DMA is enabled</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                  <field>          <name>DMAONERR</name>
+                    <description>DMA on error</description>
+                    <bitRange>[2:2]</bitRange>
+                    <enumeratedValues>
+                      <enumeratedValue>
+                          <name>Disable</name>
+                          <description>DMA receive request outputs are
+                          enabled when the UART error interrupt is
+                          asserted</description>
+                          <value>0</value>
+                      </enumeratedValue>
+                      <enumeratedValue>
+                          <name>Enable</name>
+                          <description>DMA receive request outputs are
+                          disabled when the UART error interrupt is
+                          asserted</description>
+                          <value>1</value>
+                      </enumeratedValue>
+                    </enumeratedValues>
+                  </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- UART 1 -->
+    <peripheral derivedFrom="UART0">     <name>UART1</name>
+        <description>UART 1</description>
+        <baseAddress>0x40102000</baseAddress>
+        <groupName>UART</groupName>
+
+        <interrupt>
+            <name>UART_1_RX</name>
+            <description>UART1 Receive FIFO Interrupt</description>
+            <value>45</value>
+            <name>UART_1_TX</name>
+            <description>UART1 Transmit FIFO Interrupt</description>
+            <value>46</value>
+            <name>UART_1_RT</name>
+            <description>UART1 Receive Timeout Interrupt</description>
+            <value>47</value>
+            <name>UART_1_MS</name>
+            <description>UART1 Modem Status Interrupt</description>
+            <value>48</value>
+            <name>UART_1_E</name>
+            <description>UART1 Error Interrupt</description>
+            <value>49</value>
+            <name>UART_1</name>
+            <description>UART1 Interrupt</description>
+            <value>50</value>
+        </interrupt>
+    </peripheral>
+
+    <!-- UART 0 (Secure) -->
+    <peripheral derivedFrom="UART0">     <name>UART0_Secure</name>
+        <description>UART 0 (Secure)</description>
+        <baseAddress>0x50101000</baseAddress>
+        <groupName>UART (Secure)</groupName>
+    </peripheral>
+
+    <!-- UART 1 (Secure) -->
+    <peripheral derivedFrom="UART1">     <name>UART1_Secure</name>
+        <description>UART 1 (Secure)</description>
+        <baseAddress>0x50102000</baseAddress>
+        <groupName>UART (Secure)</groupName>
+    </peripheral>
+
+    <!-- Watchdog -->
+    <peripheral>                         <name>WATCHDOG</name>
+        <description>Non-secure Watchdog Timer</description>
+        <groupName>Watchdog</groupName>
+        <baseAddress>0x40081000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0xC04</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>NONSEC_WATCHDOG</name>
+            <description>Non-Secure Watchdog Interrupt</description>
+            <value>1</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>WDOGLOAD</name>
+                <description>Watchdog Load Register</description>
+                <addressOffset>0x000</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>WDOGVALUE</name>
+                <description>Watchdog Value Register</description>
+                <addressOffset>0x004</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+                <access>read-only</access>
+            </register>
+            <register>          <name>WDOGCONTROL</name>
+                <description>Watchdog Control Register</description>
+                <addressOffset>0x008</addressOffset>
+                <fields>
+                    <field>          <name>INTEN</name>
+                        <description>Enable the interrupt event</description>
+                        <bitRange>[0:0]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>Disable Watchdog Interrupt</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>Enable Watchdog interrupt</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>RESEN</name>
+                        <description>Enable watchdog reset output</description>
+                        <bitRange>[1:1]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disable</name>
+                                <description>Disable Watchdog reset</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enable</name>
+                                <description>Enable Watchdog reset</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>WDOGINTCLR</name>
+                <description>Watchdog Interrupt Clear Register</description>
+                <addressOffset>0x00C</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>
+                        <name>INT</name>
+                        <description>Interrupt</description>
+                        <bitRange>[0:0]</bitRange>
+                        <modifiedWriteValues>oneToClear</modifiedWriteValues>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>WDOGRIS</name>
+                <description>Watchdog Raw Interrupt Status Register</description>
+                <addressOffset>0x010</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>RIS</name>
+                        <description>Raw watchdog Interrupt</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>WDOGMIS</name>
+                <description>Watchdog Mask Interrupt Status Register</description>
+                <addressOffset>0x014</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>MIS</name>
+                        <description>Masked Watchdog Interrupt</description>
+                        <bitOffset>0</bitOffset>
+                        <bitWidth>1</bitWidth>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>WDOGLOCK</name>
+                <description>Watchdog Lock Register</description>
+                <addressOffset>0xC00</addressOffset>
+                <fields>
+                    <field>          <name>Access</name>
+                        <description>Enable register writes</description>
+                        <bitRange>[31:1]</bitRange>
+                    </field>
+                    <field>          <name>Status</name>
+                        <description>Register write enable status</description>
+                        <bitRange>[0:0]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Enabled</name>
+                                <description>Write access to all other registers is enabled. This is the default</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Disabled</name>
+                                <description>Write access to all other registers is disabled</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- SPI 0 -->
+    <peripheral>                         <name>SPI0</name>
+        <version>1.0</version>
+        <description>SPI 0</description>
+        <groupName>SPI</groupName>
+        <baseAddress>0x40103000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0xFC</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>SPI_0</name>
+            <description>SPI0 Interrupt</description>
+            <value>37</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>SPICR</name>
+                <description>Configuration Register</description>
+                <addressOffset>0x00</addressOffset>
+                <resetValue>0x00020000</resetValue>
+                <fields>
+                    <field>          <name>MSEL</name>
+                        <description>Mode Select: Selects SPI controller mode (MASTER/SLAVE)</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>CPOL</name>
+                        <description>External Clock Edge: Selects the SPI clock polarity outside SPI word</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>CPHA</name>
+                        <description>Clock Phase: Selects whether the SPI clock is in active or inactive phase outside the SPI word</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>MBRD</name>
+                        <description>
+                          Master Baud Rate Divisor (2 to 256). The SCLK is generated base
+                          on SPI REFERENCE CLOCK or ext_clk divided by MBRD
+                        </description>
+                        <bitRange>[5:3]</bitRange>
+                    </field>
+                    <field>          <name>TWS</name>
+                        <description>
+                          Transfer Word Size: Define size of word to be transferred. This MUST be equal to the
+                          FIFO width (FF_W), or a sub-multiple of FF_W to allow multiple word transfers per FIFO word
+                        </description>
+                        <bitRange>[7:6]</bitRange>
+                    </field>
+                    <field>          <name>MRCS</name>
+                        <description>
+                          Reference Clock Select: When this bit is set the ext_clk is used,
+                          otherwise SPI REFERENCE CLOCK is used
+                        </description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>PSD</name>
+                        <description>
+                          Peripheral Select Decode: When this bit is set allow external 4-to-16 decode (n_ss_out [3:0 = PCSL [3:0]).
+                          When Peripheral Select Decode is not set, only 1 of 4 selects n_ss_out[3:0] are active (see PCSL)
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>PCSL</name>
+                        <description>
+                          Peripheral Chip Select Lines (master mode only):
+                          When Peripheral Select Decode is set then PCSL[3:0] directly drives n_ss_out [3:0],
+                          else (PSD is written with 0) PCSL[3:0] drives n_ss_out [3:0]
+                        </description>
+                        <bitRange>[13:10]</bitRange>
+                    </field>
+                    <field>          <name>MCSE</name>
+                        <description>
+                          Manual Chip Select Enable: When this bit is set, the n_ss_out[3:0] lines will be
+                          driven permanently by the encoded peripheral select value regardless of the current
+                          state of the main SPI state machine
+                        </description>
+                        <bitRange>[14:14]</bitRange>
+                    </field>
+                    <field>          <name>MSE</name>
+                        <description>
+                          Manual Start Enable: When this bit is set do not allow transmission to start until
+                          Manual Start Command (see MSC) bit is written with a '1'
+                        </description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                    <field>          <name>MSC</name>
+                        <description>
+                          Manual Start Command: When manual start mode is enabled (see Manual Start Enable bit
+                          of Configuration Register) and TX FIFO is not empty, writing a 1 to this bit will start
+                          transmission. Writing a 0 will have no effect. It returns '0' when read
+                        </description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>MFGE</name>
+                        <description>
+                          Mode Fail Generation Enable: When this bit is set the logic generating Mode Fail is enabled
+                        </description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>          <name>SPSE</name>
+                        <description>
+                          Sample Point Shift Enable: When this bit is set and controller is in MASTER receiver mode
+                          then sample point of receiving data is shifted with respect to sample point of SPI protocol
+                          specification
+                        </description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>          <name>RXCLR</name>
+                        <description>
+                          RX FIFO Clear: Writing a 1 to this bit will clear the RX FIFO. Writing a 0 will have
+                          no effect. It returns '0' when read
+                        </description>
+                        <bitRange>[19:19]</bitRange>
+                    </field>
+                    <field>          <name>TXCLR</name>
+                        <description>
+                          TX FIFO Clear: Writing a 1 to this bit will clear the TX FIFO. Writing a '0' will have
+                          no effect. It returns 0 when read
+                        </description>
+                        <bitRange>[20:20]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIISR</name>
+                <description>Interrupt Status Register</description>
+                <addressOffset>0x04</addressOffset>
+                <resetValue>0x00000004</resetValue>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>ROF</name>
+                        <description>
+                          RX FIFO Overflow: This bit is set if an attempt is made to push the RX FIFO when it is full
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>MF</name>
+                        <description>
+                          Mode Fail: Indicates the voltage on pin n_ss_in is inconsistent with the SPI mode
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>TNF</name>
+                        <description>TX FIFO Not Full (current FIFO status)</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TF</name>
+                        <description>TX FIFO Full (current FIFO status)</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RNE</name>
+                        <description>RX FIFO Not Empty (current FIFO status)</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RF</name>
+                        <description>RX FIFO Full (current FIFO status)</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TUF</name>
+                        <description>
+                          TX FIFO Underflow: This bit is reset only by a system reset and cleared only when
+                          the register is read
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIIER</name>
+                <description>Interrupt Enable Register</description>
+                <addressOffset>0x08</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>ROFE</name>
+                        <description>RX FIFO Overflow Enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>MFE</name>
+                        <description>Mode Fail Enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>TNFE</name>
+                        <description>TX FIFO Not Full Enable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TFE</name>
+                        <description>TX FIFO Full Enable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RNEE</name>
+                        <description>RX FIFO Not Empty Enable</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RFE</name>
+                        <description>RX FIFO Full Enable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TUFE</name>
+                        <description>TX FIFO Underflow Enable</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIIDR</name>
+                <description>Interrupt Disable Register</description>
+                <addressOffset>0x0C</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>ROFD</name>
+                        <description>RX FIFO Overflow Disable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>MFD</name>
+                        <description>Mode Fail Disable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>TNFD</name>
+                        <description>TX FIFO Not Full Disable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TFD</name>
+                        <description>TX FIFO Full Disable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RNED</name>
+                        <description>RX FIFO Not Empty Disable</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RFD</name>
+                        <description>RX FIFO Full Disable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TUFD</name>
+                        <description>TX FIFO Underflow Disable</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIIMR</name>
+                <description>Interrupt Mask Register</description>
+                <addressOffset>0x010</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>ROFM</name>
+                        <description>RX FIFO Overflow Mask</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>MFM</name>
+                        <description>Mode Fail Mask</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>TNFM</name>
+                        <description>TX FIFO Not Full Mask</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TFM</name>
+                        <description>TX FIFO Full Mask</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RNEM</name>
+                        <description>RX FIFO Not Empty Mask</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RFM</name>
+                        <description>RX FIFO Full Mask</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TUFM</name>
+                        <description>TX FIFO Underflow Mask</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIENR</name>
+                <description>SPI Enable Register</description>
+                <addressOffset>0x014</addressOffset>
+                <fields>
+                    <field>          <name>SPIE</name>
+                        <description>
+                          SPI Enable: When this bit is set the SPI controller is enabled, otherwise SPI is disabled.
+                          When SPI controller is disabled all output enables are inactive and all pins are set to input mode.
+                          Writing '0' disables the SPI controller once current transfer of the data word (FF_W) is complete
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIDELAY</name>
+                <description>Delay Register</description>
+                <addressOffset>0x018</addressOffset>
+                <fields>
+                    <field>          <name>D_NSS</name>
+                        <description>Delay NSS</description>
+                        <bitRange>[31:24]</bitRange>
+                    </field>
+                    <field>          <name>D_BTWN</name>
+                        <description>Delay Between</description>
+                        <bitRange>[23:16]</bitRange>
+                    </field>
+                    <field>          <name>D_AFTER</name>
+                        <description>Delay After</description>
+                        <bitRange>[15:8]</bitRange>
+                    </field>
+                    <field>          <name>D_INIT</name>
+                        <description>Delay Init</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPITDR</name>
+                <description>Transmit Data Register</description>
+                <addressOffset>0x01C</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>TDATA</name>
+                        <description>
+                          Transmit Data: Writes to the TX FIFO location indicated by its internal write address
+                          and increments the write address by pushing it
+                        </description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIRDR</name>
+                <description>Receive Data Register</description>
+                <addressOffset>0x020</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>RDATA</name>
+                        <description>
+                          Receive Data: Reads the RX FIFO location indicated by the current read address
+                          and then increments the read address
+                        </description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPISIC</name>
+                <description>Slave Idle Count Register</description>
+                <addressOffset>0x024</addressOffset>
+                <fields>
+                    <field>          <name>SICNT</name>
+                        <description>
+                          Slave Idle Count: SPI in slave mode detects a start only when the external SPI master serial clock (sclk_in)
+                          is stable (quiescent state) for SPI REFERENCE CLOCK cycles specified by slave idle count register or when the SPI is deselected.
+                        </description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPITTH</name>
+                <description>TX FIFO Threshold Register</description>
+                <addressOffset>0x028</addressOffset>
+                <fields>
+                    <field>          <name>TTRSH</name>
+                        <description>
+                           TX Threshold: Defines the level at which the TX FIFO not full interrupt is generated.
+                        </description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SPIRTH</name>
+                <description>RX FIFO Threshold Register</description>
+                <addressOffset>0x02C</addressOffset>
+                <fields>
+                    <field>          <name>RTRSH</name>
+                        <description>
+                           RX Threshold: Defines the level at which the RX FIFO not empty interrupt is generated.
+                        </description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- SPI 0 (Secure) -->
+    <peripheral derivedFrom="SPI0">      <name>SPI0_Secure</name>
+        <description>SPI 0 (Secure)</description>
+        <baseAddress>0x50103000</baseAddress>
+        <groupName>SPI (Secure)</groupName>
+    </peripheral>
+
+    <!-- I2C 0 -->
+    <peripheral>                         <name>I2C0</name>
+        <version>1.0</version>
+        <description>I2C 0</description>
+        <groupName>I2C</groupName>
+        <baseAddress>0x40104000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0xFC</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>I2C_0</name>
+            <description>I2C0 Interrupt</description>
+            <value>34</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>CR</name>
+                <description>Control Register</description>
+                <addressOffset>0x000</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>RW</name>
+                        <description>
+                          Read/Write: Direction of transfer
+                          0 - master transmitter, 1 - master receiver
+                          This bit is used in master mode only.
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>MS</name>
+                        <description>
+                          Master/Slave: Overall interface mode
+                          0 - slave, 1 - master
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>NEA</name>
+                        <description>
+                          Normal/Extended Address: 
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>ACKEN</name>
+                        <description>
+                          Acknowledge Enable: Enable transmission of ACK when master-receiver
+                          0 – acknowledge disabled, NACK transmitted, 1 – acknowledge enabled, ACK transmitted
+                          This bit must always be set if FIFO is implemented.
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>HOLD</name>
+                        <description>
+                          Hold mode: Hold I2C sclk low until host services the data resources or clears this bit
+                          1 - when no more data is available for transmit or no more data can be received, hold the sclk line low until serviced by the host.
+                          0 - allow the transfer to terminate as soon as all the data has been transmitted or received.
+                          This bit has the same meaning in both master and slave modes.
+                        </description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>SLVMON</name>
+                        <description>
+                          Slave Monitor mode: Slave monitor mode.
+                          0 - normal operation, 1 - monitor mode
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>CLRFIFO</name>
+                        <description>
+                          Clear FIFO: initializes the FIFO to all zeros and clears the transfer size register
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>DIV_A</name>
+                        <description>
+                          Divisor A: Divisor for stage A clock divider. Divides the input pclk frequency by divisor_a + 1
+                        </description>
+                        <bitRange>[13:8]</bitRange>
+                    </field>
+                    <field>          <name>DIV_B</name>
+                        <description>
+                           Divisor B: Divisor for stage B clock divider. Divides the output frequency from divisor_a by divisor_b + 1
+                        </description>
+                        <bitRange>[15:14]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SR</name>
+                <description>Status Register</description>
+                <addressOffset>0x004</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <access>read-only</access>
+                  <fields>
+                    <field>          <name>RXRW</name>
+                        <description>
+                           RX read/write flag: Indicates the mode of the transmission received from a master.
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>RXDV</name>
+                        <description>
+                           Receiver Data Valid: Indicates that there is valid, new data to be read from the interface.
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TXDV</name>
+                        <description>
+                           Transmitter Data Valid: Indicates that there is still a byte of data to be transmitted by the interface.
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>RXOVF</name>
+                        <description>
+                           Receiver Overflow: This flag is set when the receiver receives a byte of data before the previous byte has been read by the host.
+                        </description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>BA</name>
+                        <description>
+                           Bus Active: Indicates there is an ongoing transfer on the I2C bus. The I2C controller is not necessarily involved in it
+                        </description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>AR</name>
+                <description>Address Register</description>
+                <addressOffset>0x008</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>ADD</name>
+                        <description>
+                           I2C Address
+                        </description>
+                        <bitRange>[9:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>DR</name>
+                <description>Data Register</description>
+                <addressOffset>0x00C</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>DAT</name>
+                        <description>
+                           I2C Data
+                        </description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>ISR</name>
+                <description>Interrupt Status Register</description>
+                <addressOffset>0x010</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>COMP</name>
+                        <description>
+                           Transfer Complete
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>DATA</name>
+                        <description>
+                          More Data
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>NACK</name>
+                        <description>
+                          Transfer Not Acknowledged
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TO</name>
+                        <description>
+                          Transfer Time Out
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>SLV_RDY</name>
+                        <description>
+                         Monitored Slave Ready
+                        </description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RX_OVF</name>
+                        <description>
+                          Receive Overflow
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TX_OVF</name>
+                        <description>
+                           FIFO Transmit Overflow 
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>RX_UNF</name>
+                        <description>
+                          FIFO Receive Underflow
+                        </description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>ARB_LOST</name>
+                        <description>
+                          Arbitration Lost
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>TSR</name>
+                <description>Transfer Size Register</description>
+                <addressOffset>0x014</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>TS</name>
+                        <description>
+                           Transfer Size
+                        </description>
+                        <bitRange>[3:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SMPR</name>
+                <description>Slave Monitor Pause Register</description>
+                <addressOffset>0x018</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>PI</name>
+                        <description>
+                           Pause Interval
+                        </description>
+                        <bitRange>[3:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>TOR</name>
+                <description>Time Out Register</description>
+                <addressOffset>0x01C</addressOffset>
+                <resetValue>0x0000001F</resetValue>
+                <fields>
+                    <field>          <name>TO</name>
+                        <description>
+                           Time Out
+                        </description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>IMR</name>
+                <description>Interrupt Mask Register</description>
+                <addressOffset>0x020</addressOffset>
+                <resetValue>0x000002FF</resetValue>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>COMP</name>
+                        <description>
+                           Transfer Complete
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>DATA</name>
+                        <description>
+                          More Data
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>NACK</name>
+                        <description>
+                          Transfer Not Acknowledged
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TO</name>
+                        <description>
+                          Transfer Time Out
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>SLV_RDY</name>
+                        <description>
+                         Monitored Slave Ready
+                        </description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RX_OVF</name>
+                        <description>
+                          Receive Overflow
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TX_OVF</name>
+                        <description>
+                           FIFO Transmit Overflow 
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>RX_UNF</name>
+                        <description>
+                          FIFO Receive Underflow
+                        </description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>ARB_LOST</name>
+                        <description>
+                          Arbitration Lost
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>IER</name>
+                <description>Interrupt Enable Register</description>
+                <addressOffset>0x024</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>COMP</name>
+                        <description>
+                           Transfer Complete
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>DATA</name>
+                        <description>
+                          More Data
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>NACK</name>
+                        <description>
+                          Transfer Not Acknowledged
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TO</name>
+                        <description>
+                          Transfer Time Out
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>SLV_RDY</name>
+                        <description>
+                         Monitored Slave Ready
+                        </description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RX_OVF</name>
+                        <description>
+                          Receive Overflow
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TX_OVF</name>
+                        <description>
+                           FIFO Transmit Overflow 
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>RX_UNF</name>
+                        <description>
+                          FIFO Receive Underflow
+                        </description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>ARB_LOST</name>
+                        <description>
+                          Arbitration Lost
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>IDR</name>
+                <description>Interrupt Disable Register</description>
+                <addressOffset>0x028</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>COMP</name>
+                        <description>
+                           Transfer Complete
+                        </description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>DATA</name>
+                        <description>
+                          More Data
+                        </description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>NACK</name>
+                        <description>
+                          Transfer Not Acknowledged
+                        </description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>TO</name>
+                        <description>
+                          Transfer Time Out
+                        </description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>SLV_RDY</name>
+                        <description>
+                         Monitored Slave Ready
+                        </description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RX_OVF</name>
+                        <description>
+                          Receive Overflow
+                        </description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>TX_OVF</name>
+                        <description>
+                           FIFO Transmit Overflow 
+                        </description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>RX_UNF</name>
+                        <description>
+                          FIFO Receive Underflow
+                        </description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>ARB_LOST</name>
+                        <description>
+                          Arbitration Lost
+                        </description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>GFCR</name>
+                <description>Glitch Filter Control Register</description>
+                <addressOffset>0x02C</addressOffset>
+                <resetValue>0x00000000</resetValue>
+                <fields>
+                    <field>          <name>GF</name>
+                        <description>
+                           Glitch Filter depth
+                        </description>
+                        <bitRange>[3:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- I2C 1 -->
+    <peripheral derivedFrom="I2C0">      <name>I2C1</name>
+        <version>1.0</version>
+        <description>I2C 1</description>
+        <groupName>I2C</groupName>
+        <baseAddress>0x40105000</baseAddress>
+
+        <interrupt>
+            <name>I2C_1</name>
+            <description>I2C1 Interrupt</description>
+            <value>35</value>
+        </interrupt>
+    </peripheral>
+
+    <!-- I2C 0 (Secure) -->
+    <peripheral derivedFrom="I2C0">      <name>I2C0_Secure</name>
+        <version>1.0</version>
+        <description>I2C 0 (Secure)</description>
+        <groupName>I2C (Secure)</groupName>
+        <baseAddress>0x50104000</baseAddress>
+    </peripheral>
+
+    <!-- I2C 1 (Secure) -->
+    <peripheral derivedFrom="I2C0">      <name>I2C1_Secure</name>
+        <version>1.0</version>
+        <description>I2C 1 (Secure)</description>
+        <groupName>I2C (Secure)</groupName>
+        <baseAddress>0x50105000</baseAddress>
+    </peripheral>
+
+    <!-- I2S 0 -->
+    <peripheral>                         <name>I2S0</name>
+        <version>1.0</version>
+        <description>I2S 0</description>
+        <groupName>I2S</groupName>
+        <baseAddress>0x40106000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0xFC</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>I2S_0</name>
+            <description>I2S0 Interrupt</description>
+            <value>36</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>CTRL</name>
+                <description>Transceiver Control Register</description>
+                <addressOffset>0x000</addressOffset>
+                <resetValue>0x01900000</resetValue>
+            </register>
+            <register>          <name>INTR_STAT</name>
+                <description>Interrupt Status Register</description>
+                <addressOffset>0x004</addressOffset>
+                <resetValue>0x00003300</resetValue>
+            </register>
+            <register>          <name>SRR</name>
+                <description>Sample Rate and Resolution Control Register</description>
+                <addressOffset>0x008</addressOffset>
+                <resetValue>0x00000000</resetValue>
+            </register>
+            <register>          <name>CID_CTRL</name>
+                <description>Clock Strobes and Interrupt Masks Control Register</description>
+                <addressOffset>0x00C</addressOffset>
+                <resetValue>0x00000000</resetValue>
+            </register>
+            <register>          <name>TFIFO_STAT</name>
+                <description>Transmit FIFO Level Status Register</description>
+                <addressOffset>0x010</addressOffset>
+                <resetValue>0x00000000</resetValue>
+            </register>
+            <register>          <name>RFIFO_STAT</name>
+                <description>Receive FIFO Level Status Register</description>
+                <addressOffset>0x014</addressOffset>
+                <resetValue>0x00000000</resetValue>
+            </register>
+            <register>          <name>TFIFO_CTRL</name>
+                <description>Transmit FIFO Thresholds Control Register</description>
+                <addressOffset>0x018</addressOffset>
+                <resetValue>0x000F0000</resetValue>
+            </register>
+            <register>          <name>RFIFO_CTRL</name>
+                <description>Receive FIFO Rhresholds Control Register</description>
+                <addressOffset>0x01C</addressOffset>
+                <resetValue>0x000F0000</resetValue>
+            </register>
+            <register>          <name>DEV_CONF</name>
+                <description>Device Configuration Register</description>
+                <addressOffset>0x020</addressOffset>
+                <resetValue>0x00000208</resetValue>
+            </register>
+            <register>          <name>POLL_STAT</name>
+                <description>Polling Status Register</description>
+                <addressOffset>0x024</addressOffset>
+                <resetValue>0x00000003</resetValue>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- I2S 0 (Secure) -->
+    <peripheral derivedFrom="I2S0">      <name>I2S0_Secure</name>
+        <description>I2S 0 (Secure)</description>
+        <baseAddress>0x50106000</baseAddress>
+        <groupName>I2S (Secure)</groupName>
+    </peripheral>
+
+
+    <!-- S32K Watchdog -->
+    <peripheral derivedFrom="WATCHDOG">  <name>S32KWATCHDOG</name>
+        <description>S32K Watchdog</description>
+        <groupName>Watchdog</groupName>
+        <baseAddress>0x4002E000</baseAddress>
+    </peripheral>
+
+    <!-- Watchdog (Secure) -->
+    <peripheral derivedFrom="WATCHDOG">  <name>WATCHDOG_Secure</name>
+        <description>Watchdog (Secure)</description>
+        <groupName>Watchdog (Secure)</groupName>
+        <baseAddress>0x50081000</baseAddress>
+    </peripheral>
+
+    <!-- S32K Watchdog (Secure) -->
+    <peripheral derivedFrom="WATCHDOG">  <name>S32KWATCHDOG_Secure</name>
+        <description>S32K Watchdog (Secure)</description>
+        <groupName>Watchdog (Secure)</groupName>
+        <baseAddress>0x5002E000</baseAddress>
+    </peripheral>
+
+    <!-- System Control (SYSCTRL) (Secure) -->
+    <peripheral>                         <name>SYSCTRL</name>
+        <baseAddress>0x50021000</baseAddress>
+        <description>System Control (Secure)</description>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <registers>
+            <register>          <name>SECDBGSTAT</name>
+                <description>Secure Debug Configuration Status Register</description>
+                <addressOffset>0x000</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>SECDBGSET</name>
+                <description>Secure Debug Configuration Set Register</description>
+                <addressOffset>0x004</addressOffset>
+                <access>write-only</access>
+            </register>
+            <register>          <name>SECDBGCLR</name>
+                <description>Secure Debug Configuration Clear Register</description>
+                <addressOffset>0x008</addressOffset>
+                <access>write-only</access>
+            </register>
+            <register>          <name>SCSECCTRL</name>
+                <description>System Control Security Control Register</description>
+                <addressOffset>0x00C</addressOffset>
+            </register>
+            <register>          <name>FCLK_DIV</name>
+                <description>Fast Clock Divider Configuration Register</description>
+                <addressOffset>0x010</addressOffset>
+            </register>
+            <register>          <name>SYSCLK_DIV</name>
+                <description>System Clock Divider Configuration Register</description>
+                <addressOffset>0x014</addressOffset>
+            </register>
+            <register>          <name>CLOCK_FORCE</name>
+                <description>Clock Forces</description>
+                <addressOffset>0x018</addressOffset>
+            </register>
+            <register>          <name>RESET_SYNDROME</name>
+                <description>Reset syndrome</description>
+                <addressOffset>0x100 </addressOffset>
+                <resetValue>0x00000001</resetValue>
+            </register>
+            <register>          <name>RESET_MASK</name>
+                <description>Reset MASK</description>
+                <addressOffset>0x104</addressOffset>
+                <resetValue>0x00000030</resetValue>
+            </register>
+            <register>          <name>SWRESET</name>
+                <description>Software Reset</description>
+                <addressOffset>0x108</addressOffset>
+                <access>write-only</access>
+            </register>
+            <register>          <name>GRETREG</name>
+                <description>General Purpose Retention Register</description>
+                <addressOffset>0x10C</addressOffset>
+            </register>
+            <register>          <name>INITSVTOR0</name>
+                <description>Initial Secure Reset Vector Register For CPU 0</description>
+                <addressOffset>0x110</addressOffset>
+            </register>
+            <register>          <name>INITSVTOR1</name>
+                <description>Initial Secure Reset Vector Register For CPU 1</description>
+                <addressOffset>0x114</addressOffset>
+            </register>
+            <register>          <name>CPUWAIT</name>
+                <description>CPU Boot wait control after reset</description>
+                <addressOffset>0x118</addressOffset>
+            </register>
+            <register>          <name>NMI_ENABLE</name>
+                <description>NMI Enable Register</description>
+                <addressOffset>0x11C</addressOffset>
+                <resetValue>0x00000001</resetValue>
+            </register>
+            <register>          <name>WICCTRL</name>
+                <description>CPU WIC Request and Acknowledgement</description>
+                <addressOffset>0x120</addressOffset>
+            </register>
+            <register>          <name>EWCTRL</name>
+                <description>External Wakeup Control</description>
+                <addressOffset>0x124</addressOffset>
+            </register>
+            <register>          <name>PDCM_PD_SYS_SENSE</name>
+                <description>Power Control Dependency Matrix PD_SYS Power Domain Sensitivity</description>
+                <addressOffset>0x200</addressOffset>
+                <resetValue>0x0000007F</resetValue>
+            </register>
+            <register>          <name>PDCM_PD_SRAM0_SENSE</name>
+                <description>Power Control Dependency Matrix PD_SRAM0 Power Domain Sensitivity</description>
+                <addressOffset>0x20C</addressOffset>
+            </register>
+            <register>          <name>PDCM_PD_SRAM1_SENSE</name>
+                <description>Power Control Dependency Matrix PD_SRAM1 Power Domain Sensitivity</description>
+                <addressOffset>0x210</addressOffset>
+            </register>
+            <register>          <name>PDCM_PD_SRAM2_SENSE</name>
+                <description>Power Control Dependency Matrix PD_SRAM2 Power Domain Sensitivity</description>
+                <addressOffset>0x214</addressOffset>
+            </register>
+            <register>          <name>PDCM_PD_SRAM3_SENSE</name>
+                <description>Power Control Dependency Matrix PD_SRAM3 Power Domain Sensitivity</description>
+                <addressOffset>0x218</addressOffset>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- Serial Communication Controller (SCC) -->
+    <peripheral>                         <name>SCC</name>
+        <description>Serial Communication Controller</description>
+        <baseAddress>0x4010C800</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <registers>
+            <register>          <name>CLK_CTRL_SEL</name>
+                <description>Clock Control Select Register</description>
+                <addressOffset>0x000</addressOffset>
+                <resetValue>0x00000062</resetValue>
+                <fields>
+                    <field>          <name>SEL_PREMUX_CLK</name>
+                        <description>Select PREMUX input: 0: 32K, 1: FASTCLK</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>SEL_DAPSWMUX_CLK</name>
+                        <description>Select DAPSWMUX input: 0: PRE_MUX_CLK, 1: JTAG TCK</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>SEL_MAINMUX_CLK</name>
+                        <description>Select MAINMUX input: 0: PLL0_CLK, 1: PRE_MUX_CLK</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>SEL_REFMUX_CLK</name>
+                        <description>Select REFMUX input: 0: PRE_MUX_CLK, 1: PRE_PLL_CLK</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>SEL_RM38KMUX_CLK</name>
+                        <description>Select RM38KMUX input: 0: REF_MUX_CLK, 1: RM38K (not used)</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>SEL_SCCMUX_CLK</name>
+                        <description>Select SCCMUX input: 0: SCCCLK, 1: PRE_MUX_CLK</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>SEL_RM38P4_PREMUX_CLK</name>
+                        <description>Select RM38KPREMUX input: 0: SYSSYSSUGCLK, 1: NRM138P4 (not used)</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>CTRL_SEL_TEST_MUX_CLK</name>
+                        <description>Select TESTMUX input</description>
+                        <bitRange>[11:7]</bitRange>
+                    </field>
+                    <field>          <name>CTRL_PLL_MUX_CLK_SEL</name>
+                        <description>PLL MUX select: 0: PLL0, 1: Not used</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_PLL_PREDIV_CTRL</name>
+                <description>PLL Predivider Control Register</description>
+                <addressOffset>0x004</addressOffset>
+                <fields>
+                    <field>          <name>PREDIV_CTRL</name>
+                        <description>PLL0 pre-divider value: Divison value = PREDIV_CTRL+1</description>
+                        <bitRange>[9:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_BBGEN_DIV_CLK</name>
+                <description>BBGEN Divider Clock</description>
+                <addressOffset>0x008</addressOffset>
+                <resetValue>0x00000028</resetValue>
+                <fields>
+                    <field>          <name>BBGEN_DIV</name>
+                        <description>Bbgen divider value</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_POSTDIV_QSPI</name>
+                <description>QSPI Divider</description>
+                <addressOffset>0x010</addressOffset>
+                <fields>
+                    <field>          <name>postdiv_ctrl_qspi_div_clk</name>
+                        <description>qspi_div_clk value</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_POSTDIV_RTC</name>
+                <description>RTC Divider</description>
+                <addressOffset>0x014</addressOffset>
+                <resetValue>0x00007FFF</resetValue>
+                <fields>
+                    <field>          <name>postdiv_ctrl_rtc_div_clk</name>
+                        <description>rtc_div_clk value</description>
+                        <bitRange>[31:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_POSTDIV_TEST</name>
+                <description>Test Divider</description>
+                <addressOffset>0x01C</addressOffset>
+                <resetValue>0x0000000A</resetValue>
+                <fields>
+                    <field>          <name>postdiv_ctrl_test_div_clk</name>
+                        <description>test_div_clk value</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CTRL_BYPASS_DIV</name>
+                <description>Bypass Divider Control Register</description>
+                <addressOffset>0x020</addressOffset>
+                <resetValue>0x00000001</resetValue>
+                <fields>
+                    <field>          <name>ctrl_bypass_div_pll_prediv_clk</name>
+                        <description>pll_prediv_clk bypass value</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_bypass_div_qspi_div_clk</name>
+                        <description>qspi_div_clk bypass value</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_bypass_div_rtc_div_clk</name>
+                        <description>rtc_div_clk bypass value</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_bypass_div_test_div_clk</name>
+                        <description>test_div_clk bypass value</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>PLL_CTRL_PLL0_CLK</name>
+                <description>PLL0 Control Register</description>
+                <addressOffset>0x024</addressOffset>
+                <resetValue>0x001005F4</resetValue>
+                <fields>
+                    <field>          <name>Pll0_M</name>
+                        <description>Control pins to change the target frequency of internal oscillator</description>
+                        <bitRange>[11:0]</bitRange>
+                    </field>
+                    <field>          <name>Pll0_S</name>
+                        <description>Division value of the 3-bit programmable scaler</description>
+                        <bitRange>[14:12]</bitRange>
+                    </field>
+                    <field>          <name>Pll0_EXTAFC</name>
+                        <description>Monitoring pin</description>
+                        <bitRange>[20:16]</bitRange>
+                    </field>
+                    <field>          <name>Pll0_AFC_ENB</name>
+                        <description>Monitoring pin</description>
+                        <bitRange>[28:28]</bitRange>
+                    </field>
+                    <field>          <name>Pll0_BYPASS</name>
+                        <description>bypass mode</description>
+                        <bitRange>[29:29]</bitRange>
+                    </field>
+                    <field>          <name>Pll1_RESETB</name>
+                        <description>Power down</description>
+                        <bitRange>[30:30]</bitRange>
+                    </field>
+                    <field>          <name>Pll0_RESETB</name>
+                        <description>Power down</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_CTRL_ENABLE</name>
+                <description>Clock Control Enable Register</description>
+                <addressOffset>0x030</addressOffset>
+                <resetValue>0x0000FFFF</resetValue>
+                <fields>
+                    <field>          <name>ctrl_enable_clk1hz</name>
+                        <description>rtc_div_clk enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_dapswclk</name>
+                        <description>dapsw_mux_clk enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_gpiohclk</name>
+                        <description>I_SYSSYSUGCLK enable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_i2sclk0</name>
+                        <description>I_SYSSYSUGCLK enable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_i2sclk1</name>
+                        <description>I_SYSSYSUGCLK enable</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_i2sclk2</name>
+                        <description>I_SYSSYSUGCLK enable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_mainclk</name>
+                        <description>main_mux_clk enable</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_qspiphyclk</name>
+                        <description>qspi_div_clk enable</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_refclk</name>
+                        <description>ref_mux_clk enable</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_rm38kclk</name>
+                        <description>rm38k_mux_clk enable</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_sccclk</name>
+                        <description>scc_mux_clk enable</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_taptck</name>
+                        <description>tck_mux_clk enable</description>
+                        <bitRange>[14:14]</bitRange>
+                    </field>
+                    <field>          <name>ctrl_enable_testclk</name>
+                        <description>test_div_clk enable</description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CLK_STATUS</name>
+                <description>Clock Status Register</description>
+                <addressOffset>0x034</addressOffset>
+                <access>read-only</access>
+                <resetValue>0x00000001</resetValue>
+                <fields>
+                    <field>          <name>status_out_clk_mainclk_ready</name>
+                        <description>Clock ready (active)</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>status_lock_signal_pll0_clk</name>
+                        <description>PLL Lock Status</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>RESET_CTRL</name>
+                <description>Reset Control Register</description>
+                <addressOffset>0x040</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+                <fields>
+                    <field>          <name>GPTIMER_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>I2C0_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>I2C1_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>I2S_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>SPI_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>QSPI_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>UART0_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>UART1_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>GPIO_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>PVT_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>PWM0_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>PWM1_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>          <name>PWM2_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[13:13]</bitRange>
+                    </field>
+                    <field>          <name>RTC_RESET</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[14:14]</bitRange>
+                    </field>
+                    <field>          <name>CASTOR_NSRST_PSI_Sel</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                    <field>          <name>CASTOR_NSRST_Sel</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>CASTOR_NSRST</name>
+                        <description>Reset Active low</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>DBG_CTRL</name>
+                <description>Debug Control Register</description>
+                <addressOffset>0x048</addressOffset>
+                <resetValue>0x0000001F</resetValue>
+                <fields>
+                    <field>          <name>DBGENIN</name>
+                        <description>Castor DBGENIN</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>NIDENIN</name>
+                        <description>Castor NIDENIN</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>SPIDENIN</name>
+                        <description>Castor SPIDENIN</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>SPNIDENIN</name>
+                        <description>Castor SPNIDENIN</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>TODBGENSEL</name>
+                        <description>Debug expansion TODBGENSEL</description>
+                        <bitRange>[7:8]</bitRange>
+                    </field>
+                    <field>          <name>dbg_dcu_force</name>
+                        <description>Castor DBG ports control 0: use Crypto DCU 1: Use SCC signals (force)</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SRAM_CTRL</name>
+                <description>SRAM Control Register</description>
+               <addressOffset>0x04C</addressOffset>
+                <fields>
+                    <field>          <name>code_sram0_pgen</name>
+                        <description>1st 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>code_sram1_pgen</name>
+                        <description>2nd 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>code_sram2_pgen</name>
+                        <description>3rd 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>code_sram3_pgen</name>
+                        <description>4th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>code_sram4_pgen</name>
+                        <description>5th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>code_sram5_pgen</name>
+                        <description>6th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>code_sram6_pgen</name>
+                        <description>7th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>code_sram7_pgen</name>
+                        <description>8th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>code_sram8_pgen</name>
+                        <description>9th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>code_sram9_pgen</name>
+                        <description>10th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>code_sram10_pgen</name>
+                        <description>11st 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>code_sram11_pgen</name>
+                        <description>12th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>code_sram12_pgen</name>
+                        <description>13th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>          <name>code_sram13_pgen</name>
+                        <description>14th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[13:13]</bitRange>
+                    </field>
+                    <field>          <name>code_sram14_pgen</name>
+                        <description>15th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[14:14]</bitRange>
+                    </field>
+                    <field>          <name>code_sram15_pgen</name>
+                        <description>16th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                    <field>          <name>code_sram16_pgen</name>
+                        <description>17th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>code_sram17_pgen</name>
+                        <description>18th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>          <name>code_sram18_pgen</name>
+                        <description>19th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>          <name>code_sram19_pgen</name>
+                        <description>20th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[19:19]</bitRange>
+                    </field>
+                    <field>          <name>code_sram20_pgen</name>
+                        <description>21st 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[20:20]</bitRange>
+                    </field>
+                    <field>          <name>code_sram21_pgen</name>
+                        <description>22th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[21:21]</bitRange>
+                    </field>
+                    <field>          <name>code_sram22_pgen</name>
+                        <description>23th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[22:22]</bitRange>
+                    </field>
+                    <field>          <name>code_sram23_pgen</name>
+                        <description>24th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[23:23]</bitRange>
+                    </field>
+                    <field>          <name>code_sram24_pgen</name>
+                        <description>25th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[24:24]</bitRange>
+                    </field>
+                    <field>          <name>code_sram25_pgen</name>
+                        <description>26th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[25:25]</bitRange>
+                    </field>
+                    <field>          <name>code_sram26_pgen</name>
+                        <description>27th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[26:26]</bitRange>
+                    </field>
+                    <field>          <name>code_sram27_pgen</name>
+                        <description>28th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[27:27]</bitRange>
+                    </field>
+                    <field>          <name>code_sram28_pgen</name>
+                        <description>29th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[28:28]</bitRange>
+                    </field>
+                    <field>          <name>code_sram29_pgen</name>
+                        <description>30th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[29:29]</bitRange>
+                    </field>
+                    <field>          <name>code_sram30_pgen</name>
+                        <description>31st 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[30:30]</bitRange>
+                    </field>
+                    <field>          <name>code_sram31_pgen</name>
+                        <description>32th 64KB Code SRAM cell power gate enable</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>INTR_CTRL</name>
+                <description>MPC Interrupt Control Register</description>
+                <addressOffset>0x050</addressOffset>
+                <fields>
+                    <field>          <name>sram_mpc_cfg_init_value</name>
+                        <description>sram mpc cfg init value</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>qspi_mpc_cfg_init_value</name>
+                        <description>qspi mpc cfg init value</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>mram_mpc_cfg_init_value</name>
+                        <description>mram mpc cfg init value</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CPU0_VTOR</name>
+                <description>CPU 0 VTOR Register</description>
+                <addressOffset>0x058</addressOffset>
+                <resetValue>0x10000000</resetValue>
+            </register>
+            <register>          <name>CPU0_VTOR_1</name>
+                <description>CPU 0 VTOR 1 Register</description>
+                <addressOffset>0x05C</addressOffset>
+                <resetValue>0x1A000000</resetValue>
+            </register>
+            <register>          <name>CPU1_VTOR</name>
+                <description>CPU 1 VTROR Register</description>
+                <addressOffset>0x060</addressOffset>
+                <resetValue>0x10000000</resetValue>
+            </register>
+            <register>          <name>CPU1_VTOR_1</name>
+                <description>CPU 1 VTOR 1 Register</description>
+                <addressOffset>0x064</addressOffset>
+                <resetValue>0x1A000000</resetValue>
+            </register>
+            <register>          <name>IOMUX_MAIN_INSEL</name>
+                <description>IOMux Main Function Input Data Select Register</description>
+                <addressOffset>0x068</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_MAIN_OUTSEL</name>
+                <description>IOMux Main Function Output Data Select Register</description>
+                <addressOffset>0x070</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_MAIN_OENSEL</name>
+                <description>IOMux Main Function Output Enable Select Register</description>
+                <addressOffset>0x078</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_MAIN_DEFAULT_IN</name>
+                <description>IOMux Main Function Input Default Data Register</description>
+                <addressOffset>0x080</addressOffset>
+            </register>
+            <register>          <name>IOMUX_ALTF1_INSEL</name>
+                <description>IOMux Alternate Function 1 Input Data Select Register</description>
+                <addressOffset>0x088</addressOffset>
+            </register>
+            <register>          <name>IOMUX_ALTF1_OUTSEL</name>
+                <description>IOMux Alternate Function 1 Output Data Select Register</description>
+                <addressOffset>0x090</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF1_OENSEL</name>
+                <description>IOMux Alternate Function 1 Output Enable Select Register</description>
+                <addressOffset>0x098</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF1_DEFAULT_IN</name>
+                <description>IOMux Alternate Function 1 Input Default Data Register</description>
+                <addressOffset>0x0A0</addressOffset>
+
+            </register>
+            <register>          <name>IOMUX_ALTF2_INSEL</name>
+                <description>IOMux Alternate Function 2 Input Data Select Register</description>
+                <addressOffset>0x0A8</addressOffset>
+            </register>
+            <register>          <name>IOMUX_ALTF2_OUTSEL</name>
+                <description>IOMux Alternate Function 2 Output Data Select Register</description>
+                <addressOffset>0x0B0</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF2_OENSEL</name>
+                <description>IOMux Alternate Function 2 Output Enable Select Register</description>
+                <addressOffset>0x0B8</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF2_DEFAULT_IN</name>
+                <description>IOMux Alternate Function 1 Input Default Data Register</description>
+                <addressOffset>0x0C0</addressOffset>
+            </register>
+            <register>          <name>IOMUX_ALTF3_INSEL</name>
+                <description>IOMux Alternate Function 3 Input Data Select Register</description>
+                <addressOffset>0x0C8</addressOffset>
+            </register>
+            <register>          <name>IOMUX_ALTF3_OUTSEL</name>
+                <description>IOMux Alternate Function 3 Output Data Select Register</description>
+                <addressOffset>0x0D0</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF3_OENSEL</name>
+                <description>IOMux Alternate Function 3 Output Enable Select Register</description>
+                <addressOffset>0x0D8</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOMUX_ALTF3_DEFAULT_IN</name>
+                <description>IOMux Alternate Function 1 Input Default Data Register</description>
+                <addressOffset>0x0E0</addressOffset>
+            </register>
+            <register>          <name>IOPAD_DS0</name>
+                <description>IO Pad Drive Select 0 Register</description>
+                <addressOffset>0x0E8</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOPAD_DS1</name>
+                <description>IO Pad Drive Select 1 Register</description>
+                <addressOffset>0x0F0</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOPAD_PE</name>
+                <description>IO Pad Pull Enable Register</description>
+                <addressOffset>0x0F8</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>IOPAD_PS</name>
+                <description>IO Pad Pull Select Register</description>
+                <addressOffset>0x100</addressOffset>
+                <resetValue>0xFC1FFFFF</resetValue>
+            </register>
+            <register>          <name>IOPAD_SR</name>
+                <description>IO Pad Slew Rate Register</description>
+                <addressOffset>0x108</addressOffset>
+            </register>
+            <register>          <name>IOPAD_IS</name>
+                <description>IO Pad Input Mode Select Register</description>
+                <addressOffset>0x110</addressOffset>
+                <resetValue>0xFFFFFFFF</resetValue>
+            </register>
+            <register>          <name>PVT_CTRL</name>
+                <description>PVT Control Register</description>
+                <addressOffset>0x118</addressOffset>
+                <fields>
+                    <field>          <name>TSTSENNUM</name>
+                        <description>Test SEN number</description>
+                        <bitRange>[4:0]</bitRange>
+                    </field>
+                    <field>          <name>TSTGRPSEL</name>
+                        <description>Test group select</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SRAM_RW_MARGINE</name>
+                <description>SRAM Read/Write Margin Control Register</description>
+                <addressOffset>0x134</addressOffset>
+                <fields>
+                    <field>          <name>RM0</name>
+                        <description>Read margin control for code srams: u_sram_64k_0 .. u_sram_64k_7</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WM0</name>
+                        <description>Write margin control for code srams: u_sram_64k_0 .. u_sram_64k_7</description>
+                        <bitRange>[5:4]</bitRange>
+                    </field>
+                    <field>          <name>RM1</name>
+                        <description>Read margin control for code srams: u_sram_64k_8 .. u_sram_64k_15</description>
+                        <bitRange>[10:8]</bitRange>
+                    </field>
+                    <field>          <name>WM1</name>
+                        <description>Write margin control for code srams: u_sram_64k_8 .. u_sram_64k_15</description>
+                        <bitRange>[13:12]</bitRange>
+                    </field>
+                    <field>          <name>RM2</name>
+                        <description>Read margin control for code srams: u_sram_64k_16 .. u_sram_64k_23</description>
+                        <bitRange>[18:16]</bitRange>
+                    </field>
+                    <field>          <name>WM2</name>
+                        <description>Write margin control for code srams: u_sram_64k_16 .. u_sram_64k_23</description>
+                        <bitRange>[21:20]</bitRange>
+                    </field>
+                    <field>          <name>RM3</name>
+                        <description>Read margin control for code srams: u_sram_64k_24 .. u_sram_64k_31</description>
+                        <bitRange>[26:24]</bitRange>
+                    </field>
+                    <field>          <name>WM3</name>
+                        <description>Write margin control for code srams: u_sram_64k_24 .. u_sram_64k_31</description>
+                        <bitRange>[29:28]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>STATIC_CONF_SIG0</name>
+                <addressOffset>0x138</addressOffset>
+                <resetValue>0x000001E0</resetValue>
+                <fields>
+                    <field>          <name>CTMCHCISBYPASS</name>
+                        <description>Cross Trigger Channel Interface Configuration</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>CTMCHCIHSBYPASS</name>
+                        <description>Cross Trigger Channel Interface Configuarion</description>
+                        <bitRange>[4:1]</bitRange>
+                    </field>
+                    <field>          <name>DBGENSELDIS</name>
+                        <description>DBGEN Selector Disable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>NIDENSELDIS</name>
+                        <description>NIDEN Selector Disable</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>SPIDENSELDIS</name>
+                        <description>SPIDEN Selector Disable</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>SPNIDENSELDIS</name>
+                        <description>SPNIDEN Selector Disable</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>STATIC_CONF_SIG1</name>
+                <addressOffset>0x13C</addressOffset>
+                <fields>
+                    <field>          <name>TISBYPASSIN</name>
+                        <description>Cross Trigger Interface synchronous bypass on CTITRIGIN</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                    <field>          <name>TISBYPASSACK</name>
+                        <description>Cross Trigger Interface synchronous bypass on CTITRIGOUTACK</description>
+                        <bitRange>[11:8]</bitRange>
+                    </field>
+                    <field>          <name>TIHSBYPASS</name>
+                        <description>Cross Trigger interface handshake bypass on CTITRIGOUT</description>
+                        <bitRange>[15:12]</bitRange>
+                    </field>
+                    <field>          <name>TINIDENSEL</name>
+                        <description>NIDEN mask on CTITRIGINT</description>
+                        <bitRange>[23:16]</bitRange>
+                    </field>
+                    <field>          <name>TODBGENSEL</name>
+                        <description>DBGEN mask on CTITRIGOUT</description>
+                        <bitRange>[27:24]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>REQ_SET</name>
+              <description>Clock and Power Request Set Register</description>
+                <addressOffset>0x140</addressOffset>
+                <resetValue>0x00000001</resetValue>
+                <fields>
+                    <field>          <name>clk_req_set</name>
+                        <description>Set SYSMAINCLKREQUEST</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>pwr_req_set</name>
+                        <description>Set SYSPOWERREQUEST</description>
+                        <bitRange>[4:1]</bitRange>
+                    </field>
+                    <field>          <name>pwr_req_set_en</name>
+                        <description>External event enable</description>
+                        <bitRange>[11:8]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>REQ_CLEAR</name>
+              <description>Clock and Power Request Clear Register</description>
+                <addressOffset>0x144</addressOffset>
+                <fields>
+                    <field>          <name>clk_req_clear</name>
+                        <description>Clock request clear</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>pwr_req_clear</name>
+                        <description>Power request clear</description>
+                        <bitRange>[4:1]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>PCSM_CTRL_OVEERIDE</name>
+              <description>PCSM Control Override Register</description>
+                <addressOffset>0x148</addressOffset>
+                <fields>
+                    <field>          <name>SYSSYSCLKQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>SYSFCLKQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>CRYPTOSYSCLKQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>BCRYPTOSPIKCLKQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>CRYPTOPWRQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>SYSPWRQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>DEBUGPIKCLKQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>DBGPWRQACTIVE</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>DEBUGPIKCLKQACTIVE_en</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>DBGPWRQACTIVE_en</name>
+                        <description>Q-Channels QACTIVE Override</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>PD_CPU0_ISO_OVEERIDE</name>
+                <addressOffset>0x14C</addressOffset>
+                <fields>
+                    <field>          <name>CHSEC_FREQ_SEL</name>
+                        <description>Secure Frame Frequency select</description>
+                        <bitRange>[1:0]</bitRange>
+                    </field>
+                    <field>          <name>CHSEC_BYPASS</name>
+                        <description>Secure Frame Bypass</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>CHSEC_DISCHARGE_CNTL</name>
+                        <description>Secure Frame discharge control</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>CHSEC_SE_CNTL</name>
+                        <description>Secure Frame Scan Enable control</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>CHSEC_ISO_ENB</name>
+                        <description>Secure Frame Isolation Enable</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>CHSEC_MISC</name>
+                        <description>Secure Frame Control</description>
+                        <bitRange>[15:8]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>PD_CPU1_ISO_OVEERIDE</name>
+                <description>CPU1 Isolation Override Register</description>
+                <addressOffset>0x150</addressOffset>
+            </register>
+            <register>          <name>SYS_SRAM_RW_ASSIST0</name>
+                <description>CPU0 SRAM Read/Write Margin Control Register</description>
+                <addressOffset>0x154</addressOffset>
+                <fields>
+                    <field>          <name>RM0</name>
+                        <description>Castor cpu0 tag_sram_0 read margin</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WM0</name>
+                        <description>Castor cpu0 tag_sram_0 write margin</description>
+                        <bitRange>[5:4]</bitRange>
+                    </field>
+                    <field>          <name>RM1</name>
+                        <description>Castor cpu0 tag_sram_1 read margin</description>
+                        <bitRange>[18:16]</bitRange>
+                    </field>
+                    <field>          <name>WM1</name>
+                        <description>Castor cpu0 tag_sram_1 write margin</description>
+                        <bitRange>[21:20]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SYS_SRAM_RW_ASSIST1</name>
+                <description>CPU1 SRAM Read/Write Margin Control Register</description>
+                <addressOffset>0x158</addressOffset>
+                <fields>
+                    <field>          <name>RM0</name>
+                        <description>Castor cpu1 tag_sram_0 read margin</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WM0</name>
+                        <description>Castor cpu1 tag_sram_0 write margin</description>
+                        <bitRange>[5:4]</bitRange>
+                    </field>
+                    <field>          <name>RM1</name>
+                        <description>Castor cpu1 tag_sram_1 read margin</description>
+                        <bitRange>[18:16]</bitRange>
+                    </field>
+                    <field>          <name>WM1</name>
+                        <description>Castor cpu1 tag_sram_1 write margin</description>
+                        <bitRange>[21:20]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SYS_SRAM_RW_ASSIST4</name>
+                <description>Core 0/1 SRAM Read/Write Margin Control Register</description>
+                <addressOffset>0x164</addressOffset>
+                <fields>
+                    <field>          <name>RM0</name>
+                        <description>Castor core_0 sram_0 read margin</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WM0</name>
+                        <description>Castor core_0 sram_0 write margin</description>
+                        <bitRange>[5:4]</bitRange>
+                    </field>
+                    <field>          <name>RM1</name>
+                        <description>Castor core_0 sram_1 read margin</description>
+                        <bitRange>[10:8]</bitRange>
+                    </field>
+                    <field>          <name>WM1</name>
+                        <description>Castor core_0 sram_1 write margin</description>
+                        <bitRange>[13:12]</bitRange>
+                    </field>
+                    <field>          <name>RM2</name>
+                        <description>Castor core_1 sram_0 read margin</description>
+                        <bitRange>[18:16]</bitRange>
+                    </field>
+                    <field>          <name>WM2</name>
+                        <description>Castor core_1 sram_0 write margin</description>
+                        <bitRange>[21:20]</bitRange>
+                    </field>
+                    <field>          <name>RM3</name>
+                        <description>Castor core_1 sram_1 read margin</description>
+                        <bitRange>[26:24]</bitRange>
+                    </field>
+                    <field>          <name>WM3</name>
+                        <description>Castor core_1 sram_1 write margin</description>
+                        <bitRange>[29:28]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SYS_SRAM_RW_ASSIST5</name>
+                <description>Core 2/3 SRAM Read/Write Margin Control Register</description>
+                <addressOffset>0x168</addressOffset>
+                <fields>
+                    <field>          <name>RM0</name>
+                        <description>Castor core_2 sram_0 read margin</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WM0</name>
+                        <description>Castor core_2 sram_0 write margin</description>
+                        <bitRange>[5:4]</bitRange>
+                    </field>
+                    <field>          <name>RM1</name>
+                        <description>Castor core_2 sram_1 read margin</description>
+                        <bitRange>[10:8]</bitRange>
+                    </field>
+                    <field>          <name>WM1</name>
+                        <description>Castor core_2 sram_1 write margin</description>
+                        <bitRange>[13:12]</bitRange>
+                    </field>
+                    <field>          <name>RM2</name>
+                        <description>Castor core_3 sram_0 read margin</description>
+                        <bitRange>[18:16]</bitRange>
+                    </field>
+                    <field>          <name>WM2</name>
+                        <description>Castor core_3 sram_0 write margin</description>
+                        <bitRange>[21:20]</bitRange>
+                    </field>
+                    <field>          <name>RM3</name>
+                        <description>Castor core_3 sram_1 read margin</description>
+                        <bitRange>[26:24]</bitRange>
+                    </field>
+                    <field>          <name>WM3</name>
+                        <description>Castor core_3 sram_1 write margin</description>
+                        <bitRange>[29:28]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>REQ_EDGE_SEL</name>
+              <description>Clock and Power Request Edge Select Register</description>
+                <addressOffset>0x184</addressOffset>
+            </register>
+            <register>          <name>REQ_ENABLE</name>
+              <description>Clock and Power Request Enable Register</description>
+                <addressOffset>0x188</addressOffset>
+            </register>
+            <register>          <name>MRAM_CTRL0</name>
+                <description>eMRAM Control 0 Register</description>
+                <addressOffset>0x198</addressOffset>
+                <resetValue>0x40144003</resetValue>
+                <fields>
+                    <field>          <name>mram_clk_en</name>
+                        <description>eMRAM clock enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>proc_spec_clk_en</name>
+                        <description>eMRAM controller clock enable</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>autostop_en</name>
+                        <description>Auto stop enable</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>mram_inv_clk_sel</name>
+                        <description>eMRAM clock invert select</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>fast_read_en</name>
+                        <description>Fast read enable</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>mram_dout_sel</name>
+                        <description>eMRAM data out select</description>
+                        <bitRange>[5:6]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD_0</name>
+                        <description>eMRAM0 PG VDD</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD18_0</name>
+                        <description>eMRAM0 PG VDD18</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD_1</name>
+                        <description>eMRAM1 PG VDD</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD18_1</name>
+                        <description>eMRAM1 PG VDD18</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>write_csn_clks</name>
+                        <description>Number of clock cycles for single write operation</description>
+                        <bitRange>[15:12]</bitRange>
+                    </field>
+                    <field>          <name>csn_high_clks</name>
+                        <description>Number of clock cycles to wait when CSN is high before going to new access</description>
+                        <bitRange>[19:16]</bitRange>
+                    </field>
+                    <field>          <name>read_csn_clks</name>
+                        <description>Number of clocks cycles for single read operation</description>
+                        <bitRange>[23:20]</bitRange>
+                    </field>
+                    <field>          <name>mram_otp_clk_en</name>
+                        <description>eMRAM OTP clock enable</description>
+                        <bitRange>[29:29]</bitRange>
+                    </field>
+                    <field>          <name>mram_clk_sync_bypass</name>
+                        <description>eMRAM clock sync bypass</description>
+                        <bitRange>[30:30]</bitRange>
+                    </field>
+                    <field>          <name>mram_da_en</name>
+                        <description>eMRAM direct access enable</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>MRAM_CTRL1</name>
+                <description>eMRAM Control 1 Register</description>
+                <addressOffset>0x19C</addressOffset>
+                <fields>
+                    <field>          <name>mram_da_addr</name>
+                        <description>eMRAM direct access address</description>
+                        <bitRange>[23:0]</bitRange>
+                    </field>
+                    <field>          <name>mram_da_ctrl</name>
+                        <description>eMRAM direct access controls</description>
+                        <bitRange>[31:24]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>MRAM_CTRL2</name>
+                <description>eMRAM Control 2 Register</description>
+                <addressOffset>0x1A0</addressOffset>
+                <resetValue>0xFFFF0119</resetValue>
+                <fields>
+                    <field>          <name>prescale</name>
+                        <description>eMRAM clock frequency value</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                    <field>          <name>mram_clk_div</name>
+                        <description>eMRAM clock divider</description>
+                        <bitRange>[15:8]</bitRange>
+                    </field>
+                    <field>          <name>time_to_stop</name>
+                        <description>Number of useconds to wait in inactive mode before going to STOP mode if auto_stop is enabled</description>
+                        <bitRange>[31:16]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>MRAM_CTRL3</name>
+                <description>eMRAM Control 3 Register</description>
+                <addressOffset>0x1A4</addressOffset>
+                <resetValue>0x00000020</resetValue>
+                <fields>
+                    <field>          <name>TEST_MODE</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[2:0]</bitRange>
+                    </field>
+                    <field>          <name>WRSTN</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>          <name>STOP_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[4:4]</bitRange>
+                    </field>
+                    <field>          <name>RESETB_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[5:5]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>PG_VDD18_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>M_SEL</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>DA0</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                    <field>          <name>DA1</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>          <name>SCAN_MODE</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[11:11]</bitRange>
+                    </field>
+                    <field>          <name>TST_SCANENABLE</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[12:12]</bitRange>
+                    </field>
+                    <field>          <name>PDN_SCAN</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[13:13]</bitRange>
+                    </field>
+                    <field>          <name>WRCK</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>ShiftWR</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>          <name>SelectWIR</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>          <name>CaptureWR</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[19:19]</bitRange>
+                    </field>
+                    <field>          <name>RBACT1</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[20:20]</bitRange>
+                    </field>
+                    <field>          <name>UpdateWR</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[21:21]</bitRange>
+                    </field>
+                    <field>          <name>WSI</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[22:22]</bitRange>
+                    </field>
+                    <field>          <name>TST_SCANIN</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[27:23]</bitRange>
+                    </field>
+                    <field>          <name>mram_stop</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[28:28]</bitRange>
+                    </field>
+                    <field>          <name>mram_resetb</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[29:29]</bitRange>
+                    </field>
+                    <field>          <name>mram_load_start</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[30:30]</bitRange>
+                    </field>
+                    <field>          <name>mram_load_rstn</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>MRAM_CTRL4</name>
+                <description>eMRAM Control 4 Register</description>
+                <addressOffset>0x1A8</addressOffset>
+                <resetValue>0x00100002</resetValue>
+                <fields>
+                    <field>          <name>CK_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                    <field>          <name>CSN_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>          <name>WEN_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>          <name>DIN_DA_SPLIT</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[11:4]</bitRange>
+                    </field>
+                    <field>          <name>DQ_SEL</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[15:12]</bitRange>
+                    </field>
+                    <field>          <name>OTP_LOAD_RSTn_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>OTP_LOAD_START_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>          <name>Capture_OTP_LOAD_TM</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>          <name>REG_CLK</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[19:19]</bitRange>
+                    </field>
+                    <field>          <name>REG_RESET</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[20:20]</bitRange>
+                    </field>
+                    <field>          <name>XA_CNT</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[21:21]</bitRange>
+                    </field>
+                    <field>          <name>XA_CNT_SEL</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[22:22]</bitRange>
+                    </field>
+                    <field>          <name>XA_ShiftorCapture</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[23:23]</bitRange>
+                    </field>
+                    <field>          <name>XA_SI</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[24:24]</bitRange>
+                    </field>
+                    <field>          <name>TCK</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[25:25]</bitRange>
+                    </field>
+                    <field>          <name>TDI</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[26:26]</bitRange>
+                    </field>
+                    <field>          <name>TMS</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[27:27]</bitRange>
+                    </field>
+                    <field>          <name>TRST</name>
+                        <description>Access by SCC at functional mode</description>
+                        <bitRange>[28:28]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>MRAM_DIN0</name>
+                <description>eMRAM input data mram_din[31:0]</description>
+                <addressOffset>0x1B0</addressOffset>
+            </register>
+            <register>          <name>MRAM_DIN1</name>
+                <description>eMRAM input data mram_din[63:32]</description>
+                <addressOffset>0x1B4</addressOffset>
+            </register>
+            <register>          <name>MRAM_DIN2</name>
+                <description>eMRAM input data mram_din[77:64]</description>
+                <addressOffset>0x1B8</addressOffset>
+            </register>
+            <register>          <name>MRAM_DOUT0</name>
+                <description>eMRAM output data mram_dout[31:0]</description>
+                <addressOffset>0x1C0</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>MRAM_DOUT1</name>
+                <description>eMRAM output data mram_dout[63:32]</description>
+                <addressOffset>0x1C4</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>MRAM_DOUT2</name>
+                <description>eMRAM output data mram_dout[77:64]</description>
+                <addressOffset>0x1C8</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>MRAM_STATUS</name>
+                <description>eMRAM Status Register</description>
+                <addressOffset>0x1CC</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>fsm_state</name>
+                        <description>eMRAM controller FSM state</description>
+                        <bitRange>[4:0]</bitRange>
+                    </field>
+                    <field>          <name>mram_test_mode</name>
+                        <description>eMRAM test mode</description>
+                        <bitRange>[7:5]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>SELECTION_CONTROL_REG</name>
+                <description>Selection Control Register</description>
+                <addressOffset>0x1E0</addressOffset>
+                <resetValue>0x01000200</resetValue>
+                <fields>
+                    <field>          <name>Clock_phase_shifter_select</name>
+                        <description>Clock phase shifter select</description>
+                        <bitRange>[0:1]</bitRange>
+                    </field>
+                    <field>          <name>Clock_phase_shifter_bypass</name>
+                        <description>Clock phase shifter bypass</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>AZ_CTRL</name>
+                <description>AZ Control Register</description>
+                <addressOffset>0x200</addressOffset>
+                <fields>
+                    <field>          <name>SCC_nPORESETAON_nPORESET_SEL</name>
+                        <description>Memory subsystem reset select: 1: nPORESETAON 0: NPORESET</description>
+                        <bitRange>[9:9]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>CASTOR_OTP_CTRL</name>
+                <description>OTP Control Register</description>
+                <addressOffset>0x204</addressOffset>
+                <fields>
+                    <field>          <name>scc_addr</name>
+                        <description>otp addr from scc</description>
+                        <bitRange>[15:0]</bitRange>
+                    </field>
+                    <field>          <name>scc_din</name>
+                        <description>din from scc</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>scc_web</name>
+                        <description>web from scc</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>          <name>scc_readen</name>
+                        <description>readen from scc</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>          <name>scc_otp_ctrl</name>
+                        <description>scc otp control</description>
+                        <bitRange>[29:20]</bitRange>
+                    </field>
+                    <field>          <name>pad_sel</name>
+                        <description>OTP control selection</description>
+                        <bitRange>[30:30]</bitRange>
+                    </field>
+                    <field>          <name>scc_sel</name>
+                        <description>OTP control selection</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>BBGEN_CTRL</name>
+                <description>Body Bias Enable Control Register</description>
+                <addressOffset>0x220</addressOffset>
+            </register>
+            <register>          <name>SPARE_CTRL1</name>
+                <description>Spare 1 Control Register</description>
+                <addressOffset>0x224</addressOffset>
+            </register>
+            <register>          <name>CHIP_ID</name>
+              <description>Chip ID Register</description>
+                <addressOffset>0x400</addressOffset>
+                <access>read-only</access>
+                <resetValue>0x07990477</resetValue>
+            </register>
+            <register>          <name>IO_IN_STATUS</name>
+              <description>GP IO Pads Input Status Register</description>
+                <addressOffset>0x404</addressOffset>
+                <access>read-only</access>
+                <resetValue>0x013FFFFF</resetValue>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- Serial Communication Controller (SCC) (Secure) -->
+    <peripheral derivedFrom="SCC">       <name>SCC_Secure</name>
+        <description>Serial Communication Controller (Secure)</description>
+        <baseAddress>0x5010C800</baseAddress>
+    </peripheral>
+
+    <!-- Secure Privilege Control (SPCTRL) -->
+    <peripheral>                         <name>SPCTRL</name>
+        <description>Secure Privilege Control Block</description>
+        <baseAddress>0x50080000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <registers>
+            <register>          <name>SPCSECTRL</name>
+                <description>Secure Privilege Controller Secure Configuration Control Register</description>
+                <addressOffset>0x0</addressOffset>
+            </register>
+            <register>          <name>BUSWAIT</name>
+                <description>Bus Access wait control after reset</description>
+                <addressOffset>0x4</addressOffset>
+            </register>
+            <register>          <name>SECRESPCFG</name>
+                <description>Security Violation Response Configuration Register</description>
+                <addressOffset>0x10</addressOffset>
+            </register>
+            <register>          <name>NSCCFG</name>
+                <description>Non Secure Callable Configuration for IDAU</description>
+                <addressOffset>0x14</addressOffset>
+            </register>
+            <register>          <name>SECMPCINTSTATUS</name>
+                <description>Secure MPC Interrupt Status</description>
+                <addressOffset>0x1C</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>SECPPCINTSTAT</name>
+                <description>Secure PPC Interrupt Status</description>
+                <addressOffset>0x20</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>SECPPCINTCLR</name>
+                <description>Secure PPC Interrupt Clear</description>
+                <addressOffset>0x24</addressOffset>
+                <access>write-only</access>
+            </register>
+            <register>          <name>SECPPCINTEN</name>
+                <description>Secure PPC Interrupt Enable</description>
+                <addressOffset>0x28</addressOffset>
+            </register>
+            <register>          <name>SECMSCINTSTAT</name>
+                <description>Secure MSC Interrupt Status</description>
+                <addressOffset>0x30</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>SECMSCINTCLR</name>
+                <description>Secure MSC Interrupt Clear</description>
+                <addressOffset>0x34</addressOffset>
+            </register>
+            <register>          <name>SECMSCINTEN</name>
+                <description>Secure MSC Interrupt Enable</description>
+                <addressOffset>0x38</addressOffset>
+            </register>
+            <register>          <name>BRGINTSTAT</name>
+                <description>Bridge Buffer Error Interrupt Status</description>
+                <addressOffset>0x40</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>BRGINTCLR</name>
+                <description>Bridge Buffer Error Interrupt Clear</description>
+                <addressOffset>0x44</addressOffset>
+                <access>write-only</access>
+            </register>
+            <register>          <name>BRGINTEN</name>
+                <description>Bridge Buffer Error Interrupt Enable</description>
+                <addressOffset>0x48</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPC0</name>
+                <description>Non-Secure Access AHB slave Peripheral Protection Control 0</description>
+                <addressOffset>0x50</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPCEXP0</name>
+                <description>Expansion 0 Non_Secure Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0x60</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPCEXP1</name>
+                <description>Expansion 1 Non_Secure Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0x64</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPCEXP2</name>
+                <description>Expansion 2 Non_Secure Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0x68</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPCEXP3</name>
+                <description>Expansion 3 Non_Secure Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0x6C</addressOffset>
+            </register>
+            <register>          <name>APBNSPPC0</name>
+                <description>Non-Secure Access APB slave Peripheral Protection Control 0</description>
+                <addressOffset>0x70</addressOffset>
+            </register>
+            <register>          <name>APBNSPPC1</name>
+                <description>Non-Secure Access APB slave Peripheral Protection Control 1</description>
+                <addressOffset>0x74</addressOffset>
+            </register>
+            <register>          <name>APBNSPPCEXP0</name>
+                <description>Expansion 0 Non_Secure Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0x80</addressOffset>
+            </register>
+            <register>          <name>APBNSPPCEXP1</name>
+                <description>Expansion 1 Non_Secure Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0x84</addressOffset>
+            </register>
+            <register>          <name>APBNSPPCEXP2</name>
+                <description>Expansion 2 Non_Secure Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0x88</addressOffset>
+            </register>
+            <register>          <name>APBNSPPCEXP3</name>
+                <description>Expansion 3 Non_Secure Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0x8C</addressOffset>
+            </register>
+            <register>          <name>AHBSPPPC0</name>
+                <description>Secure Unprivileged Access AHB slave Peripheral Protection Control 0</description>
+                <addressOffset>0x90</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>AHBSPPPCEXP0</name>
+                <description>Expansion 0 Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA0</addressOffset>
+            </register>
+            <register>          <name>AHBSPPPCEXP1</name>
+                <description>Expansion 1 Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA4</addressOffset>
+            </register>
+            <register>          <name>AHBSPPPCEXP2</name>
+                <description>Expansion 2 Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA8</addressOffset>
+            </register>
+            <register>          <name>AHBSPPPCEXP3</name>
+                <description>Expansion 3 Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xAC</addressOffset>
+            </register>
+            <register>          <name>APBSPPPC0</name>
+                <description>Secure Unprivileged Access APB slave Peripheral Protection Control 0</description>
+                <addressOffset>0xB0</addressOffset>
+            </register>
+            <register>          <name>APBSPPPC1</name>
+                <description>Secure Unprivileged Access APB slave Peripheral Protection Control 1</description>
+                <addressOffset>0xB4</addressOffset>
+            </register>
+            <register>          <name>APBSPPPCEXP0</name>
+                <description>Expansion 0 Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC0</addressOffset>
+            </register>
+            <register>          <name>APBSPPPCEXP1</name>
+                <description>Expansion 1 Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC4</addressOffset>
+            </register>
+            <register>          <name>APBSPPPCEXP2</name>
+                <description>Expansion 2 Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC8</addressOffset>
+            </register>
+            <register>          <name>APBSPPPCEXP3</name>
+                <description>Expansion 3 Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xCC</addressOffset>
+            </register>
+            <register>          <name>NSMSCEXP</name>
+                <description>Expansion MSC Non-Secure Configuration</description>
+                <addressOffset>0xD0</addressOffset>
+                <access>read-only</access>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- Non-secure Privilege Control (NSPCTRL) -->
+    <peripheral>                         <name>NSPCTRL</name>
+        <description>Non-secure Privilege Control Block</description>
+        <baseAddress>0x40080000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <registers>
+            <register>          <name>AHBNSPPPC0</name>
+                <description>Non-Secure Unprivileged Access AHB slave Peripheral Protection Control #0</description>
+                <addressOffset>0x90</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPPCEXP0</name>
+                <description>Expansion 0 Non_Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA0</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPPCEXP1</name>
+                <description>Expansion 1 Non_Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA4</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPPCEXP2</name>
+                <description>Expansion 2 Non_Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xA8</addressOffset>
+            </register>
+            <register>          <name>AHBNSPPPCEXP3</name>
+                <description>Expansion 3 Non_Secure Unprivileged Access AHB slave Peripheral Protection Control</description>
+                <addressOffset>0xAC</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPC0</name>
+                <description>Non-Secure Unprivileged Access APB slave Peripheral Protection Control 0</description>
+                <addressOffset>0xB0</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPC1</name>
+                <description>Non-Secure Unprivileged Access APB slave Peripheral Protection Control 1</description>
+                <addressOffset>0xB4</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPCEXP0</name>
+                <description>Expansion 0 Non_Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC0</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPCEXP1</name>
+                <description>Expansion 1 Non_Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC4</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPCEXP2</name>
+                <description>Expansion 2 Non_Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xC8</addressOffset>
+            </register>
+            <register>          <name>APBNSPPPCEXP3</name>
+                <description>Expansion 3 Non_Secure Unprivileged Access APB slave Peripheral Protection Control</description>
+                <addressOffset>0xCC</addressOffset>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- SRAM 0 Memory Protection Controller (Secure)-->
+    <peripheral>                         <name>SRAM0_MPC</name>
+        <description>Memory Protection Controller 0</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50083000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>MPC</name>
+            <description>MPC Combined</description>
+            <value>9</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>CTRL</name>
+                <description>MPC Control Register</description>
+                <addressOffset>0x00</addressOffset>
+                <fields>
+                    <field>          <name>bit[4]</name>
+                        <description>Security error response configuration</description>
+                        <bitRange>[4:4]</bitRange>
+                        <enumeratedValues>
+                          <enumeratedValue>
+                              <name>RAZ-WI</name>
+                              <description>Read-As-Zero - Writes ignored</description>
+                              <value>0</value>
+                          </enumeratedValue>
+                          <enumeratedValue>
+                              <name>BUSERROR</name>
+                              <description>Bus Error</description>
+                              <value>1</value>
+                          </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>          <name>bit[6]</name>
+                        <description>Data interface gating request</description>
+                        <bitRange>[6:6]</bitRange>
+                    </field>
+                    <field>          <name>bit[7]</name>
+                        <description>Data interface gating acknowledge (RO)</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>          <name>bit[8]</name>
+                        <description>Auto-increment</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>          <name>bit[31]</name>
+                        <description>Security lockdown</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>BLK_MAX</name>
+                <description>Maximum value of block based index Register</description>
+                <addressOffset>0x10</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>bit[3_0]</name>
+                        <description>Block size</description>
+                        <bitRange>[3:0]</bitRange>
+                    </field>
+                    <field>          <name>bit[31]</name>
+                        <description>Initialization in progress</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>BLK_CFG</name>
+                <description>Block Configuration</description>
+                <addressOffset>0x14</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>BLK_IDX</name>
+                <description>Index value for accessing block based look up table</description>
+                <addressOffset>0x18</addressOffset>
+            </register>
+            <register>          <name>BLK_LUT</name>
+                <description>Block based gating Look Up Table</description>
+                <addressOffset>0x1C</addressOffset>
+            </register>
+            <register>          <name>INT_STAT</name>
+                <description>Interrupt state</description>
+                <addressOffset>0x20</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>bit[0]</name>
+                        <description>mpc_irq triggered</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>INT_CLEAR</name>
+                <description>Interrupt clear</description>
+                <addressOffset>0x24</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>bit[0]</name>
+                        <description>mpc_irq clear (cleared automatically)</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>INT_EN</name>
+                <description>Interrupt enable</description>
+                <addressOffset>0x28</addressOffset>
+                <fields>
+                    <field>          <name>bit[0]</name>
+                        <description>mpc_irq enable. Bits are valid when mpc_irq triggered is set</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>INT_INFO1</name>
+                <description>Interrupt information 1</description>
+                <addressOffset>0x2C</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>INT_INFO2</name>
+                <description>Interrupt information 2</description>
+                <addressOffset>0x30</addressOffset>
+                <access>read-only</access>
+                <fields>
+                    <field>          <name>bit[15_0]</name>
+                        <description>hmaster</description>
+                        <bitRange>[15:0]</bitRange>
+                    </field>
+                    <field>          <name>bit[16]</name>
+                        <description>hnonsec</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>          <name>bit[17]</name>
+                        <description>cfg_ns</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>INT_SET</name>
+                <description>Interrupt set. Debug purpose only</description>
+                <addressOffset>0x34</addressOffset>
+                <access>write-only</access>
+                <fields>
+                    <field>          <name>bit[0]</name>
+                        <description>mpc_irq set. Debug purpose only</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- SRAM 1 Memory Protection Controller (Secure) -->
+    <peripheral derivedFrom="SRAM0_MPC"> <name>SRAM1_MPC</name>
+        <description>SRAM 1 Memory Protection Controller</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50084000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM 2 Memory Protection Controller (Secure) -->
+    <peripheral derivedFrom="SRAM0_MPC"> <name>SRAM2_MPC</name>
+        <description>SRAM 2 Memory Protection Controller</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50085000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM 3 Memory Protection Controller (Secure) -->
+    <peripheral derivedFrom="SRAM0_MPC"> <name>SRAM3_MPC</name>
+        <description>SRAM 3 Memory Protection Controller</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50086000</baseAddress>
+    </peripheral>
+
+    <!-- Code SRAM Memory Protection Controller (Secure) -->
+    <peripheral derivedFrom="SRAM0_MPC"> <name>CODE_SRAM_MPC</name>
+        <description>Code SRAM Memory Protection Controller</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50130000</baseAddress>
+    </peripheral>
+
+    <!-- QSPI Flash Memory Protection Controller (Secure) -->
+    <peripheral derivedFrom="SRAM0_MPC"> <name>QSPI_MPC</name>
+        <description>QSPI Flash Memory Protection Controller</description>
+        <groupName>MPC</groupName>
+        <baseAddress>0x50120000</baseAddress>
+    </peripheral>
+
+    <!-- SYS Power Policy Unit (Secure)-->
+    <peripheral>                         <name>SYS_PPU</name>
+        <description>SYS Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50022000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0x1000</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <registers>
+            <register>          <name>PWPR</name>
+                <description>Power Policy Register</description>
+                <addressOffset>0x000</addressOffset>
+            </register>
+            <register>          <name>PMER</name>
+                <description>Power Mode Emulation Register</description>
+                <addressOffset>0x004</addressOffset>
+            </register>
+            <register>          <name>PWSR</name>
+                <description>Power Status Register</description>
+                <addressOffset>0x008</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>DISR</name>
+                <description>Device Interface Input Current Status Register</description>
+                <addressOffset>0x010</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>MISR</name>
+                <description>Miscellaneous Input Current Status Register</description>
+                <addressOffset>0x014</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>STSR</name>
+                <description>Stored Status Register</description>
+                <addressOffset>0x018</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>UNLK</name>
+                <description>Unlock Register</description>
+                <addressOffset>0x01C</addressOffset>
+            </register>
+            <register>          <name>PWCR</name>
+                <description>Power Configuration Register</description>
+                <addressOffset>0x020</addressOffset>
+            </register>
+            <register>          <name>PTCR</name>
+                <description>Power Mode Transition Configuration Register</description>
+                <addressOffset>0x024</addressOffset>
+            </register>
+            <register>          <name>IMR</name>
+                <description>Interrupt Mask Register</description>
+                <addressOffset>0x030</addressOffset>
+            </register>
+            <register>          <name>AIMR</name>
+                <description>Additional Interrupt Mask Register</description>
+                <addressOffset>0x034</addressOffset>
+            </register>
+            <register>          <name>ISR</name>
+                <description>Interrupt Status Register</description>
+                <addressOffset>0x038</addressOffset>
+            </register>
+            <register>          <name>AISR</name>
+                <description>Additional Interrupt Status Register</description>
+                <addressOffset>0x03C</addressOffset>
+            </register>
+            <register>          <name>IESR</name>
+                <description>Input Edge Sensitivity Register</description>
+                <addressOffset>0x040</addressOffset>
+            </register>
+            <register>          <name>OPSR</name>
+                <description>Operating Mode Active Edge Sensitivity Register</description>
+                <addressOffset>0x044</addressOffset>
+            </register>
+            <register>          <name>FUNRR</name>
+                <description>Functional Retention RAM Configuration Register</description>
+                <addressOffset>0x050</addressOffset>
+            </register>
+            <register>          <name>FULRR</name>
+                <description>Full Retention RAM Configuration Register</description>
+                <addressOffset>0x054</addressOffset>
+            </register>
+            <register>          <name>MEMRR</name>
+                <description>Memory Retention RAM Configuration Register</description>
+                <addressOffset>0x058</addressOffset>
+            </register>
+            <register>          <name>EDTR0</name>
+                <description>Power Mode Entry Delay Register 0</description>
+                <addressOffset>0x160</addressOffset>
+            </register>
+            <register>          <name>EDTR1</name>
+                <description>Power Mode Entry Delay Register 1</description>
+                <addressOffset>0x164</addressOffset>
+            </register>
+            <register>          <name>DCDR0</name>
+                <description>Device Control Delay Configuration Register 0</description>
+                <addressOffset>0x170</addressOffset>
+            </register>
+            <register>          <name>DCDR1</name>
+                <description>Device Control Delay Configuration Register 1</description>
+                <addressOffset>0x174</addressOffset>
+            </register>
+            <register>          <name>IDR0</name>
+                <description>PPU Identification Register 0</description>
+                <addressOffset>0xFB0</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>IDR1</name>
+                <description>PPU Identification Register 1</description>
+                <addressOffset>0xFB4</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>IIDR</name>
+                <description>Implementation Identification Register</description>
+                <addressOffset>0xFC8</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>AIDR</name>
+                <description>Architecture Identification Register</description>
+                <addressOffset>0xFCC</addressOffset>
+                <access>read-only</access>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- CPU0 Core Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>CPU0CORE_PPU</name>
+        <description>CPU0 Core Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50023000</baseAddress>
+    </peripheral>
+
+    <!-- CPU0 Debug Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>CPU0DBG_PPU</name>
+        <description>CPU0 Debug Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50024000</baseAddress>
+    </peripheral>
+
+    <!-- CPU1 Core Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>CPU1CORE_PPU</name>
+        <description>CPU1 Core Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50025000</baseAddress>
+    </peripheral>
+
+    <!-- CPU1 Debug Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>CPU1DBG_PPU</name>
+        <description>CPU1 Debug Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50026000</baseAddress>
+    </peripheral>
+
+    <!-- Crypto Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>CRYPTO_PPU</name>
+        <description>Crypto Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50027000</baseAddress>
+    </peripheral>
+
+    <!-- Debug Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>DBG_PPU</name>
+        <description>Debug Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x50029000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM0 Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>SRAM0_PPU</name>
+        <description>SRAM0 Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x5002A000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM1 Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>SRAM1_PPU</name>
+        <description>SRAM1 Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x5002B000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM2 Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>SRAM2_PPU</name>
+        <description>SRAM2 Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x5002C000</baseAddress>
+    </peripheral>
+
+    <!-- SRAM3 Power Policy Unit (Secure) -->
+    <peripheral derivedFrom="SYS_PPU">   <name>SRAM3_PPU</name>
+        <description>SRAM3 Power Policy Unit</description>
+        <groupName>PPU</groupName>
+        <baseAddress>0x5002D000</baseAddress>
+    </peripheral>
+
+    <!-- QSPI Flash Controller -->
+    <peripheral>                         <name>QSPIFCTRL</name>
+        <version>1.0</version>
+        <description>QSPI Flash Controller</description>
+        <groupName>QSPI</groupName>
+        <baseAddress>0x4010A000</baseAddress>
+
+        <addressBlock>
+            <offset>0</offset>
+            <size>0xB0</size>
+            <usage>registers</usage>
+        </addressBlock>
+
+        <interrupt>
+            <name>QSPI</name>
+            <description>QSPI Interrupt</description>
+            <value>38</value>
+        </interrupt>
+
+        <registers>
+            <register>          <name>QSPICFG</name>
+                <description>QSPI Configuration Register</description>
+                <addressOffset>0x00</addressOffset>
+                <resetValue>0x80780081</resetValue>
+                <fields>
+                    <field>                            <name>PIPLIDLE</name>
+                        <description>Serial Interface and QSPI pipeline is IDLE</description>
+                        <bitRange>[31:31]</bitRange>
+                    </field>
+                    <field>                            <name>PIPLPHYEN</name>
+                        <description>Pipeline PHY Mode enable</description>
+                        <bitRange>[25:25]</bitRange>
+                    </field>
+                    <field>                            <name>DTREN</name>
+                        <description>Enable DTR Protocol</description>
+                        <bitRange>[24:24]</bitRange>
+                    </field>
+                    <field>                            <name>AHBDECEN</name>
+                        <description>Enable AHB Decoder</description>
+                        <bitRange>[23:23]</bitRange>
+                    </field>
+                    <field>                            <name>MAMOBRDIV</name>
+                        <description>Master mode baud rate divisor (2 to 32)</description>
+                        <bitRange>[22:19]</bitRange>
+                    </field>
+                    <field>                            <name>ENTRXIPMODEIMM</name>
+                        <description>Enter XIP Mode immediately</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>                            <name>ENTRXIPMODEONR</name>
+                        <description>Enter XIP Mode on next READ</description>
+                        <bitRange>[17:17]</bitRange>
+                    </field>
+                    <field>                            <name>ENAHBADDRRM</name>
+                        <description>Enable AHB Address Re-mapping</description>
+                        <bitRange>[16:16]</bitRange>
+                    </field>
+                    <field>                            <name>ENDMAPIF</name>
+                        <description>Enable DMA Peripheral Interface</description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                    <field>                            <name>WPPINDRV</name>
+                        <description>Set to drive the WP pin of Flash device</description>
+                        <bitRange>[14:14]</bitRange>
+                    </field>
+                    <field>                            <name>PERCSLINES</name>
+                        <description>Peripheral chip select lines</description>
+                        <bitRange>[13:10]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>ss0</name>
+                                <description>n_ss_out: 0b1110</description>
+                                <value>0bxxx0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ss1</name>
+                                <description>n_ss_out: 0b1101</description>
+                                <value>0bxx01</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ss2</name>
+                                <description>n_ss_out: 0b1011</description>
+                                <value>0bx011</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ss3</name>
+                                <description>n_ss_out: 0b0111</description>
+                                <value>0b0111</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>ssinactive</name>
+                                <description>n_ss_out: 0b1111 (no peripheral selected)</description>
+                                <value>0b1111</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>                            <name>PERSELDEC</name>
+                        <description>Peripheral select decode</description>
+                        <bitRange>[9:9]</bitRange>
+                        <enumeratedValues>
+                            <enumeratedValue>
+                                <name>Disabled</name>
+                                <description>Only 1 of 4 selects n_ss_out is active</description>
+                                <value>0</value>
+                            </enumeratedValue>
+                            <enumeratedValue>
+                                <name>Enabled</name>
+                                <description>Allow external 4-to-16 decode</description>
+                                <value>1</value>
+                            </enumeratedValue>
+                        </enumeratedValues>
+                    </field>
+                    <field>                            <name>LEGIPMODEEN</name>
+                        <description>Legacy IP Mode Enable</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>                            <name>ENDIRACCCTR</name>
+                        <description>Enable Direct Access Controller</description>
+                        <bitRange>[7:7]</bitRange>
+                    </field>
+                    <field>                            <name>PHYMODEEN</name>
+                        <description>PHY Mode enable</description>
+                        <bitRange>[3:3]</bitRange>
+                    </field>
+                    <field>                            <name>CLKPHASE</name>
+                        <description>Clock phase, this maps to the standard SPI CPHA transfer format</description>
+                        <bitRange>[2:2]</bitRange>
+                    </field>
+                    <field>                            <name>CLKPOLARITY</name>
+                        <description>Clock polarity outside SPI word. This maps to the standard SPI CPOL transfer format</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>                            <name>QSPIEN</name>
+                        <description>QSPI Enable</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>DEVREADINSTR</name>
+                <description>Device Read Instruction Register</description>
+                <addressOffset>0x04</addressOffset>
+                <resetValue>0x00000003</resetValue>
+                <fields>
+                    <field>                            <name>READDUMCLKCYCNUM</name>
+                        <description>Number of Dummy Clock Cycles required by device for Read Instruction</description>
+                        <bitRange>[28:24]</bitRange>
+                    </field>
+                    <field>                            <name>MODEBITEN</name>
+                        <description>Mode Bit Enable</description>
+                        <bitRange>[20:20]</bitRange>
+                    </field>
+                    <field>                            <name>DATATRTYPESSPI</name>
+                        <description>Data Transfer Type for Standard SPI modes</description>
+                        <bitRange>[17:16]</bitRange>
+                    </field>
+                    <field>                            <name>ADDRTRTYPESSPI</name>
+                        <description>Address Transfer Type for Standard SPI modes</description>
+                        <bitRange>[13:12]</bitRange>
+                    </field>
+                    <field>                            <name>DDRBITEN</name>
+                        <description>DDR Bit Enable</description>
+                        <bitRange>[10:10]</bitRange>
+                    </field>
+                    <field>                            <name>INSTRTYPE</name>
+                        <description>Instruction Type</description>
+                        <bitRange>[9:8]</bitRange>
+                    </field>
+                    <field>                            <name>ROPCODE</name>
+                        <description>Read Opcode to use when not in XIP mode</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>DEVWRITEINSTR</name>
+                <description>Device Write Instruction Configuration Register</description>
+                <addressOffset>0x08</addressOffset>
+                <resetValue>0x00000002</resetValue>
+                <fields>
+                    <field>                            <name>WRITEDUMCLKCYCNUM</name>
+                        <description>Number of Dummy Clock Cycles required by device for Write Instruction</description>
+                        <bitRange>[28:24]</bitRange>
+                    </field>
+                    <field>                            <name>DATATRTYPESSPI</name>
+                        <description>Data Transfer Type for Standard SPI modes</description>
+                        <bitRange>[17:16]</bitRange>
+                    </field>
+                    <field>                            <name>ADDRTRTYPESSPI</name>
+                        <description>Address Transfer Type for Standard SPI modes</description>
+                        <bitRange>[13:12]</bitRange>
+                    </field>
+                    <field>                            <name>WELDISABLE</name>
+                        <description>WEL Disable</description>
+                        <bitRange>[8:8]</bitRange>
+                    </field>
+                    <field>                            <name>WROPCODE</name>
+                        <description>Write Opcode</description>
+                        <bitRange>[7:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>DEVSIZE</name>
+                <description>Device Size Configuration Register</description>
+                <addressOffset>0x14</addressOffset>
+                <resetValue>0X00101002</resetValue>
+                <fields>
+                    <field>                            <name>FDEVSIZECS3</name>
+                        <description>Size of Flash Device connected to CS[3] pin</description>
+                        <bitRange>[28:27]</bitRange>
+                    </field>
+                    <field>                            <name>FDEVSIZECS2</name>
+                        <description>Size of Flash Device connected to CS[2] pin</description>
+                        <bitRange>[26:25]</bitRange>
+                    </field>
+                    <field>                            <name>FDEVSIZECS1</name>
+                        <description>Size of Flash Device connected to CS[1] pin</description>
+                        <bitRange>[24:23]</bitRange>
+                    </field>
+                    <field>                            <name>FDEVSIZECS0</name>
+                        <description>Size of Flash Device connected to CS[0] pin</description>
+                        <bitRange>[22:21]</bitRange>
+                    </field>
+                    <field>                            <name>BYTEPERBLKNUM</name>
+                        <description>Number of bytes per block</description>
+                        <bitRange>[20:16]</bitRange>
+                    </field>
+                    <field>                            <name>BYTEPERDEVPGNUM</name>
+                        <description>Number of bytes per device page</description>
+                        <bitRange>[15:4]</bitRange>
+                    </field>
+                    <field>                            <name>ADDRBYTENUM</name>
+                        <description>Number of address bytes</description>
+                        <bitRange>[3:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>REMAPADDR</name>
+                <description>Remap Address Register</description>
+                <addressOffset>0x24</addressOffset>
+            </register>
+            <register>          <name>FLASHCMDCTRL</name>
+                <description>Flash Command Control Register</description>
+                <addressOffset>0x90</addressOffset>
+                <fields>
+                    <field>                            <name>CMDOPCODE</name>
+                        <description>Command Opcode</description>
+                        <bitRange>[31:24]</bitRange>
+                    </field>
+                    <field>                            <name>RDATAEN</name>
+                        <description>Read Data Enable</description>
+                        <bitRange>[23:23]</bitRange>
+                    </field>
+                    <field>                            <name>RDATABYTENUM</name>
+                        <description>Number of Read Data Bytes</description>
+                        <bitRange>[22:20]</bitRange>
+                    </field>
+                    <field>                            <name>CMDADDREN</name>
+                        <description>Command Address Enable</description>
+                        <bitRange>[19:19]</bitRange>
+                    </field>
+                    <field>                            <name>MODEBITEN</name>
+                        <description>Mode Bit Enable</description>
+                        <bitRange>[18:18]</bitRange>
+                    </field>
+                    <field>                            <name>ADDRBYTENUM</name>
+                        <description>Number of Address Bytes</description>
+                        <bitRange>[17:16]</bitRange>
+                    </field>
+                    <field>                            <name>WRDATAEN</name>
+                        <description>Write Data Enable</description>
+                        <bitRange>[15:15]</bitRange>
+                    </field>
+                    <field>                            <name>WRDATABYTENUM</name>
+                        <description>Number of Write Data Bytes</description>
+                        <bitRange>[14:12]</bitRange>
+                    </field>
+                    <field>                            <name>DUMCYCNUM</name>
+                        <description>Number of Dummy Cycles</description>
+                        <bitRange>[11:7]</bitRange>
+                    </field>
+                    <field>                            <name>CMDEXINPROG</name>
+                        <description>Command execution in progress</description>
+                        <bitRange>[1:1]</bitRange>
+                    </field>
+                    <field>                            <name>CMDEXEC</name>
+                        <description>Execute the command</description>
+                        <bitRange>[0:0]</bitRange>
+                    </field>
+                </fields>
+            </register>
+            <register>          <name>FLASHCMDADDR</name>
+                <description>Flash Command Address Register</description>
+                <addressOffset>0x94</addressOffset>
+            </register>
+            <register>          <name>FLASHCMDRDATALOW</name>
+                <description>Flash Command Read Data Register (Lower)</description>
+                <addressOffset>0xA0</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>FLASHCMDRDATAUP</name>
+                <description>Flash Command Read Data Register (Upper)</description>
+                <addressOffset>0xA4</addressOffset>
+                <access>read-only</access>
+            </register>
+            <register>          <name>FLASHCMDWRDATALOW</name>
+                <description>Flash Command Write Data Register (Lower)</description>
+                <addressOffset>0xA8</addressOffset>
+            </register>
+            <register>          <name>FLASHCMDWRDATAUP</name>
+                <description>Flash Command Write Data Register (Upper)</description>
+                <addressOffset>0xAC</addressOffset>
+            </register>
+        </registers>
+    </peripheral>
+
+    <!-- QSPI Flash Controller (Secure) -->
+    <peripheral derivedFrom="QSPIFCTRL"> <name>QSPIFCTRL_Secure</name>
+        <description>QSPI Flash Controller (Secure)</description>
+        <groupName>QSPI (Secure)</groupName>
+        <baseAddress>0x5010A000</baseAddress>
+    </peripheral>
+
+  </peripherals>
+</device>

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -91,6 +91,7 @@ from .cypress import target_CY8C64xA
 from .cypress import target_CY8C64x5
 from . import target_musca_a1
 from . import target_musca_b1
+from . import target_musca_s1
 from . import target_LPC55S69Jxxxxx
 from . import target_LPC55S28Jxxxxx
 from . import target_M251
@@ -203,6 +204,7 @@ BUILTIN_TARGETS = {
           'cy8c64x5_cm4': target_CY8C64x5.cy8c64x5_cm4,
           'musca_a1' : target_musca_a1.MuscaA1,
           'musca_b1' : target_musca_b1.MuscaB1,
+          'musca_s1' : target_musca_s1.MuscaS1,
           'lpc55s69' : target_LPC55S69Jxxxxx.LPC55S69,
           'lpc55s28' : target_LPC55S28Jxxxxx.LPC55S28,
           'cy8c64xx_cm0_full_flash' : target_CY8C64xx.cy8c64xx_cm0_full_flash,

--- a/pyocd/target/builtin/target_musca_s1.py
+++ b/pyocd/target/builtin/target_musca_s1.py
@@ -1,0 +1,167 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...flash.flash import Flash
+from ...coresight.coresight_target import CoreSightTarget
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
+from ...core import exceptions
+from ...utility.timeout import Timeout
+import logging
+
+LOG = logging.getLogger(__name__)
+RESET_MASK = 0x50021104
+RESET_MASK_SYSRSTREQ0_EN = 1 << 4
+
+FLASH_ALGO_QSPI = {
+    'load_address' : 0x20000000,
+
+    # Flash algorithm as a hex string
+    'instructions': [
+    0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,
+    0x41f0e92d, 0x460e4605, 0x24004617, 0xf9cbf000, 0xb1144604, 0xe8bd2001, 0x200081f0, 0x4601e7fb,
+    0x47702000, 0x2000b510, 0xf9d9f000, 0xbd102000, 0x4604b510, 0x417ff024, 0x1000f5a1, 0xf0002100,
+    0x2000f9d9, 0xb570bd10, 0x460d4604, 0xf0244616, 0xf5a1417f, 0x462a1000, 0xf0004631, 0xbd70fa07,
+    0x43f8e92d, 0x46884607, 0xf0274615, 0xf5a6467f, 0x24001600, 0x2204e022, 0x46304669, 0xfa5cf000,
+    0x0000f89d, 0x42885d29, 0xf89dd111, 0x1c601001, 0x42815c28, 0xf89dd10b, 0x1ca01002, 0x42815c28,
+    0xf89dd105, 0x1ce01003, 0x42815c28, 0xf506d004, 0x44201000, 0x83f8e8bd, 0x1d241d36, 0xd3da4544,
+    0x0008eb07, 0xe92de7f6, 0x460643f8, 0x4614460f, 0x457ff026, 0x1500f5a5, 0x0800f04f, 0x2204e01a,
+    0x46284669, 0xfa28f000, 0x0000f89d, 0xd10b42a0, 0x0001f89d, 0xd10742a0, 0x0002f89d, 0xd10342a0,
+    0x0003f89d, 0xd00242a0, 0xe8bd2001, 0x1d2d83f8, 0x0804f108, 0xd3e245b8, 0xe7f62000, 0x9800b501,
+    0xbd086800, 0x9800b503, 0xbd0c6001, 0x4604b570, 0x46290625, 0xf7ff48fe, 0xf045fff5, 0x48fc0101,
+    0xfff0f7ff, 0xf7ff48fa, 0x4605ffe9, 0xbf00e000, 0xf7ff48f7, 0xf000ffe3, 0x28020002, 0xbd70d0f7,
+    0x2006b510, 0xffe2f7ff, 0xf7ff20e4, 0xbd10ffdf, 0xbf00b510, 0x64b0f04f, 0x48ed4621, 0xffd2f7ff,
+    0x0101f044, 0xf7ff48ea, 0x48e9ffcd, 0xffc6f7ff, 0xe0004604, 0x48e6bf00, 0xffc0f7ff, 0x0002f000,
+    0xd0f72802, 0x301048e2, 0xffb8f7ff, 0x0001f000, 0xd1df2800, 0xe92dbd10, 0xb0844dff, 0x46904683,
+    0x9f12469a, 0xf1b89e10, 0xd0060f00, 0x0001f1a8, 0x0003f000, 0x0008f040, 0x2000e000, 0xb12f9003,
+    0xf0001e78, 0xf0400007, 0xe0000008, 0x90022000, 0x1e70b12e, 0x0007f000, 0x0008f040, 0x2000e000,
+    0x25009001, 0x444949cb, 0x98137809, 0xb2c04348, 0x48c79000, 0x99051d00, 0xff84f7ff, 0xbf00b33e,
+    0xe0042400, 0x0004f81a, 0x2505ea40, 0x2e041c64, 0x4630da01, 0x2004e000, 0xd8f342a0, 0x48bc4629,
+    0xf7ff3018, 0x2500ff6f, 0xe0042404, 0x0004f81a, 0x2505ea40, 0x2e081c64, 0x4630da01, 0x2008e000,
+    0xd8f342a0, 0x48b24629, 0xf7ff301c, 0xea4fff5b, 0x9802610b, 0x5100ea41, 0xea419803, 0x98014100,
+    0x3100ea41, 0xf0009800, 0xea41001f, 0x462915c0, 0xf7ff48a7, 0xf045ff47, 0x48a50101, 0xff42f7ff,
+    0xf7ff48a3, 0x4605ff3b, 0x48a1bf00, 0xff36f7ff, 0x0002f000, 0xd0f82802, 0x489db31f, 0xf7ff3010,
+    0x4605ff2d, 0xe0032400, 0x55059811, 0x1c640a2d, 0xda012f04, 0xe0004638, 0x42a02004, 0x4894d8f4,
+    0xf7ff3014, 0x4605ff1b, 0xe0032404, 0x55059811, 0x1c640a2d, 0xda012f08, 0xe0004638, 0x42a02008,
+    0xb008d8f4, 0x8df0e8bd, 0xb087b500, 0x21032000, 0xe9cdaa05, 0x46030200, 0xe9cd4602, 0x46011002,
+    0xf7ff209f, 0xf89dff48, 0x28ba0015, 0xf89dd003, 0x28bb0015, 0x2000d135, 0xaa052102, 0x0200e9cd,
+    0x46024603, 0x1002e9cd, 0x20b54601, 0xff33f7ff, 0x0015f89d, 0xd103288f, 0x0014f89d, 0xd02028ff,
+    0xf88d208f, 0x20ff0018, 0x0019f88d, 0xf7ff2006, 0x2000fedd, 0xe9cd2302, 0x90023000, 0x4602ab06,
+    0x90034601, 0xf7ff20b1, 0xf7ffff16, 0x2066fef1, 0xfeccf7ff, 0xfeecf7ff, 0xf7ff2099, 0xf7fffec7,
+    0xb007fee7, 0xb510bd00, 0x2401b086, 0x21032000, 0xe9cdaa05, 0x46030200, 0xe9cd4602, 0x46011002,
+    0xf7ff209f, 0xf89dfef8, 0x28ba0015, 0xf89dd003, 0x28bb0015, 0x2400d100, 0xb0064620, 0xb510bd10,
+    0x20064604, 0xfea2f7ff, 0xf7ff20c7, 0xf7fffe9f, 0xbd10febf, 0xb085b530, 0x460d4604, 0xf7ff2006,
+    0x2000fe95, 0xe9cda904, 0x46030100, 0x46212203, 0x0502e9cd, 0xf7ff20d8, 0xf7fffece, 0xb005fea9,
+    0xb510bd30, 0x4842bf00, 0xf7ff3890, 0xf000fe77, 0x28004000, 0x483ed0f7, 0xf7ff3890, 0x4604fe6f,
+    0x1480f024, 0x483a4621, 0xf7ff3890, 0xbd10fe6b, 0x4837b510, 0xf7ff3890, 0x4604fe61, 0x0480f044,
+    0x48334621, 0xf7ff3890, 0xbd10fe5d, 0x45f0e92d, 0x4606b089, 0x4617468a, 0x4654463d, 0xe05046b0,
+    0xd30d2d04, 0xf88d7820, 0x78600017, 0x0016f88d, 0xf88d78a0, 0x78e00015, 0x0014f88d, 0xe02b1f2d,
+    0xd10d2d03, 0xf88d7820, 0x78600017, 0x0016f88d, 0xf88d78a0, 0x20ff0015, 0x0014f88d, 0xe01b2500,
+    0xd10c2d02, 0xf88d7820, 0x78600017, 0x0016f88d, 0xf88d20ff, 0xf88d0015, 0x25000014, 0x2d01e00c,
+    0x7820d10a, 0x0017f88d, 0xf88d20ff, 0xf88d0016, 0xf88d0015, 0x25000014, 0xf7ff2006, 0x2000fe17,
+    0x2304aa07, 0x2001e9cd, 0x90039300, 0x2203ab05, 0x20024641, 0xfe4ff7ff, 0xfe2af7ff, 0x0804f108,
+    0x19f01d24, 0xd8ab4540, 0xb0092000, 0x85f0e8bd, 0x4010a090, 0x00000005, 0xb088b570, 0x460c4605,
+    0x20004616, 0xaa062104, 0x1200e9cd, 0x2203ab04, 0x1002e9cd, 0x46104629, 0xfe2df7ff, 0x0018f89d,
+    0xf89d7020, 0x70600019, 0x001af89d, 0xf89d70a0, 0x70e0001b, 0xb0082000, 0x0000bd70, 0x00000000,
+    0x00000800
+    ],
+
+    # Relative function addresses
+    'pc_init': 0x20000021,
+    'pc_unInit': 0x2000003f,
+    'pc_program_page': 0x20000067,
+    'pc_erase_sector': 0x20000051,
+    'pc_eraseAll': 0x20000045,
+
+    'static_base' : 0x20000000 + 0x00000020 + 0x0000057c,
+    'begin_stack' : 0x20000800,
+    'begin_data' : 0x20000000 + 0x1000,
+    'page_size' : 0x100,
+    'analyzer_supported' : False,
+    'analyzer_address' : 0x00000000,
+    'page_buffers' : [0x20001000, 0x20001100],   # Enable double buffering
+    'min_program_length' : 0x100,
+
+    # Flash information
+    'flash_start': 0x200000,
+    'flash_size': 0x800000,
+    'sector_sizes': (
+        (0x0, 0x10000),
+    )
+}
+
+
+class MuscaS1(CoreSightTarget):
+
+    VENDOR = "Arm"
+
+    MEMORY_MAP = MemoryMap(
+        RamRegion(name='nemram',     start=0x0A000000, length=0x00200000, access='rx',
+                        # is_boot_memory=True,
+                        # is_external=False,
+                        # is_default=True
+                        ),
+        RamRegion(name='semram',     start=0x1A000000, length=0x00200000, access='rxs',
+                        # is_boot_memory=True,
+                        # is_external=False,
+                        # is_default=True,
+                        alias='nemram'),
+        FlashRegion(name='nqspi',       start=0x00200000, length=0x02000000, access='rx',
+                        blocksize=0x10000,
+                        page_size=0x10000,
+                        is_boot_memory=True,
+                        is_external=True,
+                        is_default=True,
+                        algo=FLASH_ALGO_QSPI),
+        FlashRegion(name='sqspi',       start=0x10200000, length=0x02000000, access='rxs',
+                        blocksize=0x10000,
+                        page_size=0x10000,
+                        is_boot_memory=True,
+                        is_external=True,
+                        is_default=True,
+                        algo=FLASH_ALGO_QSPI,
+                        alias='nqspi'),
+        RamRegion(  name='ncoderam',    start=0x00000000, length=0x00200000, access='rwx'),
+        RamRegion(  name='scoderam',    start=0x10000000, length=0x00200000, access='rwxs',
+                        alias='ncoderam'),
+        RamRegion(  name='nsysram',     start=0x20000000, length=0x00080000, access='rwx'),
+        RamRegion(  name='ssysram',     start=0x30000000, length=0x00080000, access='rwxs',
+                        alias='nsysram'),
+        # This issue in Musca-B1 seems to have been fixed:
+        # # Due to an errata, the first 8 kB of sysram is not accessible to the debugger.
+        # # RamRegion(name='nsysram', start=0x20002000, length=0x0007e000, access='rwx'),
+        # # RamRegion(name='ssysram', start=0x30002000, length=0x0007e000, access='rwxs',
+        # #                 alias = 'nsysram'),
+        )
+
+    def __init__(self, session):
+        super(MuscaS1, self).__init__(session, self.MEMORY_MAP)
+        self._svd_location = SVDFile.from_builtin("Musca_S1.svd")
+
+    def create_init_sequence(self):
+        seq = super(MuscaS1, self).create_init_sequence()
+
+        seq.insert_before('halt_on_connect',
+            ('enable_sysresetreq',        self._enable_sysresetreq),
+            )
+
+        return seq
+
+    def _enable_sysresetreq(self):
+        LOG.info("Enabling SYSRSTREQ0_EN")
+        reset_mask = self.read32(RESET_MASK)
+        reset_mask |= RESET_MASK_SYSRSTREQ0_EN
+        self.write32(RESET_MASK, reset_mask)


### PR DESCRIPTION
Flashing for QSPI works, but still some instability on `SW_SYSRESETREQ` even with `RESET_MASK_SYSRSTREQ0_EN`.