### PR TITLE
Reconnect support

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -1253,8 +1253,7 @@ class InitDpCommand(CommandBase):
             }
 
     def execute(self):
-        self.context.target.dp.init()
-        self.context.target.dp.power_up_debug()
+        self.context.target.dp.connect()
 
 class MakeApCommand(CommandBase):
     INFO = {

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -75,7 +75,7 @@ class CoreSightTarget(SoCTarget):
         seq = CallSequence(
             ('load_svd',            self.load_svd),
             ('pre_connect',         self.pre_connect),
-            ('dp_init',             self.dp.init_sequence),
+            ('dp_init',             self.dp.create_connect_sequence),
             ('create_discoverer',   self.create_discoverer),
             ('discovery',           lambda : self._discoverer.discover()),
             ('check_for_cores',     self.check_for_cores),

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -268,24 +268,24 @@ class DebugPort(object):
         """! @brief Unlock the DP."""
         self.probe.unlock()
 
-    def init(self, protocol=None):
+    def connect(self, protocol=None):
         """! @brief Connect to the target.
         
         This method causes the debug probe to connect using the selected wire protocol. The probe
         must have already been opened prior to this call.
         
-        Unlike init_sequence(), this method is intended to be used when manually constructing a
-        DebugPort instance. It simply calls init_sequence() and invokes the returned call sequence.
+        Unlike create_connect_sequence(), this method is intended to be used when manually constructing a
+        DebugPort instance. It simply calls create_connect_sequence() and invokes the returned call sequence.
         
         @param self
         @param protocol One of the @ref pyocd.probe.debug_probe.DebugProbe.Protocol
             "DebugProbe.Protocol" enums. If not provided, will default to the `protocol` setting.
         """
         self._protocol = protocol
-        self.init_sequence().invoke()
+        self.create_connect_sequence().invoke()
 
-    def init_sequence(self):
-        """! @brief Init task to connect to the target.
+    def create_connect_sequence(self):
+        """! @brief Returns call sequence to connect to the target.
         
         Returns a @ref pyocd.utility.sequence.CallSequence CallSequence that will connect to the
         DP, power up debug and the system, check the DP version to identify whether the target uses
@@ -294,6 +294,7 @@ class DebugPort(object):
         The probe must have already been opened prior to this method being called.
         
         @param self
+        @return @ref pyocd.utility.sequence.CallSequence CallSequence
         """
         return CallSequence(
             ('get_probe_capabilities', self._get_probe_capabilities),

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -126,6 +126,15 @@ class DPConnector(object):
         """! @brief DPIDR instance containing values read from the DP IDR register."""
         return self._idr
     
+    def _get_protocol(self, protocol):
+        # Convert protocol from setting if not passed as parameter.
+        if protocol is None:
+            protocol_name = self._session.options.get('dap_protocol').strip().lower()
+            protocol = DebugProbe.PROTOCOL_NAME_MAP[protocol_name]
+            if protocol not in self._probe.supported_wire_protocols:
+                raise exceptions.DebugError("requested wire protocol %s not supported by the debug probe" % protocol.name)
+        return protocol
+    
     def connect(self, protocol=None):
         """! @brief Establish a connection to the DP.
         
@@ -138,27 +147,51 @@ class DPConnector(object):
         @exception DebugError
         @exception TransferError
         """
-        protocol_name = self._session.options.get('dap_protocol').strip().lower()
-        send_swj = self._session.options.get('dap_swj_enable') \
-                and (DebugProbe.Capability.SWJ_SEQUENCE in self._probe.capabilities)
-        use_dormant = self._session.options.get('dap_swj_use_dormant')
+        try:
+            self._probe.lock()
 
-        # Convert protocol from setting if not passed as parameter.
-        if protocol is None:
-            protocol = DebugProbe.PROTOCOL_NAME_MAP[protocol_name]
-            if protocol not in self._probe.supported_wire_protocols:
-                raise exceptions.DebugError("requested wire protocol %s not supported by the debug probe" % protocol.name)
-        if protocol != DebugProbe.Protocol.DEFAULT:
+            # Determine the requested wire protocol.
+            protocol = self._get_protocol(protocol)
+
+            # If this is not None then the probe is already connected.
+            current_wire_protocol = self._probe.wire_protocol
+            already_connected = current_wire_protocol is not None
+        
+            if already_connected:
+                self._check_protocol(current_wire_protocol, protocol)
+            else:
+                self._connect_probe(protocol)
+
+            self._connect_dp(protocol)
+        finally:
+            self._probe.unlock()
+    
+    def _check_protocol(self, current_wire_protocol, protocol):
+        # Warn about mismatched current and requested wire protocols.
+        if (protocol is not current_wire_protocol) and (protocol is not DebugProbe.Protocol.DEFAULT):
+            LOG.warning("Cannot use %s; already connected with %s", protocol.name, current_wire_protocol.name)
+        else:
+            LOG.debug("Already connected with %s", current_wire_protocol.name)
+
+    def _connect_probe(self, protocol):
+        # Debug log with the selected protocol.
+        if protocol is not DebugProbe.Protocol.DEFAULT:
             LOG.debug("Using %s wire protocol", protocol.name)
-            
+        
         # Connect using the selected protocol.
         self._probe.connect(protocol)
 
         # Log the actual protocol if selected was default.
-        if protocol == DebugProbe.Protocol.DEFAULT:
+        if protocol is DebugProbe.Protocol.DEFAULT:
             protocol = self._probe.wire_protocol
             LOG.debug("Default wire protocol selected; using %s", protocol.name)
         
+    def _connect_dp(self, protocol):
+        # Get SWJ settings.
+        use_dormant = self._session.options.get('dap_swj_use_dormant')
+        send_swj = self._session.options.get('dap_swj_enable') \
+                and (DebugProbe.Capability.SWJ_SEQUENCE in self._probe.capabilities)
+
         # Create object to send SWJ sequences.
         swj = SWJSequenceSender(self._probe, use_dormant)
         
@@ -207,6 +240,13 @@ class DebugPort(object):
     """! @brief Represents the Arm Debug Interface (ADI) Debug Port (DP)."""
     
     def __init__(self, probe, target):
+        """! @brief Constructor.
+        @param self The DebugPort object.
+        @param probe The @ref pyocd.probe.debug_probe.DebugProbe "DebugProbe" object. The probe is assumed to not
+            have been opened yet.
+        @param target An instance of @ref pyocd.core.soc_target.SoCTarget "SoCTarget". Assumed to not have been
+            fully initialized.
+        """
         self._probe = probe
         self.target = target
         self._session = target.session
@@ -219,6 +259,8 @@ class DebugPort(object):
         self._probe_managed_ap_select = False
         self._probe_managed_dpbanksel = False
         self._probe_supports_dpbanksel = False
+        self._have_probe_capabilities = False
+        self._did_check_version = False
         
         # DPv3 attributes
         self._is_dpv3 = False
@@ -296,13 +338,26 @@ class DebugPort(object):
         @param self
         @return @ref pyocd.utility.sequence.CallSequence CallSequence
         """
-        return CallSequence(
-            ('get_probe_capabilities', self._get_probe_capabilities),
+        seq = [
+            ('lock_probe',          self.probe.lock),
+            ]
+        if not self._have_probe_capabilities:
+            seq += [
+                ('get_probe_capabilities', self._get_probe_capabilities),
+                ]
+        seq += [
             ('connect',             self._connect),
             ('clear_sticky_err',    self.clear_sticky_err),
             ('power_up_debug',      self.power_up_debug),
-            ('check_version',       self._check_version),
-            )
+            ]
+        if not self._did_check_version:
+            seq += [
+                ('check_version',       self._check_version),
+                ]
+        seq += [
+            ('unlock_probe',        self.probe.unlock),
+            ]
+        return CallSequence(*seq)
 
     def _get_probe_capabilities(self):
         """! @brief Examine the probe's capabilities."""
@@ -310,6 +365,7 @@ class DebugPort(object):
         self._probe_managed_ap_select = (DebugProbe.Capability.MANAGED_AP_SELECTION in caps)
         self._probe_managed_dpbanksel = (DebugProbe.Capability.MANAGED_DPBANKSEL in caps)
         self._probe_supports_dpbanksel = (DebugProbe.Capability.BANKED_DP_REGISTERS in caps)
+        self._have_probe_capabilities = True
 
     def _connect(self):
         # Attempt to connect.
@@ -347,6 +403,8 @@ class DebugPort(object):
                 LOG.debug("DP BASEPTR = 0x%08x", self._base_addr)
             else:
                 LOG.warning("DPv3 has no valid base address")
+
+        self._did_check_version = True
 
     def flush(self):
         try:

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -162,6 +162,7 @@ class DPConnector(object):
             else:
                 self._connect_probe(protocol)
 
+            protocol = self._probe.wire_protocol
             self._connect_dp(protocol)
         finally:
             self._probe.unlock()

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -142,7 +142,8 @@ class DebugProbe(object):
         """! @brief Currently selected wire protocol.
         
         If the probe is not open and connected, i.e., open() and connect() have not been called,
-        then this property will be None.
+        then this property will be None. If a value other than None is returned, then the probe
+        has been connected successfully.
         """
         raise NotImplementedError()
     
@@ -188,6 +189,8 @@ class DebugProbe(object):
         
         This lock is recursive, so locking multiple times from a single thread is acceptable as long
         as the thread unlocks the same number of times.
+        
+        This method does not return until the calling thread has ownership of the lock.
         """
         self._lock.acquire()
     

--- a/pyocd/probe/shared_probe_proxy.py
+++ b/pyocd/probe/shared_probe_proxy.py
@@ -33,7 +33,6 @@ class SharedDebugProbeProxy(object):
         self._probe = probe
         self._open_count = 0
         self._connect_count = 0
-        self._active_protocol = None
 
     @property
     def session(self):
@@ -73,9 +72,7 @@ class SharedDebugProbeProxy(object):
         self._connect_count -= 1
 
     def swj_sequence(self, length, bits):
-        # Only the first connected client can perform SWJ sequences.
-        if self._connect_count == 1:
-            self._probe.swj_sequence(length, bits)
+        self._probe.swj_sequence(length, bits)
     
     def __getattr__(self, name):
         """! @brief Redirect to underlying probe object methods."""

--- a/pyocd/probe/swj.py
+++ b/pyocd/probe/swj.py
@@ -43,6 +43,8 @@ class SWJSequenceSender(object):
             self._switch_to_swd()
         elif protocol == DebugProbe.Protocol.JTAG:
             self._switch_to_jtag()
+        else:
+            assert False, "unhandled protocol %s in SWJSequenceSender" % protocol
 
     def _switch_to_swd(self):
         """! @brief Send SWJ sequence to select SWD."""

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -99,8 +99,7 @@ class Flash_cc3220sf(Flash):
         time.sleep(1.3)
 
         # reconnect to the board
-        self.target.dp.init()
-        self.target.dp.power_up_debug()
+        self.target.dp.connect()
 
         self.target.halt()
         self.target.reset_and_halt()

--- a/pyocd/target/builtin/target_s5js100.py
+++ b/pyocd/target/builtin/target_s5js100.py
@@ -232,8 +232,7 @@ class CortexM_S5JS100(CortexM):
                     sleep(0.1)
                 except exceptions.TransferError:
                     self.flush()
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     sleep(0.01)
             else:
                 raise exceptions.TimeoutError("Timeout waiting for reset")
@@ -271,8 +270,7 @@ class CortexM_S5JS100(CortexM):
             # LOG.info("s5js100.get_state dhcsr 0x%x", dhcsr)
         except exceptions.TransferError:
             # LOG.info("s5js100.get_state read fail dhcsr..try more")
-            self._ap.dp.init()
-            self._ap.dp.power_up_debug()
+            self._ap.dp.connect()
             dhcsr = self.read_memory(CortexM.DHCSR)
             # LOG.info("fail s5js100.get_state dhcsr 0x%x", dhcsr)
 

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -39,8 +39,7 @@ class CortexM_PSoC6(CortexM):
         if reset_type is Target.ResetType.HW:
             self._ap.dp.reset()
             sleep(0.5)
-            self._ap.dp.init()
-            self._ap.dp.power_up_debug()
+            self._ap.dp.connect()
             self.fpb.enable()
         else:
             if reset_type is Target.ResetType.SW_VECTRESET:
@@ -63,8 +62,7 @@ class CortexM_PSoC6(CortexM):
                 except exceptions.TransferError:
                     self.flush()
                     try:
-                        self._ap.dp.init()
-                        self._ap.dp.power_up_debug()
+                        self._ap.dp.connect()
                     except exceptions.TransferError:
                         self.flush()
 
@@ -213,8 +211,7 @@ class CortexM_PSoC64(CortexM):
         with Timeout(5.0) as t_o:
             while t_o.check():
                 try:
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     dhcsr_reg = self.read32(CortexM.DHCSR)
                     if (dhcsr_reg & CortexM.S_RESET_ST) == 0:
                         break
@@ -241,8 +238,7 @@ class CortexM_PSoC64(CortexM):
         with Timeout(2.0) as t_o:
             while t_o.check():
                 try:
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     self.flush()
                     break
                 except exceptions.TransferError:
@@ -255,8 +251,7 @@ class CortexM_PSoC64(CortexM):
         with Timeout(self.acquire_timeout) as t_o:
             while t_o.check():
                 try:
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     # self.write32(self.IPC2_DATA_ADDR, 0)
                     self.write32(self.TEST_MODE_ADDR, self.TEST_MODE_VALUE)
                     self.flush()
@@ -315,8 +310,7 @@ class CortexM_PSoC64(CortexM):
         with Timeout(self.acquire_timeout) as t_o:
             while t_o.check():
                 try:
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     self.halt()
                     self.wait_halted()
                     self.write_core_register('xpsr', CortexM.XPSR_THUMB)
@@ -384,8 +378,7 @@ class SYS_AP_PSoC64(GenericMemAPTarget):
         with Timeout(self._acquire_timeout) as t_o:
             while t_o.check():
                 try:
-                    self._ap.dp.init()
-                    self._ap.dp.power_up_debug()
+                    self._ap.dp.connect()
                     break
                 except exceptions.TransferError:
                     pass


### PR DESCRIPTION
The purpose of this change is to provide clean support for reconnecting the DP. In some devices, a warm reset will also reset debug logic and kill the debug connection (even though this is forbidden by the Cortex-M architecture). The target support for these devices needs a way to perform the DP connect sequence without encountering problems such as #995. 

There are a few related changes.

1. The `DebugPort.init()` method was renamed to `connect()`, and `init_sequence()` renamed to `create_connect_sequence()`.
2. `DebugPort` allows `connect()` to be called multiple times so a DP reconnect can be performed. It conditionalizes the call sequence by whether it already has retrieved DP version and other info.
3. The `DAPConnect.connect()` method was refactored into multiple methods. The main change is that it only connects the probe if it is not already connected.
4. `SharedDebugProbeProxy` no longer restricts `swj_sequence()` use to when the connect count is 1. This caused problems for DP reconnection.

In addition, Commander uses a shared probe proxy when it creates the session. This fixes failed connections to a probe server started with the `probeserver` command from within Commander (it worked from when used via a gdbserver remote monitor command).

**Note:** this PR builds on #1017 and includes its changes. Once that PR is merged, this one will be rebased. 

Fixes #995