### PR TITLE
Gdbserver and commander fixes

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -674,7 +674,7 @@ class PyOCDTool(object):
             except IndexError:
                 pass
 
-    def server_listening(self, server):
+    def _gdbserver_listening_cb(self, note):
         """! @brief Callback invoked when the gdbserver starts listening on its port."""
         if self.echo_msg is not None:
             print(self.echo_msg, file=sys.stderr)
@@ -770,9 +770,8 @@ class PyOCDTool(object):
                     # Don't create a server if this core is not listed by the user.
                     if core_number not in core_list:
                         continue
-                    gdb = GDBServer(session,
-                        core=core_number,
-                        server_listening_callback=self.server_listening)
+                    gdb = GDBServer(session, core=core_number)
+                    session.subscribe(self._gdbserver_listening_cb, GDBServer.GDBSERVER_START_LISTENING_EVENT, gdb)
                     session.gdbservers[core_number] = gdb
                     gdbs.append(gdb)
                     gdb.start()

--- a/pyocd/commands/base.py
+++ b/pyocd/commands/base.py
@@ -133,8 +133,8 @@ class CommandBase(object):
                     offset = int(offset.strip(), base=0)
 
             value = None
-            if arg.lower() in self.context.target.core_registers.by_name:
-                value = self.context.target.read_core_register(arg.lower())
+            if arg.lower() in self.context.selected_core.core_registers.by_name:
+                value = self.context.selected_core.read_core_register(arg.lower())
                 self.context.writei("%s = 0x%08x", arg.lower(), value)
             else:
                 subargs = arg.lower().split('.')
@@ -155,7 +155,8 @@ class CommandBase(object):
                 value = int(arg, base=0)
 
             if deref:
-                value = conversion.byte_list_to_u32le_list(self.context.target.read_memory_block8(value + offset, 4))[0]
+                value = conversion.byte_list_to_u32le_list(
+                        self.context.selected_core.read_memory_block8(value + offset, 4))[0]
                 self.context.writei("[%s,%d] = 0x%08x", arg, offset, value)
 
             return value

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -138,6 +138,7 @@ class CommandExecutionContext(object):
 
         # State attributes.
         self._session = None
+        self._selected_core = None
         self._selected_ap_address = None
         self._peripherals = {}
         self._loaded_peripherals = False
@@ -192,7 +193,7 @@ class CommandExecutionContext(object):
     def attach_session(self, session):
         """! @brief Associate a session with the command context.
         
-        Various data for the context are initialized. This includes  selecting the initially selected MEM-AP,
+        Various data for the context are initialized. This includes selecting the initially selected core and MEM-AP,
         and getting an ELF file that was set on the target.
         
         @param self This object.
@@ -207,8 +208,13 @@ class CommandExecutionContext(object):
         # Select the first core's MEM-AP by default.
         if not self._no_init:
             try:
-                if self.target.selected_core is not None:
-                    self.selected_ap_address = self.target.selected_core.ap.address
+                # Selected core defaults to the target's default selected core.
+                if self.selected_core is None:
+                    self.selected_core = self.target.selected_core
+            
+                # Get the AP for the selected core.
+                if self.selected_core is not None:
+                    self.selected_ap_address = self.selected_core.ap.address
             except IndexError:
                 pass
             
@@ -262,6 +268,15 @@ class CommandExecutionContext(object):
     @output_stream.setter
     def output_stream(self, stream):
         self._output = stream
+    
+    @property
+    def selected_core(self):
+        """! @brief The Target instance for the selected core."""
+        return self._selected_core
+    
+    @selected_core.setter
+    def selected_core(self, value):
+        self._selected_core = value
     
     @property
     def selected_ap_address(self):

--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -96,7 +96,7 @@ class CoresValue(ValueBase):
             for i, core in self.context.target.cores.items():
                 self.context.writei("Core %d type:  %s%s", i,
                         coresight.core_ids.CORE_TYPE_NAME[core.core_type],
-                        " (selected)" if (self.context.target.selected_core.core_number == i) else "")
+                        " (selected)" if (self.context.selected_core.core_number == i) else "")
 
 class MemoryMapValue(ValueBase):
     INFO = {
@@ -111,7 +111,7 @@ class MemoryMapValue(ValueBase):
         pt = prettytable.PrettyTable(["Region", "Type", "Start", "End", "Size", "Access", "Sector", "Page"])
         pt.align = 'l'
         pt.border = False
-        for region in self.context.target.get_memory_map():
+        for region in self.context.selected_core.get_memory_map():
             pt.add_row([
                 region.name,
                 region.type.name.capitalize(),
@@ -205,14 +205,14 @@ class FaultValue(ValueBase):
                 if showAll or bit != 0:
                     self.context.writei("    %s = 0x%x", name, bit)
         
-        cfsr = self.context.target.read32(CFSR)
+        cfsr = self.context.selected_core.read32(CFSR)
         mmfsr = cfsr & 0xff
         bfsr = (cfsr >> 8) & 0xff
         ufsr = (cfsr >> 16) & 0xffff
-        hfsr = self.context.target.read32(HFSR)
-        dfsr = self.context.target.read32(DFSR)
-        mmfar = self.context.target.read32(MMFAR)
-        bfar = self.context.target.read32(BFAR)
+        hfsr = self.context.selected_core.read32(HFSR)
+        dfsr = self.context.selected_core.read32(DFSR)
+        mmfar = self.context.selected_core.read32(MMFAR)
+        bfar = self.context.selected_core.read32(BFAR)
         
         print_fields('MMFSR', mmfsr, MMFSR_fields, showAll)
         if showAll or mmfsr & (1 << 7): # MMFARVALID
@@ -393,7 +393,7 @@ class RegisterGroupsValue(ValueBase):
             }
 
     def display(self, args):
-        for g in sorted(self.context.target.core_registers.groups):
+        for g in sorted(self.context.selected_core.core_registers.groups):
             self.context.write(g)
 
 class VectorCatchValue(ValueBase):
@@ -409,7 +409,7 @@ class VectorCatchValue(ValueBase):
             }
 
     def display(self, args):
-        catch = self.context.target.get_vector_catch()
+        catch = self.context.selected_core.get_vector_catch()
 
         self.context.write("Vector catch:")
         for mask in sorted(VC_NAMES_MAP.keys()):
@@ -422,7 +422,7 @@ class VectorCatchValue(ValueBase):
             raise exceptions.CommandError("missing vector catch setting")
     
         try:
-            self.context.target.set_vector_catch(convert_vector_catch(args[0]))
+            self.context.selected_core.set_vector_catch(convert_vector_catch(args[0]))
         except ValueError as e:
             self.context.write(e)
 

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -340,9 +340,9 @@ class GDBServer(threading.Thread):
                 if self.detach_event.isSet():
                     continue
 
-                LOG.info("One client connected!")
+                LOG.info("Client connected to port %d!", self.port)
                 self._run_connection()
-                LOG.info("Client disconnected!")
+                LOG.info("Client disconnected from port %d!", self.port)
                 self._cleanup_for_next_connection()
 
             except Exception as e:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -311,9 +311,6 @@ class GDBServer(threading.Thread):
 
     def run(self):
         LOG.info('GDB server started on port %d (core %d)', self.port, self.core)
-        
-        # Make sure the target is halted. Otherwise gdb gets easily confused.
-        self.target.halt()
 
         while True:
             try:
@@ -339,6 +336,9 @@ class GDBServer(threading.Thread):
 
                 if self.detach_event.isSet():
                     continue
+        
+                # Make sure the target is halted. Otherwise gdb gets easily confused.
+                self.target.halt()
 
                 LOG.info("Client connected to port %d!", self.port)
                 self._run_connection()

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -40,6 +40,7 @@ from .context_facade import GDBDebugContextFacade
 from .symbols import GDBSymbolProvider
 from ..rtos import RTOS
 from . import signals
+from . import gdbserver_commands
 from .packet_io import (
     CTRL_C,
     checksum,
@@ -1204,65 +1205,3 @@ class GDBServer(threading.Thread):
         elif notification.event == 'report_core_number':
             self.report_core = notification.data.new_value
 
-class ThreadsCommand(CommandBase):
-    INFO = {
-            'names': ['threads'],
-            'group': 'gdbserver',
-            'category': 'threads',
-            'nargs': 1,
-            'usage': "{flush,enable,disable,status}",
-            'help': "Control thread awareness.",
-            }
-    
-    def parse(self, args):
-        self.action = args[0]
-        if self.action not in ('flush', 'enable', 'disable', 'status'):
-            raise exceptions.CommandError("invalid action")
-    
-    def execute(self):
-        # Get the gdbserver for the selected core.
-        core_number = self.context.target.selected_core.core_number
-        try:
-            gdbserver = self.context.session.gdbservers[core_number]
-        except KeyError:
-            raise exceptions.CommandError("no gdbserver for core #%i" % core_number)
-
-        if gdbserver.thread_provider is None:
-            self.context.write("Threads are unavailable")
-            return
-
-        if self.action == 'flush':
-            gdbserver.thread_provider.invalidate()
-            self.context.write("Threads flushed")
-        elif self.action == 'enable':
-            gdbserver.thread_provider.read_from_target = True
-            self.context.write("Threads enabled")
-        elif self.action == 'disable':
-            gdbserver.thread_provider.read_from_target = False
-            self.context.write("Threads disabled")
-        elif self.action == 'status':
-            self.context.write("Threads are " +
-                    ("enabled" if gdbserver.thread_provider.read_from_target else "disabled"))
-
-class ArmSemihostingCommand(CommandBase):
-    INFO = {
-            'names': ['arm'],
-            'group': 'gdbserver',
-            'category': 'semihosting',
-            'nargs': 2,
-            'usage': "semihosting {enable,disable}",
-            'help': "Enable or disable semihosting.",
-            'extra_help': "Provided for compatibility with OpenOCD. The same functionality can be achieved "
-                            "by setting the 'enable_semihosting' session option.",
-            }
-    
-    def parse(self, args):
-        if args[0] != 'semihosting':
-            raise exceptions.CommandError("invalid action")
-        if args[1] not in ('enable', 'disable'):
-            raise exceptions.CommandError("invalid action")
-        self.action = args[1]
-    
-    def execute(self):
-        enable = (self.action == 'enable')
-        self.context.session.options['enable_semihosting'] = enable

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -261,7 +261,10 @@ class GDBServer(threading.Thread):
         """! @brief Initialize the remote command processor infrastructure."""
         # Create command execution context. The output stream will default to stdout
         # but we'll change it to a fresh StringIO prior to running each command.
+        #
+        # Note we also modify the selected_core property so it is initially set to the gdbserver's core.
         self._command_context = CommandExecutionContext()
+        self._command_context.selected_core = self.target
         self._command_context.attach_session(self.session)
         
         # Add the gdbserver command group.

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -1,0 +1,87 @@
+# pyOCD debugger
+# Copyright (c) 2020 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import six
+
+from ..core import exceptions
+from ..commands.execution_context import CommandExecutionContext
+from ..commands.base import CommandBase
+
+LOG = logging.getLogger(__name__)
+
+class ThreadsCommand(CommandBase):
+    INFO = {
+            'names': ['threads'],
+            'group': 'gdbserver',
+            'category': 'threads',
+            'nargs': 1,
+            'usage': "{flush,enable,disable,status}",
+            'help': "Control thread awareness.",
+            }
+    
+    def parse(self, args):
+        self.action = args[0]
+        if self.action not in ('flush', 'enable', 'disable', 'status'):
+            raise exceptions.CommandError("invalid action")
+    
+    def execute(self):
+        # Get the gdbserver for the selected core.
+        core_number = self.context.target.selected_core.core_number
+        try:
+            gdbserver = self.context.session.gdbservers[core_numb
+        except KeyError:
+            raise exceptions.CommandError("no gdbserver for core #%i" % core_number)
+
+        if gdbserver.thread_provider is None:
+            self.context.write("Threads are unavailable")
+            return
+
+        if self.action == 'flush':
+            gdbserver.thread_provider.invalidate()
+            self.context.write("Threads flushed")
+        elif self.action == 'enable':
+            gdbserver.thread_provider.read_from_target = True
+            self.context.write("Threads enabled")
+        elif self.action == 'disable':
+            gdbserver.thread_provider.read_from_target = False
+            self.context.write("Threads disabled")
+        elif self.action == 'status':
+            self.context.write("Threads are " +
+                    ("enabled" if gdbserver.thread_provider.read_from_target else "disabled"))
+
+class ArmSemihostingCommand(CommandBase):
+    INFO = {
+            'names': ['arm'],
+            'group': 'gdbserver',
+            'category': 'semihosting',
+            'nargs': 2,
+            'usage': "semihosting {enable,disable}",
+            'help': "Enable or disable semihosting.",
+            'extra_help': "Provided for compatibility with OpenOCD. The same functionality can be achieved "
+                            "by setting the 'enable_semihosting' session option.",
+            }
+    
+    def parse(self, args):
+        if args[0] != 'semihosting':
+            raise exceptions.CommandError("invalid action")
+        if args[1] not in ('enable', 'disable'):
+            raise exceptions.CommandError("invalid action")
+        self.action = args[1]
+    
+    def execute(self):
+        enable = (self.action == 'enable')
+        self.context.session.options['enable_semihosting'] = enable

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -40,9 +40,9 @@ class ThreadsCommand(CommandBase):
     
     def execute(self):
         # Get the gdbserver for the selected core.
-        core_number = self.context.target.selected_core.core_number
+        core_number = self.context.selected_core.core_number
         try:
-            gdbserver = self.context.session.gdbservers[core_numb
+            gdbserver = self.context.session.gdbservers[core_number]
         except KeyError:
             raise exceptions.CommandError("no gdbserver for core #%i" % core_number)
 


### PR DESCRIPTION
A couple fixes related to gdbserver monitor commands.

1. The command execution context tracks the selected core used by commands, instead of using the `SoCTarget`'s selected core. This allows each command context to have independent selected cores.
2. The gdbserver sets the selected core for the command execution context used for remote monitor commands to the core associated with the gdbserver.

Plus some cleanup:

1. Moved gdbserver commands to a separate Python module.
2. Replaced the "server listening" callback used to print the parameters of `echo` commands passed to the gdbserver via `-c` arguments (used for synchronization with the Eclipse Embedded CDT plugin and Cortex Debug VSCode plugin) with a notification.
3. The gdbserver's port number is logged as part of the client connect and disconnect messages.
4. Small change for the gdbserver to halt the target after gdb connects rather than before, so the target is always halted even if gdb disconnects and reconnects multiple times.

Fixes #1012 