### PR TITLE
Faulthandler catches and backtraces python segfaults.

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -28,6 +28,7 @@ import fnmatch
 import re
 import prettytable
 from time import sleep
+import faulthandler
 
 from . import __version__
 from .core.session import Session
@@ -375,6 +376,9 @@ class PyOCDTool(object):
 
     def run(self, args=None):
         """! @brief Main entry point for command line processing."""
+        # Use faulthandler to traceback segfaults.
+        faulthandler.enable()
+
         try:
             self._args = self.build_parser().parse_args(args)
             

--- a/pyocd/tools/flash_tool.py
+++ b/pyocd/tools/flash_tool.py
@@ -22,6 +22,7 @@ import sys
 import logging
 import itertools
 from struct import unpack
+import faulthandler
 
 try:
     from intelhex import IntelHex
@@ -129,6 +130,9 @@ def ranges(i):
 
 
 def main():
+    # Use faulthandler to traceback segfaults.
+    faulthandler.enable()
+
     args = parser.parse_args()
     setup_logging(args)
     DAPAccess.set_args(args.daparg)

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -23,6 +23,7 @@ import logging
 import argparse
 import json
 import pkg_resources
+import faulthandler
 
 from .. import __version__
 from .. import target
@@ -253,6 +254,9 @@ class GDBServerTool(object):
                 print(t)
 
     def run(self, args=None):
+        # Use faulthandler to traceback segfaults.
+        faulthandler.enable()
+
         self.args = self.build_parser().parse_args(args)
         self.gdb_server_settings = self.get_gdb_server_settings(self.args)
         self.setup_logging(self.args)

--- a/pyocd/tools/pyocd.py
+++ b/pyocd/tools/pyocd.py
@@ -19,6 +19,7 @@ from __future__ import print_function
 import argparse
 import logging
 import sys
+import faulthandler
 
 from .. import __version__
 from ..probe.pydapaccess import DAPAccess
@@ -64,6 +65,9 @@ class PyOCDTool(object):
         logging.basicConfig(level=level)
 
     def run(self):
+        # Use faulthandler to traceback segfaults.
+        faulthandler.enable()
+
         # Read command-line arguments.
         self.args = self.get_args()
         


### PR DESCRIPTION
This is really helpful to get an instant backtrack in case of python crash.
Python crash may be caused by invalid system dependencies and many more.
Such situation is really hard to debug. This solution gives hint at glance.

DOC: https://docs.python.org/dev/library/faulthandler.html

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>