### PR TITLE
CMSIS-DAP: handle pyusb returning None for USB serial number

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
-# Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2006-2021 Arm Limited
 # Copyright (c) 2020 Patrick Huesmann
+# Copyright (c) 2021 mentha
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +29,7 @@ from .common import (
     filter_device_by_class,
     is_known_cmsis_dap_vid_pid,
     check_ep,
+    generate_device_unique_id,
     )
 from ..dap_access_api import DAPAccessIntf
 
@@ -167,9 +169,9 @@ class PyUSB(Interface):
             new_board = PyUSB()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product
-            new_board.vendor_name = board.manufacturer
-            new_board.serial_number = board.serial_number
+            new_board.product_name = board.product or hex(board.idProduct)
+            new_board.vendor_name = board.manufacturer or hex(board.idVendor)
+            new_board.serial_number = board.serial_number or generate_device_unique_id(board)
             boards.append(new_board)
 
         return boards
@@ -354,6 +356,8 @@ class FindDap(object):
         if cmsis_dap_interface is None:
             return False
         if self._serial is not None:
+            if self._serial == "" and dev.serial_number is None:
+                return True
             if self._serial != dev.serial_number:
                 return False
         return True

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
-# Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2019-2021 Arm Limited
+# Copyright (c) 2021 mentha
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,6 +28,7 @@ from .common import (
     filter_device_by_class,
     is_known_cmsis_dap_vid_pid,
     check_ep,
+    generate_device_unique_id,
     )
 from ..dap_access_api import DAPAccessIntf
 from ... import common
@@ -185,9 +187,9 @@ class PyUSBv2(Interface):
             new_board = PyUSBv2()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product
-            new_board.vendor_name = board.manufacturer
-            new_board.serial_number = board.serial_number
+            new_board.product_name = board.product or hex(board.idProduct)
+            new_board.vendor_name = board.manufacturer or hex(board.idVendor)
+            new_board.serial_number = board.serial_number or generate_device_unique_id(board)
             boards.append(new_board)
 
         return boards
@@ -336,6 +338,8 @@ class HasCmsisDapv2Interface(object):
             return False
 
         if self._serial is not None:
+            if self._serial == "" and dev.serial_number is None:
+                return True
             if self._serial != dev.serial_number:
                 return False
         return True

--- a/test/probeserver_test.py
+++ b/test/probeserver_test.py
@@ -78,7 +78,7 @@ class ProbeserverTest(Test):
         try:
             result = self.test_function(board.unique_id, self.n)
         except Exception as e:
-            result = GdbTestResult()
+            result = ProbeserverTestResult()
             result.passed = False
             print("Exception %s when testing board %s" %
                   (e, board.unique_id))


### PR DESCRIPTION
If a probe doesn't provide a serial number string, pyusb will return None. This would cause issues like #1076. pyocd now generates a semi-stable unique ID from other device info. It similarly handles missing vendor and product strings by generating strings from the VID/PID.

This change was originally by @mentha via #1031. It was generalized and expanded to be applied to both pyusb_backend and pyusb_v2_backend.