### PR TITLE
DP reset refactoring

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -196,9 +196,9 @@ Write DP register.
 <tr><td>
 <a href="#reset"><tt>reset</tt></a>
 </td><td>
-[halt|-halt|-h]
+[halt|-halt|-h] [TYPE]
 </td><td>
-Reset the target.
+Reset the target, optionally specifying the reset type.
 </td></tr>
 
 <tr><td>
@@ -298,6 +298,15 @@ Read 32-bit words.
 </td></tr>
 
 <tr><td>
+<a href="#read64"><tt>read64</tt></a>,
+<a href="#read64"><tt>rd</tt></a>
+</td><td>
+ADDR [LEN]
+</td><td>
+Read 64-bit words.
+</td></tr>
+
+<tr><td>
 <a href="#read8"><tt>read8</tt></a>,
 <a href="#read8"><tt>rb</tt></a>
 </td><td>
@@ -330,6 +339,15 @@ Write 16-bit halfwords to memory.
 ADDR DATA+
 </td><td>
 Write 32-bit words to memory.
+</td></tr>
+
+<tr><td>
+<a href="#write64"><tt>write64</tt></a>,
+<a href="#write64"><tt>wd</tt></a>
+</td><td>
+ADDR DATA...
+</td><td>
+Write 64-bit double-words to memory.
 </td></tr>
 
 <tr><td>
@@ -749,8 +767,8 @@ Write DP register.
 
 ##### `reset`
 
-**Usage**: [halt|-halt|-h] \
-Reset the target.
+**Usage**: [halt|-halt|-h] [TYPE] \
+Reset the target, optionally specifying the reset type. The reset type must be one of 'default', 'hw', 'sw', 'hardware', 'software', 'sw_sysresetreq', 'sw_vectreset', 'sw_emulated', 'sysresetreq', 'vectreset', or 'emulated'.
 
 
 ##### `unlock`
@@ -818,14 +836,21 @@ Load a binary file to an address in memory (RAM or flash). This command is depre
 
 **Aliases**: `rh` \
 **Usage**: ADDR [LEN] \
-Read 16-bit halfwords. Optional length parameter is the number of bytes to read. It must be divisible by 2. If the length is not provided, one halfword is read. The address may be unaligned.
+Read 16-bit halfwords. Optional length parameter is the number of bytes (not half-words) to read. It must be divisible by 2. If the length is not provided, one halfword is read. The address may be unaligned.
 
 
 ##### `read32`
 
 **Aliases**: `rw` \
 **Usage**: ADDR [LEN] \
-Read 32-bit words. Optional length parameter is the number of bytes to read. It must be divisible by 4. If the length is not provided, one word is read. The address may be unaligned.
+Read 32-bit words. Optional length parameter is the number of bytes (not words) to read. It must be divisible by 4. If the length is not provided, one word is read. The address may be unaligned.
+
+
+##### `read64`
+
+**Aliases**: `rd` \
+**Usage**: ADDR [LEN] \
+Read 64-bit words. Optional length parameter is the number of bytes (not double-words!) to read. It must be divisible by 8. If the length is not provided, one word is read. The address may be unaligned.
 
 
 ##### `read8`
@@ -853,6 +878,13 @@ Write 16-bit halfwords to memory. The data arguments are 16-bit halfwords in big
 **Aliases**: `ww` \
 **Usage**: ADDR DATA+ \
 Write 32-bit words to memory. The data arguments are 32-bit words in big-endian format and are written as little-endian. The address may be unaligned. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
+
+
+##### `write64`
+
+**Aliases**: `wd` \
+**Usage**: ADDR DATA... \
+Write 64-bit double-words to memory. The data arguments are 64-bit words in big-endian format and are written as little-endian. The address may be unaligned. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
 
 
 ##### `write8`

--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -81,6 +81,10 @@ class PyOCDCommander(object):
                             status, self.session.board.unique_id))
                     except exceptions.TransferFaultError:
                         pass
+                else:
+                    # Say what we're connected to, but without status.
+                    print("Connected to %s [no init mode]: %s" % (self.context.target.part_number,
+                        self.session.board.unique_id))
 
                 # Run the REPL interface.
                 console = PyocdRepl(self.context)

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -202,7 +202,7 @@ class CommandExecutionContext(object):
         @retval False An error occurred when opening the session or initing the context state.
         """
         assert self._session is None
-        assert session.is_open
+        assert session.is_open or self._no_init
         self._session = session
 
         # Select the first core's MEM-AP by default.

--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -243,7 +243,13 @@ class NresetValue(ValueBase):
             raise exceptions.CommandError("missing reset state")
         state = int(args[0], base=0)
         self.context.writef("nRESET = {}", state)
-        self.context.probe.assert_reset((state == 0))
+        
+        # Use the probe to assert reset if the DP doesn't exist for some reason, otherwise
+        # use the DP so reset notifications are sent.
+        if self.context.target.dp is None:
+            self.context.probe.assert_reset((state == 0))
+        else:
+            self.context.target.dp.assert_reset((state == 0))
 
 class SessionOptionValue(ValueBase):
     INFO = {

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -211,7 +211,11 @@ class SoCTarget(Target, GraphNode):
     def reset(self, reset_type=None):
         # Perform a hardware reset if there is not a core.
         if self.selected_core is None:
-            self.session.probe.reset()
+            # Use the probe to reset if the DP doesn't exist yet.
+            if self.dp is None:
+                self.session.probe.reset()
+            else:
+                self.dp.reset()
             return
         self.selected_core.reset(reset_type)
 

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -522,7 +522,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             self.read_memory_block32 = self._read_memory_block32
         
         # Subscribe to reset events.
-        self.dp.probe.session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
+        self.dp.session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
 
     @property
     def supported_transfer_sizes(self):
@@ -707,7 +707,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
                     self.rom_table.init()
         except exceptions.TransferError as error:
             LOG.error("Transfer error while reading %s ROM table: %s", self.short_description, error,
-                exc_info=self.dp.target.session.log_tracebacks)
+                exc_info=self.dp.session.log_tracebacks)
 
     @property
     def implemented_hprot_mask(self):

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -105,10 +105,10 @@ class CoreSightTarget(SoCTarget):
         mode = self.session.options.get('connect_mode')
         if mode == 'pre-reset':
             LOG.info("Performing connect pre-reset")
-            self.session.probe.reset()
+            self.dp.reset()
         elif mode == 'under-reset':
             LOG.info("Asserting reset prior to connect")
-            self.session.probe.assert_reset(True)
+            self.dp.assert_reset(True)
     
     def perform_halt_on_connect(self):
         """! @brief Halt cores.
@@ -139,7 +139,7 @@ class CoreSightTarget(SoCTarget):
         mode = self.session.options.get('connect_mode')
         if mode == 'under-reset':
             LOG.info("Deasserting reset post connect")
-            self.session.probe.assert_reset(False)
+            self.dp.assert_reset(False)
 
             LOG.debug("Clearing reset catch")
             # Apply to all cores.

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -706,7 +706,7 @@ class CortexM(Target, CoreSightCoreComponent):
         """! @brief Perform a reset of the specified type."""
         assert isinstance(reset_type, Target.ResetType)
         if reset_type is Target.ResetType.HW:
-            self.session.probe.reset()
+            self.session.target.dp.reset()
         elif reset_type is Target.ResetType.SW_EMULATED:
             self._perform_emulated_reset()
         else:

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -739,11 +739,13 @@ class CortexM(Target, CoreSightCoreComponent):
         
         After a call to this function, the core is running.
         """
-        self.session.notify(Target.Event.PRE_RESET, self)
-
         reset_type = self._get_actual_reset_type(reset_type)
 
         LOG.debug("reset, core %d, type=%s", self.core_number, reset_type.name)
+
+        # The HW reset type is passed to the DP, which itself sends reset notifications.
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.PRE_RESET, self)
 
         self._run_token += 1
 
@@ -766,7 +768,8 @@ class CortexM(Target, CoreSightCoreComponent):
                     self.flush()
                     sleep(0.01)
 
-        self.session.notify(Target.Event.POST_RESET, self)
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.POST_RESET, self)
 
     def set_reset_catch(self, reset_type=None):
         """! @brief Prepare to halt core on reset."""

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -116,6 +116,10 @@ class DPConnector(object):
         self._probe = probe
         self._session = probe.session
         self._idr = None
+        
+        # Make sure we have a session, since we get the session from the probe and probes have their session set
+        # after creation.
+        assert self._session is not None, "DPConnector requires the probe to have a session"
     
     @property
     def idr(self):
@@ -225,7 +229,7 @@ class DebugPort(object):
         self._apacc_mem_interface = None
         
         # Subscribe to reset events.
-        self._probe.session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
+        self._session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
 
     @property
     def probe(self):

--- a/pyocd/target/builtin/target_STM32F767xx.py
+++ b/pyocd/target/builtin/target_STM32F767xx.py
@@ -124,7 +124,7 @@ class STM32F767xx(CoreSightTarget):
         super(STM32F767xx, self).__init__(session, self.MEMORY_MAP)
 
     def assert_reset_for_connect(self):
-        self.dp.probe.assert_reset(1)
+        self.dp.assert_reset(1)
 
     def safe_reset_and_halt(self):
         assert self.dp.is_reset_asserted()
@@ -143,7 +143,7 @@ class STM32F767xx(CoreSightTarget):
         # Prevent disabling bus clock/power in low power modes.
         ap.write32(DBGMCU.CR, DBGMCU.CR_VALUE)
 
-        self.dp.probe.assert_reset(0)
+        self.dp.assert_reset(0)
         time.sleep(0.01)
 
         # Restore DEMCR original value.

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -33,7 +33,8 @@ class CortexM_PSoC6(CortexM):
     VTBASE_CM4 = None
 
     def reset(self, reset_type=None):
-        self.session.notify(Target.Event.PRE_RESET, self)
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.PRE_RESET, self)
         self._run_token += 1
         if reset_type is Target.ResetType.HW:
             self._ap.dp.reset()
@@ -69,7 +70,8 @@ class CortexM_PSoC6(CortexM):
 
                     sleep(0.01)
 
-        self.session.notify(Target.Event.POST_RESET, self)
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:
@@ -186,7 +188,8 @@ class CortexM_PSoC64(CortexM):
         self._skip_reset_and_halt = value
 
     def reset(self, reset_type=None):
-        self.session.notify(Target.Event.PRE_RESET, self)
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.PRE_RESET, self)
 
         self._run_token += 1
 
@@ -219,7 +222,8 @@ class CortexM_PSoC64(CortexM):
                 except exceptions.TransferError:
                     pass
 
-        self.session.notify(Target.Event.POST_RESET, self)
+        if reset_type is not Target.ResetType.HW:
+            self.session.notify(Target.Event.POST_RESET, self)
 
     def wait_halted(self):
         with Timeout(5.0) as t_o:

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -36,7 +36,7 @@ class CortexM_PSoC6(CortexM):
         self.session.notify(Target.Event.PRE_RESET, self)
         self._run_token += 1
         if reset_type is Target.ResetType.HW:
-            self.session.probe.reset()
+            self._ap.dp.reset()
             sleep(0.5)
             self._ap.dp.init()
             self._ap.dp.power_up_debug()
@@ -191,7 +191,7 @@ class CortexM_PSoC64(CortexM):
         self._run_token += 1
 
         if reset_type is Target.ResetType.HW:
-            self.session.probe.reset()
+            self._ap.dp.reset()
             self.reinit_dap()
             self.fpb.enable()
 


### PR DESCRIPTION
This PR refactors some reset related code. The most important change is that all reset calls in higher level code end up going through the `DebugPort` reset methods, which then call down to the probe reset methods, rather than sometimes going directly to the probe.

The `DebugPort` reset methods now send pre- and post-reset notifications. This, and the above change, ensures that notifications are sent for hardware resets in addition to software resets. The `CortexM.reset()` method avoids sending notifications for hardware reset so there aren't duplicates.

Another change that builds on the above is that `AccessPort` and `DebugPort` now subscribe to reset notifications in order to clear register caches, instead of relying on a special method being called. This is much more reliable.

There were also a couple Commander changes. The `reset` command now accepts an optional reset type argument. And `--no-init` mode is fixed.