### PR TITLE
Publish raw SWV stream to TCP port

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -404,6 +404,20 @@ Frequency in Hertz of the target's system clock. Used to compute the SWO baud ra
 divider.
 </td></tr>
 
+<tr><td>swv_raw_enable</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Enable flag for the raw SWV stream server.
+</td></tr>
+
+<tr><td>swv_raw_port</td>
+<td>int</td>
+<td>3443</td>
+<td>
+TCP port number for the raw SWV stream server.
+</td></tr>
+
 <tr><td>telnet_port</td>
 <td>int</td>
 <td>4444</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2020 Patrick Huesmann
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -136,6 +137,8 @@ BUILTIN_OPTIONS = [
     OptionInfo('swv_system_clock', int, None,
         "Frequency in Hertz of the target's system clock. Used to compute the SWO baud rate "
         "divider. No default."),
+    OptionInfo('tpiu_port', int, 3443,
+        "TCP port number for the raw TPIU stream server."),
     OptionInfo('telnet_port', int, 4444,
         "Base TCP port number for the semihosting telnet server."),
     OptionInfo('vector_catch', str, 'h',

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -137,8 +137,10 @@ BUILTIN_OPTIONS = [
     OptionInfo('swv_system_clock', int, None,
         "Frequency in Hertz of the target's system clock. Used to compute the SWO baud rate "
         "divider. No default."),
-    OptionInfo('tpiu_port', int, 3443,
-        "TCP port number for the raw TPIU stream server."),
+    OptionInfo('swv_raw_enable', bool, True,
+        "Enable flag for the raw SWV stream server."),
+    OptionInfo('swv_raw_port', int, 3443,
+        "TCP port number for the raw SWV stream server."),
     OptionInfo('telnet_port', int, 4444,
         "Base TCP port number for the semihosting telnet server."),
     OptionInfo('vector_catch', str, 'h',


### PR DESCRIPTION
This patch implements a [raw SWO stream server](https://github.com/pyocd/pyOCD/issues/1009) for tools like [orbuculum](https://github.com/orbcode/orbuculum).

I introduced a new option `tpiu_port` that is set to 3443 by default. The TPIU raw server is started implicitly, when `enable_swv` is activated. (If this is not desirable, then the default could also be changed to zero and the user would have to set it explicitly to 3443 or whatever to enable it).

I tested it on a STM32 Nucleo board with `pyocd gdbserver --target stm32l433rctxp -O enable_swv=true -O swv_system_clock=16000000` and a `orbcat -c 1,"0x%08x\n"` on the other side.

Fixes #1009 