### PR TITLE
LPC55xx: correct sector size of flash regions

### DIFF
--- a/pyocd/target/builtin/target_LPC55S28Jxxxxx.py
+++ b/pyocd/target/builtin/target_LPC55S28Jxxxxx.py
@@ -18,6 +18,7 @@ from ..family.target_lpc5500 import LPC5500Family
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
+# Note: the DFP has both S and NS flash algos, but they are exactly the same except for the address range.
 FLASH_ALGO = {
     'load_address' : 0x20000000,
 
@@ -107,7 +108,8 @@ class LPC55S28(LPC5500Family):
 
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='nsflash',     start=0x00000000, length=0x00080000, access='rx',
-            blocksize=0x200,
+            page_size=0x200,
+            sector_size=0x8000,
             is_boot_memory=True,
             are_erased_sectors_readable=False,
             algo=FLASH_ALGO),
@@ -115,7 +117,8 @@ class LPC55S28(LPC5500Family):
         RamRegion(  name='nscoderam',   start=0x04000000, length=0x00008000, access='rwx',
             default=False),
         FlashRegion(name='sflash',      start=0x10000000, length=0x00080000, access='rx',
-            blocksize=0x200,
+            page_size=0x200,
+            sector_size=0x8000,
             is_boot_memory=True,
             are_erased_sectors_readable=False,
             algo=FLASH_ALGO,

--- a/pyocd/target/builtin/target_LPC55S69Jxxxxx.py
+++ b/pyocd/target/builtin/target_LPC55S69Jxxxxx.py
@@ -18,6 +18,7 @@ from ..family.target_lpc5500 import LPC5500Family
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
+# Note: the DFP has both S and NS flash algos, but they are exactly the same except for the address range.
 FLASH_ALGO = {
     'load_address' : 0x20000000,
 
@@ -107,7 +108,8 @@ class LPC55S69(LPC5500Family):
 
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='nsflash',     start=0x00000000, length=0x00098000, access='rx',
-            blocksize=0x200,
+            page_size=0x200,
+            sector_size=0x8000,
             is_boot_memory=True,
             are_erased_sectors_readable=False,
             algo=FLASH_ALGO),
@@ -115,7 +117,8 @@ class LPC55S69(LPC5500Family):
         RamRegion(  name='nscoderam',   start=0x04000000, length=0x00008000, access='rwx',
             default=False),
         FlashRegion(name='sflash',      start=0x10000000, length=0x00098000, access='rx',
-            blocksize=0x200,
+            page_size=0x200,
+            sector_size=0x8000,
             is_boot_memory=True,
             are_erased_sectors_readable=False,
             algo=FLASH_ALGO,


### PR DESCRIPTION
The flash algos use an erase sector size of 32 kB even though the hardware flash controller can erase individual 512 byte pages. What's worse is that the algos will erase 32 kB starting from the provided page, _not_ 32 kB aligned as would happen with real sectors.