### PR TITLE
target_kinetis: ensure AP#0 is MEM_AP to avoid AttributeError

### DIFF
--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -1,4 +1,5 @@
 # pyOCD debugger
+# Copyright (c) 2020 NXP
 # Copyright (c) 2006-2013,2018 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -205,8 +206,11 @@ class KL28x(Kinetis):
     def create_kl28_aps(self):
         """! @brief Set the fixed list of valid AP numbers for KL28."""
         self.dp.valid_aps = [0, 1, 2]
-        
+
     def detect_dual_core(self):
+        if not isinstance(self.aps[0], ap.MEM_AP):
+            return
+
         # Check if this is the dual core part.
         sdid = self.aps[0].read_memory(SIM_SDID)
         keyattr = (sdid & SIM_SDID_KEYATTR_MASK) >> SIM_SDID_KEYATTR_SHIFT
@@ -217,6 +221,8 @@ class KL28x(Kinetis):
             self.memory_map = self.DUAL_MAP
 
     def post_connect_hook(self):
+        if not isinstance(self.aps[0], ap.MEM_AP):
+            return
         # Disable ROM vector table remapping.
         self.aps[0].write32(RCM_MR, RCM_MR_BOOTROM_MASK)
 

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -1,4 +1,5 @@
 # pyOCD debugger
+# Copyright (c) 2020 NXP
 # Copyright (c) 2006-2018 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -117,8 +118,10 @@ class Kinetis(CoreSightTarget):
             canAccess = False
         else:
             try:
-                for attempt in range(ACCESS_TEST_ATTEMPTS):
-                    self.aps[0].read32(CortexM.DHCSR)
+                # Ensure to use AP#0 as a MEM_AP
+                if isinstance(self.aps[0], ap.MEM_AP):
+                    for attempt in range(ACCESS_TEST_ATTEMPTS):
+                        self.aps[0].read32(CortexM.DHCSR)
             except exceptions.TransferError:
                 LOG.debug("Access test failed with fault")
                 canAccess = False
@@ -157,7 +160,7 @@ class Kinetis(CoreSightTarget):
 
                 # Assert that halt on connect was forced above. Reset will stay asserted
                 # until halt on connect is executed.
-#                 assert self._force_halt_on_connect
+                # assert self._force_halt_on_connect
 
                 isLocked = False
             else:


### PR DESCRIPTION
Fixes #1015

Tested in my local with kl28z, make pyocd report no cores found

```
0007248:ERROR:target_kinetis:KL28x: bad MDM-AP IDR (is 0x02000000)
0017250:WARNING:target_kinetis:Forcing halt on connect in order to gain control of device
Exception while initing board: No cores were discovered!
Traceback (most recent call last):
  File "c:\python27\lib\site-packages\pyocd\commands\commander.py", line 206, in _post_connect
    self.session.open(init_board=not self.args.no_init)
  File "c:\python27\lib\site-packages\pyocd\core\session.py", line 461, in open
    self._board.init()
  File "c:\python27\lib\site-packages\pyocd\board\board.py", line 85, in init
    self.target.init()
  File "c:\python27\lib\site-packages\pyocd\core\soc_target.py", line 120, in init
    seq.invoke()
  File "c:\python27\lib\site-packages\pyocd\utility\sequencer.py", line 208, in invoke
    resultSequence = call()
  File "c:\python27\lib\site-packages\pyocd\coresight\coresight_target.py", line 220, in check_for_cores
    raise exceptions.DebugError("No cores were discovered!")
DebugError: No cores were discovered!
```