### PR TITLE
Bugfix in pyusb_backend: serial_number returned by pyusb may be None

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -169,9 +169,9 @@ class PyUSB(Interface):
             new_board = PyUSB()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product
-            new_board.vendor_name = board.manufacturer
-            new_board.serial_number = board.serial_number
+            new_board.product_name = board.product or ""
+            new_board.vendor_name = board.manufacturer or ""
+            new_board.serial_number = board.serial_number or ""
             boards.append(new_board)
 
         return boards
@@ -356,6 +356,8 @@ class FindDap(object):
         if cmsis_dap_interface is None:
             return False
         if self._serial is not None:
+            if self._serial == "" and dev.serial_number is None:
+                return True
             if self._serial != dev.serial_number:
                 return False
         return True

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -21,6 +21,8 @@ import six
 from time import sleep
 import platform
 import errno
+from hashlib import sha1
+from base64 import b32encode
 
 from .interface import Interface
 from .common import (
@@ -169,9 +171,17 @@ class PyUSB(Interface):
             new_board = PyUSB()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product or ""
-            new_board.vendor_name = board.manufacturer or ""
-            new_board.serial_number = board.serial_number or ""
+            new_board.product_name = board.product or hex(board.idProduct)
+            new_board.vendor_name = board.manufacturer or hex(board.idVendor)
+            if board.serial_number:
+                new_board.serial_number = board.serial_number
+            else:
+                s = new_board.vendor_name + ',' + new_board.product_name
+                if board.bus:
+                    s += ',' + str(board.bus)
+                if board.address:
+                    s += ',' + str(board.address)
+                new_board.serial_number = b32encode(sha1(s.encode()).digest()).decode('ascii')[:16]
             boards.append(new_board)
 
         return boards


### PR DESCRIPTION
Hi. I was trying to use a GD-Link with pyocd 0.28.3, and found that `pyocd list` always crash in `cmsis_dap_probe.py` when trying to truncate `unique_id` at line 99. This GD-Link doesn't have a usb serial number string, so pyusb returns None as `unique_id`.

I found a related issue pyusb/pyusb#295. This behavior is expected but not well documented.