### PR TITLE
Updated requirements to request pylink-square at least with version 0.8.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
         'naturalsort>=1.5,<2.0',
         'prettytable',
         'pyelftools',
-        'pylink-square',
+        'pylink-square>=0.8.2',
         'pyusb>=1.0.0b2,<2.0',
         'pywinusb>=0.4.0;platform_system=="Windows"',
         'pyyaml>=5.1,<6.0',


### PR DESCRIPTION
That allows running modified PyoCD without calling connect() function.

Hello Chris, I've asked Pylink - square author to slight update of pylink package to allow proper run of reset action.

Could you please use this version in PyOCD to allow me update officially our NXP SPSDK product to use this updated PyOCD. 

I really appritiate it.

Any minor update of PyOCD with this is more than welcomed :-)

Just quick explanation of requested change in Pylink:
 - Enabled control of HW reset signal after the probe is opened - The calling Connect function to control RESET line is not more needed.

Thank you
Petr
