### PR TITLE
Add OKDO E1 lpc55s69 based board

### DIFF
--- a/pyocd/board/board_ids.py
+++ b/pyocd/board/board_ids.py
@@ -195,6 +195,7 @@ BOARD_ID_TO_INFO = {
     "1304": BoardInfo(  "NuMaker-PFM-M487",     "m487jidae",        None,                   ),
     "1309": BoardInfo(  "NuMaker-M252KG",       "m252kg6ae",        None,                   ),
     "1310": BoardInfo(  "NuMaker-IoT-M263A",    "m263kiaae",        None,                   ),
+    "1503": BoardInfo(  "OKDO-E1 LPC55S69",     "lpc55s69",         "lpcxpresso55s69.bin",  ),
     "1549": BoardInfo(  "LPC1549",              "lpc1549jbd100",    None,                   ),
     "1600": BoardInfo(  "Bambino 210",          "lpc4330",          "l1_lpc4330.bin",       ),
     "1605": BoardInfo(  "Bambino 210E",         "lpc4330",          "l1_lpc4330.bin",       ),


### PR DESCRIPTION
One liner in board_ids.py to add support for [OKDO E1](https://www.okdo.com/p/okdo-e1-development-board/), a cheap board based on lpc55s69.

As the board is 'compatible' with the NXP EVK, in the sense that LEDs are connected to the same pins (though with different colours), there's no need for a new binary.

```
(venv3) ~\Git\pyOCD [OKDOE1 ≡]> pyocd list
  #   Probe                         Unique ID  
-----------------------------------------------
  0   OKDO-E1 LPC55S69 [lpc55s69]   15034033  
```