### PR TITLE
Commander wreg with peripheral register fix

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -319,7 +319,7 @@ class WriteRegCommand(RegisterCommandBase):
                     else:
                         raise exceptions.CommandError("too many dots")
                     self.context.target.flush()
-                    if do_readback:
+                    if self.do_readback:
                         self._dump_peripheral_register(p, r, True)
                 else:
                     raise exceptions.CommandError("invalid register '%s' for %s" % (subargs[1], p.name))


### PR DESCRIPTION
Fix for `wreg` when used with a peripheral register. There was a reference to an undefined variable that had moved to an attribute of `self`.

Fixes #1034 