### PR TITLE
Raspberry Pi Pico (RP2040) support

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -492,3 +492,21 @@ the J-Link logs, but this is harmless. J-Link does not support a "none" or "unkn
 </td></tr>
 
 </table>
+
+## Picoprobe options
+
+These session options are available when the Picoprobe debug probe plugin is active.
+
+<table>
+
+<tr><th>Option Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+
+<tr><td>picoprobe.safeswd</td>
+<td>bool</td>
+<td>False</td>
+<td>
+Use safer but slower SWD transfer function with Picoprobe.
+Default is False, so possible WAIT or FAULT SWD acknowldeges and protocol errors will not be caught immediately.
+</td></tr>
+
+</table>

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -176,6 +176,7 @@ class CMSISDAPProbe(DebugProbe):
                 self.Capability.SWJ_SEQUENCE,
                 self.Capability.BANKED_DP_REGISTERS,
                 self.Capability.APv2_ADDRESSES,
+                self.Capability.JTAG_SEQUENCE,
                 }
             if self._link.has_swd_sequence:
                 self._caps.add(self.Capability.SWD_SEQUENCE)
@@ -219,6 +220,12 @@ class CMSISDAPProbe(DebugProbe):
     def swd_sequence(self, sequences):
         try:
             self._link.swd_sequence(sequences)
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def jtag_sequence(self, cycles, tms, read_tdo, tdi):
+        try:
+            self._link.jtag_sequence(cycles, tms, read_tdo, tdi)
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -177,6 +177,8 @@ class CMSISDAPProbe(DebugProbe):
                 self.Capability.BANKED_DP_REGISTERS,
                 self.Capability.APv2_ADDRESSES,
                 }
+            if self._link.has_swd_sequence:
+                self._caps.add(self.Capability.SWD_SEQUENCE)
             if self._link.has_swo():
                 self._caps.add(self.Capability.SWO)
         except DAPAccess.Error as exc:
@@ -211,6 +213,12 @@ class CMSISDAPProbe(DebugProbe):
     def swj_sequence(self, length, bits):
         try:
             self._link.swj_sequence(length, bits)
+        except DAPAccess.Error as exc:
+            six.raise_from(self._convert_exception(exc), exc)
+
+    def swd_sequence(self, sequences):
+        try:
+            self._link.swd_sequence(sequences)
         except DAPAccess.Error as exc:
             six.raise_from(self._convert_exception(exc), exc)
 

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -66,6 +66,9 @@ class DebugProbe(object):
         ## @brief whether the probe automatically handles access of banked DAP registers.
         MANAGED_DPBANKSEL = 5
     
+        ## @brief Whether the probe supports the swd_sequence() API.
+        SWD_SEQUENCE = 6
+
     @classmethod
     def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
         """! @brief Returns a list of DebugProbe instances.
@@ -228,6 +231,23 @@ class DebugProbe(object):
         @param bits Integer of the bit values to send on SWDIO/TMS. The LSB is transmitted first.
         """
         pass
+
+    def swd_sequence(self, sequences):
+        """! @brief Send a sequences of bits on the SWDIO signal.
+        
+        Each sequence in the _sequences_ parameter is a tuple with 1 or 2 members in this order:
+        - 0: int: number of TCK cycles from 1-64
+        - 1: int: the SWDIO bit values to transfer. The presence of this tuple member indicates the sequence is
+            an output sequence; the absence means that the specified number of TCK cycles of SWDIO data will be
+            read and returned.
+        
+        @param self
+        @param sequences A sequence of sequence description tuples as described above.
+        
+        @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
+            sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
+        """
+        raise NotImplementedError()
 
     def set_clock(self, frequency):
         """! @brief Set the frequency for JTAG and SWD in Hz.

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -65,10 +65,13 @@ class DebugProbe(object):
         
         ## @brief whether the probe automatically handles access of banked DAP registers.
         MANAGED_DPBANKSEL = 5
-    
+
         ## @brief Whether the probe supports the swd_sequence() API.
         SWD_SEQUENCE = 6
 
+        ## @brief Whether the probe supports the jtag_sequence() API.
+        JTAG_SEQUENCE = 7
+    
     @classmethod
     def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
         """! @brief Returns a list of DebugProbe instances.
@@ -246,6 +249,20 @@ class DebugProbe(object):
         
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
+        """
+        raise NotImplementedError()
+
+    def jtag_sequence(self, cycles, tms, read_tdo, tdi):
+        """! @brief Send JTAG sequence.
+        
+        @param self
+        @param cycles Number of TCK cycles, from 1-64.
+        @param tms Fixed TMS value. Either 0 or 1.
+        @param read_tdo Boolean indicating whether TDO should be read.
+        @param tdi Integer with the TDI bit values to be transferred each TCK cycle. The LSB is
+            sent first.
+        
+        @return Either an integer with TDI bit values, or None, if _read_tdo_ was false.
         """
         raise NotImplementedError()
 

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -1,0 +1,636 @@
+# pyOCD debugger
+# Copyright (c) 2021 Federico Zuccardi Merli
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from array import array
+
+from time import sleep
+from usb import core, util
+
+from .debug_probe import DebugProbe
+from ..core import exceptions
+from ..core.options import OptionInfo
+from ..core.plugin import Plugin
+
+
+class PicoLink(object):
+    """! @brief Wrapper to handle picoprobe USB.
+
+    Just to hide details of USB and Picoprobe command layer
+    """
+
+    VID = 0x2E8A
+    PID = 0x0004
+
+    CLASS = 0xFF    # Vendor Specific
+
+    CMD_HDR_LEN = 6  # do not include pico packet header
+    PKT_HDR_LEN = 4  # pico packet header
+    HDR_LEN = PKT_HDR_LEN + CMD_HDR_LEN
+
+    PROBE_INVALID = 0       # Invalid command
+    PROBE_WRITE_BITS = 1    # Host wants us to write bits
+    PROBE_READ_BITS = 2     # Host wants us to read bits
+    PROBE_SET_FREQ = 3      # Set TCK
+    PROBE_RESET = 4         # Reset all state: it's a no-op!
+    PROBE_TARGET_RESET = 5  # Reset target (Hardware nreset)
+
+    BUFFER_SIZE = 8192      # Size of buffers in the picoprobe
+
+    def __init__(self, dev):
+        self._dev = dev
+        self._probe_id = dev.serial_number
+        self._vend = dev.manufacturer
+        self._prod = dev.product
+        # USB intefrface and endpoints
+        self._if = None
+        self._wr_ep = None
+        self._rd_ep = None
+        # Progressive command id
+        self._id = 0
+        # Probe command queue
+        self._queue = array('B', (0, 0, 0, 0))
+        self._qulen = self.PKT_HDR_LEN
+        # Buffer for endpoint reads
+        self._bits = array('B', (0 for _ in range(self.BUFFER_SIZE)))
+
+    # ------------------------------------------- #
+    #          Picoprobe Access functions
+    # ------------------------------------------- #
+    def open(self):
+        # Only one configuration considered
+        self._dev.set_configuration()
+        # Search the Vendor Specific interface in first configuration
+        for i in self._dev[0]:
+            if i.bInterfaceClass == PicoLink.CLASS:
+                self._if = i
+                break
+        # Check for a missing device interface
+        if self._if is None:
+            raise exceptions.ProbeError()
+        # Scan and assign Endpoints
+        for e in self._if:
+            if util.endpoint_direction(e.bEndpointAddress) == util.ENDPOINT_OUT:
+                self._wr_ep = e
+            else:
+                self._rd_ep = e
+        # Something is missing from this probe!
+        if self._wr_ep is None or self._rd_ep is None:
+            raise exceptions.ProbeError("Unrecognized Picoprobe interface")
+
+    def close(self):
+        self._if = None
+        self._wr_ep = None
+        self._rd_ep = None
+
+    @classmethod
+    def enumerate_picoprobes(cls):
+        """! @brief Find and return all Picoprobes """
+        return [PicoLink(probe) for probe in core.find(idVendor=PicoLink.VID, idProduct=PicoLink.PID, find_all=True)]
+
+    def q_read_bits(self, bits):
+        """! @brief Queue a read request for 'bits' bits to the probe """
+        # Cannot be called with bits = 0
+        self._queue_cmd_header(self.PROBE_READ_BITS, bits)
+
+    def q_write_bits(self, data, bits=None):
+        """! @brief Queue a write reeust 'bits' bits.
+        @param data Values to be weritten. Either int or iterable yielding bytes (0-255).
+        @param bits How many bits to write. Mandatory if data is int.
+        """
+        if bits is None:
+            bits = 8 * len(data)  # will raise TypeError if data is int
+        count = (bits + 7) // 8
+        self._queue_cmd_header(self.PROBE_WRITE_BITS, bits, count)
+        self._queue.extend(data if type(data) is not int else data.to_bytes(count, 'little'))
+
+    def flush_queue(self):
+        """! @brief Execute all the queued probe actions"""
+        # Put in the packet header (byte count)
+        self._queue[:self.PKT_HDR_LEN] = array(
+            'B', self._qulen.to_bytes(4, 'little'))
+        try:
+            self._wr_ep.write(self._queue)
+        except:
+            # Anything from the USB layer assumes probe is no longer connected
+            raise exceptions.ProbeDisconnected(
+                'Cannot access probe ' + self._probe_id)
+        finally:
+            # Make sure there are no leftovers
+            self._clear_queue()
+
+    def get_bits(self):
+        """! @briefExecute all the queued probe actions and return read values"""
+        self.flush_queue()
+        try:
+            # A single read is enough, as the 8 kB buffer in the Picoprobe can
+            # contain about 454 ACKs+Register reads, and I never queue more than 256
+            received = self._rd_ep.read(self._bits)
+        except Exception:
+            # Anything from the USB layer assumes probe is no longer connected
+            raise exceptions.ProbeDisconnected(
+                'Cannot access probe ' + self._probe_id)
+
+        # Check for correct length of received data
+        remaining = int.from_bytes(self._bits[:self.PKT_HDR_LEN], 'little')
+        if remaining != received:
+            # Something went wrong, wrong number of bytes received
+            raise exceptions.ProbeError(
+                'Mismatched header from %s: expected %d, received %d' % (self._probe_id, remaining, received))
+
+        remaining -= self.PKT_HDR_LEN
+        offset = self.PKT_HDR_LEN
+        result = []
+        # Loop over the received data, creating a list of ints
+        while remaining > 0:
+            # Check for a real read header
+            if self._bits[offset+1] != self.PROBE_READ_BITS:
+                # Something went wrong: wrong command in received header
+                # Possible sign we are misaligned
+                raise exceptions.ProbeError('Wrong header received from %s')
+            # Get the bytes count for the operation
+            # The receiver must know how many bits they are interested in!
+            count = (int.from_bytes(self._bits[offset + 2:offset + 6], 'little') + 7) // 8
+            offset += self.CMD_HDR_LEN
+            result.append(int.from_bytes(self._bits[offset:offset + count], 'little'))
+            offset += count
+            remaining -= self.CMD_HDR_LEN + count
+        return result
+
+    def set_swd_frequency(self, f):
+        self.start_queue()
+        # Write a packet with SET_FREQ and the new value, bypass the queue
+        self._queue_cmd_header(self.PROBE_SET_FREQ, f)
+        self.flush_queue()
+
+    def assert_target_reset(self, state):
+        self.start_queue()
+        # Write a packet with PROBE_TARGET_RESET and the reset pin state
+        self._queue_cmd_header(self.PROBE_TARGET_RESET, state)
+        self.flush_queue()
+
+    def get_unique_id(self):
+        return self._probe_id
+
+    @property
+    def vendor_name(self):
+        return self._vend
+
+    @property
+    def product_name(self):
+        return self._prod
+
+    # ------------------------------------------- #
+    #          Picoprobe intenal functions
+    # ------------------------------------------- #
+    def _next_id(self):
+        """! @brief Returns a progressive id for a Picoprobe command"""
+        id = self._id
+        self._id = (self._id + 1) % 0x100
+        return id
+
+    def _queue_cmd_header(self, cmd, bits, length=0, id=None):
+        """! @brief Prepare a header structure in _queue byte array"""
+        if id is None:
+            id = self._next_id()
+        length += self.CMD_HDR_LEN
+        # update packet header, packet is for sure shorter than 64
+        self._qulen += length
+        self._queue.extend((id, cmd))
+        self._queue.extend(bits.to_bytes(4, 'little'))
+
+    def _clear_queue(self):
+        # Empty send queue and reset packet header
+        del self._queue[self.PKT_HDR_LEN:]
+        self._qulen = self.PKT_HDR_LEN
+
+    def start_queue(self):
+        # Might not need anything else.
+        self._clear_queue()
+
+
+class Picoprobe(DebugProbe):
+    """! @brief Wraps a Picolink link as a DebugProbe. """
+
+    # Address of useful DP registers.
+    SELECT = 0x8
+    RDBUFF = 0xC
+
+    # Bitmasks for AP register address fields.
+    A32 = 0x0000000c
+    APBANKSEL = 0x000000f0
+    APSEL = 0xff000000
+    APSEL_APBANKSEL = APSEL | APBANKSEL
+
+    # SWD command format
+    SWD_CMD_START = (1 << 0)    # always set
+    SWD_CMD_APnDP = (1 << 1)    # set only for AP access
+    SWD_CMD_RnW = (1 << 2)      # set only for read access
+    SWD_CMD_A32 = (3 << 3)      # bits A[3:2] of register addr
+    SWD_CMD_PARITY = (1 << 5)   # parity of APnDP|RnW|A32
+    SWD_CMD_STOP = (0 << 6)     # always clear for synch SWD
+    SWD_CMD_PARK = (1 << 7)     # driven high by host
+
+    # APnDP constants.
+    DP = 0
+    AP = 1
+
+    # Read and write constants.
+    READ = 1
+    WRITE = 0
+
+    # ACK values
+    ACK_OK = 0b001
+    ACK_WAIT = 0b010
+    ACK_FAULT = 0b100
+    ACK_ALL = ACK_FAULT | ACK_WAIT | ACK_OK
+
+    ACK_EXCEPTIONS = {
+        ACK_OK: None,
+        ACK_WAIT: exceptions.TransferTimeoutError("Picoprobe: ACK WAIT received"),
+        ACK_FAULT: exceptions.TransferFaultError("Picoprobe: ACK FAULT received"),
+        ACK_ALL: exceptions.TransferError("Picoprobe: Protocol fault"),
+    }
+
+    SAFESWD_OPTION = 'picoprobe.safeswd'
+
+    PARITY_BIT = 0x100000000
+
+    @ classmethod
+    def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
+        return [cls(dev) for dev in PicoLink.enumerate_picoprobes()]
+
+    @ classmethod
+    def get_probe_with_id(cls, unique_id, is_explicit=False):
+        for dev in PicoLink.enumerate_picoprobes():
+            if dev.get_unique_id() == unique_id:
+                return cls(dev)
+
+    def __init__(self, picolink):
+        super(Picoprobe, self).__init__()
+        self._link = picolink
+        self._is_connected = False
+        self._is_open = False
+        self._unique_id = self._link.get_unique_id()
+        self._select = -1
+        self._reset = False
+
+    @ property
+    def description(self):
+        return self.vendor_name + " " + self.product_name
+
+    @ property
+    def vendor_name(self):
+        return self._link.vendor_name
+
+    @ property
+    def product_name(self):
+        return self._link.product_name
+
+    @ property
+    def supported_wire_protocols(self):
+        return [DebugProbe.Protocol.DEFAULT, DebugProbe.Protocol.SWD]
+
+    @ property
+    def unique_id(self):
+        return self._unique_id
+
+    @ property
+    def wire_protocol(self):
+        """! @brief Only valid after connecting."""
+        return DebugProbe.Protocol.SWD if self._is_connected else None
+
+    @ property
+    def is_open(self):
+        return self._is_open
+
+    @ property
+    def capabilities(self):
+        return {DebugProbe.Capability.SWJ_SEQUENCE}
+
+    def open(self):
+        self._link.open()
+        self._is_open = True
+        self._select = -1
+
+    def close(self):
+        self._link.close()
+        self._is_open = False
+
+    # ------------------------------------------- #
+    #          Target control functions
+    # ------------------------------------------- #
+    def connect(self, protocol=None):
+        """! @brief Connect to the target via SWD."""
+        # Make sure the protocol is supported
+        if (protocol is None) or (protocol == DebugProbe.Protocol.DEFAULT):
+            protocol = DebugProbe.Protocol.SWD
+
+        # Validate selected protocol.
+        if protocol != DebugProbe.Protocol.SWD:
+            raise ValueError("unsupported wire protocol %s" % protocol)
+
+        self._is_connected = True
+        # Use the bulk or safe read and write functions according to option
+        if self.session.options.get(self.SAFESWD_OPTION):
+            self.read_ap_multiple = self._safe_read_ap_multiple
+            self.write_ap_multiple = self._safe_write_ap_multiple
+        else:
+            self.read_ap_multiple = self._bulk_read_ap_multiple
+            self.write_ap_multiple = self._bulk_write_ap_multiple
+        # Subscribe to option change events
+        self.session.options.subscribe(self._change_options, [self.SAFESWD_OPTION])
+        # Do I need to do anything else here?
+        # SWJ switch sequence is handled externally...
+
+    def swj_sequence(self, length, bits):
+        self._link.start_queue()
+        self._link.q_write_bits(bits, length)
+        self._link.flush_queue()
+
+    def disconnect(self):
+        self._is_connected = False
+        self._select = -1
+
+    def set_clock(self, frequency):
+        self._link.set_swd_frequency(frequency // 1000)
+
+    def reset(self):
+        self.assert_reset(True)
+        sleep(self.session.options.get('reset.hold_time'))
+        self.assert_reset(False)
+        sleep(self.session.options.get('reset.post_delay'))
+
+    def assert_reset(self, asserted):
+        self._select = -1
+        self._link.assert_target_reset(asserted)
+        self._reset = asserted
+
+    def is_reset_asserted(self):
+        # No support for reading back the current state
+        return self._reset
+
+    # ------------------------------------------- #
+    #          DAP Access functions
+    # ------------------------------------------- #
+    def read_dp(self, addr, now=True):
+        val = self._read_reg(addr, self.DP)
+
+        # Return the result or the result callback for deferred reads
+        def read_dp_result_callback():
+
+            return val
+        return val if now else read_dp_result_callback
+
+    def write_dp(self, addr, value):
+        # Check whether we need to write a new SELECT value
+        if addr == self.SELECT:
+            if value == self._select:
+                return
+            else:
+                self._select = value
+        self._write_reg(addr, self.DP, value)
+
+    def read_ap(self, addr, now=True):
+        (ret,) = self.read_ap_multiple(addr)
+
+        def read_ap_cb():
+            return ret
+        return ret if now else read_ap_cb
+
+    def write_ap(self, addr, value):
+        self.write_ap_multiple(addr, (value,))
+
+    def _safe_read_ap_multiple(self, addr, count=1, now=True):
+        # Extract the APSEL and APBANKSEL fields
+        sel = addr & self.APSEL_APBANKSEL
+        # Write it to SELECT register on DP
+        # It would appear that a write to SELECT is always done first,
+        # so this is possibly not needed. Oh well, it's cached anyway.
+        self.write_dp(self.SELECT, sel)
+        # Send a read request for the AP, discard the stale result
+        self._read_reg(addr, self.AP)
+        # Read count - 1 new values
+        results = [self._read_reg(addr, self.AP) for n in range(count - 1)]
+        # and read the last result from the RDBUFF register
+        results.append(self.read_dp(self.RDBUFF))
+
+        def read_ap_multiple_result_callback():
+            return results
+
+        return results if now else read_ap_multiple_result_callback
+
+    def _safe_write_ap_multiple(self, addr, values):
+        # Extract the APSEL and APBANKSEL fields
+        sel = addr & self.APSEL_APBANKSEL
+        # Write it to SELECT register on DP
+        # It would appear that a write to SELECT is always done, so
+        # this is possibly not needed. Oh well, it's cached anyway.
+        self.write_dp(self.SELECT, sel)
+        # Send a read request for the AP
+        for v in values:
+            self._write_reg(addr, self.AP, v)
+
+    def _bulk_read_ap_multiple(self, addr, count=1, now=True):
+        # Extract the APSEL and APBANKSEL fields
+        sel = addr & self.APSEL_APBANKSEL
+        # Write it to SELECT register on DP
+        self.write_dp(self.SELECT, sel)
+
+        # Start queueing - queue a max of 256 AP reads not to exceed Picoprobe buffers
+        # Theoretical maximum for the Picoprobe internal 8 kB buffer is ~454
+        # Raising the chunk size brings no great benefit, though.
+        reads = []
+        while count > 0:
+            chunk = 256 if count > 256 else count
+            count -= chunk
+            self._link.start_queue()
+
+            # Queue reads for 1 old value plus count - 1 new values
+            for _ in range(chunk):
+                # Queue read command
+                self._swd_command(self.READ, self.AP, addr)
+                # Queue read value + parity + TrN
+                self._link.q_read_bits(32 + 1 + 1)
+
+            if count == 0:
+                # Now queue final read from RDBUFF
+                self._swd_command(self.READ, self.DP, self.RDBUFF)
+                # Queue read value + parity + TrN
+                self._link.q_read_bits(32 + 1 + 1)
+                # Queue write 3 idle bits (enough?)
+                self._link.q_write_bits(0, 3)
+
+            # Run and collect all the reads in this chunk
+            reads.extend(self._link.get_bits())
+
+        # Check all the acks (including the one for discarded read!)
+        self._check_swd_acks(reads[0::2])
+
+        # Skip first read and zero parity if no errors
+        results = [(v & 0x1FFFFFFFF) ^ self._parity32(v) for v in reads[3::2]]
+
+        # Paritu check
+        if any(v & self.PARITY_BIT for v in results):
+            raise exceptions.ProbeError('Bad parity in SWD read')
+
+        def read_ap_multiple_result_callback():
+            return results
+
+        return results if now else read_ap_multiple_result_callback
+
+    def _bulk_write_ap_multiple(self, addr, values):
+        # Extract the APSEL and APBANKSEL fields
+        sel = addr & self.APSEL_APBANKSEL
+        # Write it to SELECT register on DP
+        self.write_dp(self.SELECT, sel)
+        acks = []
+        left = len(values)
+        done = 0
+        # Use 256 chunks. Max is about 340.
+        while left > 0:
+            chunk = 256 if left > 256 else left
+            self._link.start_queue()
+            for value in values[done:done+chunk]:
+                # Queue write command
+                self._swd_command(self.WRITE, self.AP, addr)
+                # Prepare the write buffer
+                value |= self._parity32(value)
+                # Send the value: 32 (data) + 1 (parity) bits (no Trn needed)
+                # Insert also 3 bits of idle
+                self._link.q_write_bits(value, 32 + 1 + 3)
+            left -= chunk
+            done += chunk
+
+            # Now collect all the ACK reads!
+            acks.extend(self._link.get_bits())
+
+        self._check_swd_acks(acks)
+
+    # ------------------------------------------- #
+    #          Internal implementation functions
+    # ------------------------------------------- #
+
+    def _read_reg(self, addr, APnDP):
+        # This is a safe read
+        self._link.start_queue()
+        # Send a command with a read AP/DP request
+        self._swd_command(self.READ, APnDP, addr)
+        self._read_check_swd_ack()
+
+        # Read + 32 (data) + 1 (parity) + 1 (Trn) bits
+        self._link.q_read_bits(32 + 1 + 1)
+        # insert idle
+        self._link.q_write_bits(0, 3)
+
+        reg = self._link.get_bits()[0]
+        # Unpack the returned value
+        val = reg & 0xFFFFFFFF
+        # Remove the Trn bit
+        par = reg & self.PARITY_BIT
+        # Check for correct parity value
+        if par != self._parity32(val):
+            raise exceptions.ProbeError('Bad parity in SWD read')
+
+        return val
+
+    def _write_reg(self, addr, APnDP, value):
+        # This is a safe write
+        self._link.start_queue()
+        # Send a command with a write AP/DP request
+        self._swd_command(self.WRITE, APnDP, addr)
+        self._read_check_swd_ack()
+
+        # Prepare the write buffer
+        value |= self._parity32(value)
+
+        # Send the value: 32 (data) + 1 (parity) bits (no Trn needed)
+        # Insert also 3 bits of idle
+        self._link.q_write_bits(value, 32 + 1 + 3)
+        self._link.flush_queue()
+
+    def _swd_command(self, RnW, APnDP, addr):
+        """! @brief Builds and queues an SWD command byte plus an ACK read"""
+        cmd = (APnDP << 1) + (RnW << 2) + ((addr << 1) & self.SWD_CMD_A32)
+        cmd |= self._parity32(cmd) >> (32 - 5)
+        cmd |= self.SWD_CMD_START | self.SWD_CMD_STOP | self.SWD_CMD_PARK
+
+        # Write the command to the probe
+        self._link.q_write_bits(cmd, 8)
+        # Queue also ACK reading, plus TrN if needed
+        self._link.q_read_bits(1 + 3 + 1 - RnW)
+
+    def _read_check_swd_ack(self):
+        # Reads Trn + ACK, plus a following Trn bit if the cmd was a write
+        ack = self._link.get_bits()
+        self._check_swd_acks(ack)
+
+    def _check_swd_acks(self, raw_acks):
+        # Extract ACKs and collapse identical elements
+        acks = set((ack >> 1) & self.ACK_ALL for ack in raw_acks)
+
+        # Remove ACK OK only if present
+        acks.difference_update({self.ACK_OK})
+
+        # If there's something left, we had a problem.
+        if len(acks) == 0:
+            return
+        else:
+            try:
+                # Raise the exception for the first problem found in set.
+                e = self.ACK_EXCEPTIONS[acks.pop()]
+            except KeyError:
+                e = self.ACK_EXCEPTIONS[self.ACK_ALL]
+            raise e
+
+    @ staticmethod
+    def _parity32(n):
+        n ^= n >> 16
+        n ^= n >> 8
+        n ^= n >> 4
+        n &= 0xf
+        return (0xD32C0000 << n) & Picoprobe.PARITY_BIT
+
+    def _change_options(self, notification):
+        # Only this option, ATM
+        if notification.event == self.SAFESWD_OPTION:
+            if notification.data.new_value:
+                self.read_ap_multiple=self._safe_read_ap_multiple
+                self.write_ap_multiple=self._safe_write_ap_multiple
+            else:
+                self.read_ap_multiple=self._bulk_read_ap_multiple
+                self.write_ap_multiple=self._bulk_write_ap_multiple
+
+
+class PicoprobePlugin(Plugin):
+    """! @brief Plugin class for Picoprobe."""
+
+    def load(self):
+        return Picoprobe
+
+    @ property
+    def name(self):
+        return "Picoprobe"
+
+    @ property
+    def description(self):
+        return "Raspberry Pi Pico Probe"
+
+    @ property
+    def options(self):
+        """! @brief Returns picoprobe options."""
+        return [
+            OptionInfo(Picoprobe.SAFESWD_OPTION, bool, False,
+                       "Use safe but slower SWD transfer functions with Picoprobe.")]

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -72,7 +72,12 @@ class PicoLink(object):
     # ------------------------------------------- #
     def open(self):
         # Only one configuration considered
-        self._dev.set_configuration()
+        try:
+            # Will throw if no configuration is active (returning None is for wimps)
+            self._dev.get_active_configuration()
+        except core.USBError:
+            # Will throw on Linux if a configuration is already active.
+            self._dev.set_configuration()
         # Search the Vendor Specific interface in first configuration
         for i in self._dev[0]:
             if i.bInterfaceClass == PicoLink.CLASS:

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -250,7 +250,7 @@ class FindPicoprobe(object):
         try:
             # This can fail on Linux if the configuration is already active.
             dev.set_configuration()
-        except:
+        except Exception:
             # But do no act on possible errors, they'll be caught in the next try: clause
             pass
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -73,6 +73,16 @@ INTEGER_INFOS = [
     DAPAccessIntf.ID.MAX_PACKET_SIZE
     ]
 
+class CMSISDAPVersion:
+    """! @brief Known CMSIS-DAP versions.
+
+    The tuple fields are major, minor, patch.
+    """
+    V1_0_0 = (1, 0, 0)
+    V1_1_0 = (1, 1, 0)
+    V1_2_0 = (1, 2, 0)
+    V2_0_0 = (2, 0, 0)
+
 DAP_DEFAULT_PORT = 0
 DAP_SWD_PORT = 1
 DAP_JTAG_PORT = 2

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -16,7 +16,6 @@
 
 import array
 from .dap_access_api import DAPAccessIntf
-from ...utility import compatibility
 
 class Command:
     DAP_INFO = 0x00

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -94,6 +94,17 @@ class DAPAccessIntf(object):
         raise NotImplementedError()
 
     @property
+    def protocol_version(self):
+        """! @brief CMSIS-DAP protocol version.
+        
+        The version is represented as 3-tuple with elements, in order, of major version,
+        minor version, and patch version.
+
+        Not valid (returns None) until the device is opened.
+        """
+        raise NotImplementedError()
+
+    @property
     def vendor_name(self):
         raise NotImplementedError()
 

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -117,6 +117,14 @@ class DAPAccessIntf(object):
         """! @brief A tuple of USB VID and PID, in that order."""
         raise NotImplementedError()
 
+    @property
+    def has_swd_sequence(self):
+        """! @brief Boolean indicating whether the DAP_SWD_Sequence command is supported.
+        
+        This property is only valid after the probe is opened. Until then, the value will be None.
+        """
+        raise NotImplementedError()
+
     # ------------------------------------------- #
     #          Host control functions
     # ------------------------------------------- #
@@ -173,6 +181,24 @@ class DAPAccessIntf(object):
         @param bits Integer with the bit values, sent LSB first.
         """
         raise NotImplementedError()
+
+    def swd_sequence(self, sequences):
+        """! @brief Send a sequences of bits on the SWDIO signal.
+        
+        This method sends the DAP_SWD_Sequence CMSIS-DAP command.
+        
+        Each sequence in the _sequences_ parameter is a tuple with 1 or 2 members:
+        - 0: int: number of TCK cycles from 1-64
+        - 1: int: the SWDIO bit values to transfer. The presence of this tuple member indicates the sequence is
+            an output sequence; the absence means that the specified number of TCK cycles of SWDIO data will be
+            read and returned.
+        
+        @param self
+        @param sequences A sequence of sequence description tuples as described above.
+        
+        @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
+            sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
+        """
 
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):
         """! @brief Send JTAG sequence.

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2006-2013,2018-2020 Arm Limited
+# Copyright (c) 2006-2013,2018-2021 Arm Limited
 # Copyright (c) 2020 Koji Kitayama
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -580,6 +580,10 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def vidpid(self):
         """! @brief A tuple of USB VID and PID, in that order."""
         return self._vidpid
+
+    @property
+    def has_swd_sequence(self):
+        return self._cmsis_dap_version >= CMSISDAPVersion.V1_2_0
     
     def lock(self):
         """! @brief Lock the interface."""
@@ -753,6 +757,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def swj_sequence(self, length, bits):
         self.flush()
         self._protocol.swj_sequence(length, bits)
+
+    @locked
+    def swd_sequence(self, sequences):
+        self.flush()
+        self._protocol.swd_sequence(sequences)
 
     @locked
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):

--- a/pyocd/probe/swj.py
+++ b/pyocd/probe/swj.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2019-2021 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +22,14 @@ from ..probe.debug_probe import DebugProbe
 LOG = logging.getLogger(__name__)
 
 class SWJSequenceSender(object):
-    """! @brief Class to send canned SWJ sequences."""
+    """! @brief Class to send canned SWJ sequences.
+    
+    The primary usage of this class is for sending the SWJ sequences to switch between JTAG and SWD protocols
+    in the Arm ADI SWJ-DP. The select_protocol() method is used for this purpose.
+    
+    In addition, there are methods available to send fragments of the various selection sequences. These can be
+    used to put a target is whatever state is required.
+    """
 
     def __init__(self, probe, use_dormant):
         self._probe = probe
@@ -36,74 +44,150 @@ class SWJSequenceSender(object):
         self._use_dormant = flag
 
     def select_protocol(self, protocol):
-        """! @brief Send SWJ sequence to select chosen wire protocol."""
+        """! @brief Send SWJ sequence to select chosen wire protocol.
+        
+        The `use_dormant` property determines whether dormant mode will be used for the protocol selection, or
+        if the deprecated ADIv5.0 SWJ sequences will be used.
+        
+        @param self This object.
+        @param protocol One of the @ref pyocd.probe.debug_probe.DebugProbe.Protocol DebugProbe.Protocol enums, except
+            that `DEFAULT` is not acceptable and will cause a ValueError exception to be raised.
+        
+        @exception ValueError Request to select the `DEFAULT` protocol.
+        """
         # Not all probes support sending SWJ sequences.
         assert isinstance(protocol, DebugProbe.Protocol)
         if protocol == DebugProbe.Protocol.SWD:
-            self._switch_to_swd()
+            self.switch_to_swd()
         elif protocol == DebugProbe.Protocol.JTAG:
-            self._switch_to_jtag()
+            self.switch_to_jtag()
+        elif protocol == DebugProbe.Protocol.DEFAULT:
+            raise ValueError("cannot send SWJ sequence for default protocol")
         else:
             assert False, "unhandled protocol %s in SWJSequenceSender" % protocol
+    
+    def jtag_enter_test_logic_reset(self):
+        """! @brief Execute at least >5 TCK cycles with TMS high to enter the Test-Logic-Reset state.
+        
+        The line_reset() method can be used instead of this method, but takes a little longer to send.
+        """
+        self._probe.swj_sequence(8, 0xff)
+    
+    def line_reset(self):
+        """! @brief Execute a line reset for both SWD and JTAG.
+        
+        For JTAG, >=5 TCK cycles with TMS high enters the Test-Logic-Reset state.<br/>
+        For SWD, >=50 cycles with SWDIO high performs a line reset.
+        """
+        self._probe.swj_sequence(51, 0xffffffffffffff)
+    
+    def selection_alert(self):
+        """! @brief Send the dormant selection alert sequence.
+        
+        The 128-bit selection alert is prefixed with 8 cycles of SWDIOTMS high.
+        """
+        self._probe.swj_sequence(136, 0x19bc0ea2e3ddafe986852d956209f392ff)
+    
+    def jtag_activation_code(self):
+        """! @brief 4-bit SWDIOTMS cycles low + 8-bit JTAG activation code."""
+        self._probe.swj_sequence(12, 0x00a0)
+    
+    def swd_activation_code(self):
+        """! @brief 4-bit SWDIOTMS cycles low + 8-bit SWD activation code."""
+        self._probe.swj_sequence(12, 0x01a0)
+    
+    def idle_cycles(self, cycles):
+        """! @brief Send SWD idle cycles with SWDIOTMS low."""
+        self._probe.swj_sequence(cycles, 0)
+    
+    def jtag_to_dormant(self):
+        """! @brief Send the JTAG to DS select sequence.
+        
+        Sends the recommended 31-bit JTAG-to-DS select sequence of 0x33bbbbba (LSB-first) on SWDIOTMS. See ADIv6
+        section B5.3.2.
+        
+        @note This should be prefixed with at least 5 cycles to put the JTAG TAP in Test-Logic-Reset; see
+        jtag_enter_test_logic_reset().
+        """
+        self._probe.swj_sequence(39, 0x33bbbbba)
+    
+    def swd_to_dormant(self):
+        """! @brief Send the SWD to DS sequence.
+        
+        Sends the 16-bit SWD-to-DS select sequence of 0xe3bc (LSB-first) on SWDIOTMS. See ADIv6 section B5.3.3.
+        
+        @note An SWD line reset should prefix this sequence. See line_reset().
+        """
+        self._probe.swj_sequence(16, 0xe3bc)
+    
+    def dormant_to_swd(self):
+        """! @brief Perform the dormant mode to SWD transition sequence."""
+        
+        # 8 SWDIOTMS cycles high + 128-bit selection alert sequence.
+        self.selection_alert()
+        
+        # 4-bit SWDIOTMS cycles low + 8-bit SWD activation code.
+        self.swd_activation_code()
+        
+        # SWD line reset (>50 SWDIOTMS cycles high).
+        self.line_reset()
+        
+        # >=2 SWDIOTMS cycles low.
+        self.idle_cycles(2)
+    
+    def dormant_to_jtag(self):
+        """! @brief Perform the dormant mode to JTAG transition sequence."""
+        
+        # 8 SWDIOTMS cycles high + 128-bit selection alert sequence.
+        self.selection_alert()
+        
+        self.jtag_activation_code()
+        
+        self.jtag_enter_test_logic_reset()
 
-    def _switch_to_swd(self):
+    def switch_to_swd(self):
         """! @brief Send SWJ sequence to select SWD."""
+        
+        # Ensure current debug interface is in reset state. A full line reset is used here instead
+        # of the shorter JTAG TLR to support the case where the device is already in SWD mode.
+        self.line_reset()
+        
         if self._use_dormant:
             LOG.debug("Sending SWJ sequence to select SWD; using dormant state")
             
-            # Ensure current debug interface is in reset state
-            self._probe.swj_sequence(51, 0xffffffffffffff)
-            
-            # Send all this in one transfer:
-            # Select Dormant State (from JTAG), 0xb3bbbbbaff
-            # 8 cycles SWDIO/TMS HIGH, 0xff
-            # Alert Sequence, 0x19bc0ea2e3ddafe986852d956209f392
-            # 4 cycles SWDIO/TMS LOW + 8-Bit SWD Activation Code (0x1A), 0x01a0
-            self._probe.swj_sequence(188, 0x01a019bc0ea2e3ddafe986852d956209f392ffb3bbbbbaff)
-           
-            # Enter SWD Line Reset State
-            self._probe.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
-            self._probe.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
+            # Switch from JTAG to dormant, then dormant to SWD.
+            self.jtag_to_dormant()
+            self.dormant_to_swd()
         else:
             LOG.debug("Sending deprecated SWJ sequence to select SWD")
-            
-            # Ensure current debug interface is in reset state
-            self._probe.swj_sequence(51, 0xffffffffffffff)
             
             # Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E)
             # Change if SWJ-DP uses deprecated switch code (0xEDB6)
             self._probe.swj_sequence(16, 0xe79e)
             
             # Enter SWD Line Reset State
-            self._probe.swj_sequence(51, 0xffffffffffffff)  # > 50 cycles SWDIO/TMS High
-            self._probe.swj_sequence(8,  0x00)                # At least 2 idle cycles (SWDIO/TMS Low)
+            self.line_reset()                   # > 50 cycles SWDIO/TMS High
+            self._probe.swj_sequence(8,  0x00)  # At least 2 idle cycles (SWDIO/TMS Low)
     
-    def _switch_to_jtag(self):
+    def switch_to_jtag(self):
         """! @brief Send SWJ sequence to select JTAG."""
+        
+        # Ensure current debug interface is in reset state, for either SWD or JTAG.
+        self.line_reset()
+        
         if self._use_dormant:
             LOG.debug("Sending SWJ sequence to select JTAG ; using dormant state")
             
-            # Ensure current debug interface is in reset state
-            self._probe.swj_sequence(51, 0xffffffffffffff)
-            
-            # Select Dormant State (from SWD)
-            # At least 8 cycles SWDIO/TMS HIGH, 0xE3BC
-            # Alert Sequence, 0x19bc0ea2e3ddafe986852d956209f392
-            # 4 cycles SWDIO/TMS LOW + 8-Bit JTAG Activation Code (0x0A), 0x00a0
-            self._probe.swj_sequence(188, 0x00a019bc0ea2e3ddafe986852d956209f392ffe3bc)
-           
-            # Ensure JTAG interface is reset
-            self._probe.swj_sequence(6, 0x3f)
+            # Switch from SWD to dormant, then dormant to JTAG.
+            self.swd_to_dormant()
+            self.dormant_to_jtag()
         else:
             LOG.debug("Sending deprecated SWJ sequence to select JTAG")
-            
-            # Ensure current debug interface is in reset state
-            self._probe.swj_sequence(51, 0xffffffffffffff)
             
             # Execute SWJ-DP Switch Sequence SWD to JTAG (0xE73C)
             # Change if SWJ-DP uses deprecated switch code (0xAEAE)
             self._probe.swj_sequence(16, 0xe73c)
             
             # Ensure JTAG interface is reset
-            self._probe.swj_sequence(6, 0x3f)
+            self.jtag_enter_test_logic_reset()
     

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -252,6 +252,9 @@ class TCPClientProbe(DebugProbe):
     def swj_sequence(self, length, bits):
         self._perform_request('swj_sequence', length, bits)
 
+    def swd_sequence(self, sequences):
+        return self._perform_request('swd_sequence', sequences)
+
     def set_clock(self, frequency):
         self._perform_request('set_clock', frequency)
 

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -255,6 +255,9 @@ class TCPClientProbe(DebugProbe):
     def swd_sequence(self, sequences):
         return self._perform_request('swd_sequence', sequences)
 
+    def jtag_sequence(self, cycles, tms, read_tdo, tdi):
+        return self._perform_request('jtag_sequence', cycles, tms, read_tdo, tdi)
+
     def set_clock(self, frequency):
         self._perform_request('set_clock', frequency)
 

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -227,6 +227,7 @@ class DebugProbeRequestHandler(StreamRequestHandler):
                 'connect':              (self._request__connect,            1   ), # 'connect', protocol:str
                 'disconnect':           (self._probe.disconnect,            0   ), # 'disconnect'
                 'swj_sequence':         (self._probe.swj_sequence,          2   ), # 'swj_sequence', length:int, bits:int
+                'swd_sequence':         (self._probe.swd_sequence,          1   ), # 'swd_sequence', sequences:List[Union[Tuple[int], Tuple[int, int]]] -> Tuple[int, List[bytes]]
                 'set_clock':            (self._probe.set_clock,             1   ), # 'set_clock', freq:int
                 'reset':                (self._probe.reset,                 0   ), # 'reset'
                 'assert_reset':         (self._probe.assert_reset,          1   ), # 'assert_reset', asserted:bool

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -228,6 +228,7 @@ class DebugProbeRequestHandler(StreamRequestHandler):
                 'disconnect':           (self._probe.disconnect,            0   ), # 'disconnect'
                 'swj_sequence':         (self._probe.swj_sequence,          2   ), # 'swj_sequence', length:int, bits:int
                 'swd_sequence':         (self._probe.swd_sequence,          1   ), # 'swd_sequence', sequences:List[Union[Tuple[int], Tuple[int, int]]] -> Tuple[int, List[bytes]]
+                'jtag_sequence':        (self._probe.jtag_sequence,         4   ), # 'jtag_sequence', cycles:int, tms:int, read_tdo:bool, tdi:int -> Union[None, int]
                 'set_clock':            (self._probe.set_clock,             1   ), # 'set_clock', freq:int
                 'reset':                (self._probe.reset,                 0   ), # 'reset'
                 'assert_reset':         (self._probe.assert_reset,          1   ), # 'assert_reset', asserted:bool

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2013-2019 Arm Limited
+# Copyright (c) 2013-2021 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -110,6 +110,7 @@ from . import target_HC32L19x
 from . import target_HC32L07x
 from . import target_MPS3_AN522
 from . import target_MPS3_AN540
+from . import target_RP2040
 
 ## @brief Dictionary of all builtin targets.
 BUILTIN_TARGETS = {
@@ -243,4 +244,7 @@ BUILTIN_TARGETS = {
           'hc32l072' : target_HC32L07x.HC32L072,
           'hc32l073' : target_HC32L07x.HC32L073,
           'hc32f072' : target_HC32L07x.HC32F072,
+          'rp2040' : target_RP2040.RP2040Core0,
+          'rp2040_core0' : target_RP2040.RP2040Core0,
+          'rp2040_core1' : target_RP2040.RP2040Core1,
          }

--- a/pyocd/target/builtin/target_RP2040.py
+++ b/pyocd/target/builtin/target_RP2040.py
@@ -1,0 +1,213 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from ...core import exceptions
+from ...coresight.coresight_target import CoreSightTarget
+from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, DeviceRegion, MemoryMap)
+from ...probe.swj import SWJSequenceSender
+from ...probe.debug_probe import DebugProbe
+from ...utility import (conversion, mask)
+
+LOG = logging.getLogger(__name__)
+
+FLASH_ALGO = {
+    'load_address' : 0x20000000,
+
+    # Flash algorithm as a hex string
+    'instructions': [
+    0xe00abe00,
+    0xb085b5f0, 0x447e4e1e, 0x28017830, 0xf000d101, 0x2001f839, 0x70309004, 0x46384f15, 0xf00030f7,
+    0x4604f8a3, 0x1c804813, 0xf89ef000, 0x46384605, 0xf89af000, 0x48109003, 0xf896f000, 0x480f9002,
+    0xf892f000, 0x480b9001, 0xf88ef000, 0x47a04607, 0x607447a8, 0x980360b5, 0x980260f0, 0x98016130,
+    0x61b76170, 0x70309804, 0xb0052000, 0x46c0bdf0, 0x00004552, 0x00005843, 0x00005052, 0x00004346,
+    0x0000027a, 0x4c07b510, 0x7820447c, 0xd1062801, 0x47806960, 0x478069a0, 0x70202000, 0x2001bd10,
+    0x46c0bd10, 0x000001f8, 0x44784805, 0x28007800, 0x2001d101, 0x48014770, 0x46c04770, 0x000070d0,
+    0x000001d6, 0x4601b570, 0x447a4a0e, 0x28017810, 0x2301d10e, 0x2400071d, 0x46261b48, 0x42a94166,
+    0x68d5d308, 0x041a0319, 0x47a823d8, 0xbd704620, 0xbd702001, 0x44784804, 0x4a042121, 0xf000447a,
+    0x46c0f855, 0x000001b6, 0x00000126, 0x00000164, 0xb081b5f0, 0x4d10460b, 0x7829447d, 0xd10f2901,
+    0x070e2101, 0x1b812400, 0x41674627, 0xd30b42b0, 0x4608692d, 0x461a4611, 0x462047a8, 0xbdf0b001,
+    0x46202401, 0xbdf0b001, 0x44784804, 0x4a042121, 0xf000447a, 0x46c0f82b, 0x00000168, 0x000000d2,
+    0x00000120, 0xd4d4de00, 0x2114b280, 0x1e898809, 0x2a00884a, 0x1d09d004, 0xd1f94282, 0x47708808,
+    0x44784803, 0x4a03210e, 0xf000447a, 0x46c0f80f, 0x00000076, 0x000000c8, 0xd4d44770, 0x49024801,
+    0x46c04770, 0x4d94efcf, 0x7847d224, 0xaf00b580, 0x2300b088, 0x4c079305, 0x93039404, 0x23019302,
+    0xab069301, 0x91079300, 0x46689006, 0xf0004611, 0xdefef803, 0x00000244, 0xaf00b580, 0x9103b084,
+    0x48049002, 0x48049001, 0x46689000, 0xffbaf7ff, 0x46c0defe, 0x00000244, 0x00000244, 0x636e7546,
+    0x746f6e20, 0x756f6620, 0x7273646e, 0x616d2f63, 0x722e6e69, 0xd4d4d473, 0xd4d4d4d4, 0xd4d4d4d4,
+    0x65747461, 0x2074706d, 0x73206f74, 0x72746275, 0x20746361, 0x68746977, 0x65766f20, 0x6f6c6672,
+    0xd4d4d477, 0x00000199, 0x00000000, 0x00000001, 0x0000019d, 0x0000020a, 0x0000000b, 0x00000014,
+    0x00000011, 0x0000020a, 0x0000000b, 0x00000053, 0x00000028, 0x0000020a, 0x0000000b, 0x00000058,
+    0x0000002a, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000
+    ],
+
+    # Relative function addresses
+    'pc_init': 0x20000005,
+    'pc_unInit': 0x20000089,
+    'pc_program_page': 0x20000115,
+    'pc_erase_sector': 0x200000c9,
+    # 'pc_eraseAll': 0x200000ad, # not implemented yet
+
+    'static_base' : 0x20000000 + 0x00000004 + 0x00000254,
+    'begin_stack' : 0x20000500,
+    'begin_data' : 0x20000000 + 0x1000,
+    'page_size' : 0x0,
+    'analyzer_supported' : False,
+    'analyzer_address' : 0x00000000,
+    'page_buffers' : [0x20001000, 0x20001100],   # Enable double buffering
+    'min_program_length' : 256,
+
+    # Relative region addresses and sizes
+    'ro_start': 0x0,
+    'ro_size': 0x254,
+    'rw_start': 0x254,
+    'rw_size': 0x30,
+    'zi_start': 0x284,
+    'zi_size': 0x1c,
+}
+
+def _parity32(value):
+    parity = sum((value >> i) for i in range(32))
+    return parity & 1
+
+class RP2040Base(CoreSightTarget):
+    """! @brief Raspberry Pi RP2040.
+    
+    This device is very strange in that it as three DPs. The first two DPs each have a single AHB-AP
+    for the two Cortex-M0+ cores. The third DP is a "Rescue DP" that has no APs, but the CDBGPWRUPREQ
+    signal is repurposed as a rescue signal.
+    """
+    
+    class Targetsel:
+        """! @brief DP TARGETEL values for each DP."""
+        CORE_0 = 0x01002927
+        CORE_1 = 0x11002927
+        RESCUE_DP = 0xf1002927
+
+    VENDOR = "Raspberry Pi"
+    
+    MEMORY_MAP = MemoryMap(
+        RomRegion(  start=0,            length=0x4000,      name="bootrom",             ),
+        FlashRegion(start=0x10000000,   length=0x1000000,   name="xip",                 
+            sector_size=4096,
+            page_size=256,
+            algo=FLASH_ALGO,
+            is_boot_memory=True),
+        RomRegion(  start=0x11000000,   length=0x1000000,   name="xip_noalloc",           alias="xip"),
+        RomRegion(  start=0x12000000,   length=0x1000000,   name="xip_nocache",           alias="xip"),
+        RomRegion(  start=0x13000000,   length=0x1000000,   name="xip_noalloc_nocache",   alias="xip"),
+        RamRegion(  start=0x20000000,   length=0x40000,     name="sram0_3",               ),
+        RamRegion(  start=0x20040000,   length=0x2000,      name="sram4_5",               ),
+        RamRegion(  start=0x21000000,   length=0x40000,     name="sram0_3_alias",         alias="sram0_3"),
+        RamRegion(  start=0x51000000,   length=0x1000,      name="usbram",                ),
+        )
+
+    def __init__(self, session):
+        super().__init__(session, self.MEMORY_MAP)
+
+        ## The TARGETSEL value to be used.
+        self._core_targetsel = None
+
+        # Disable the SWJ sequence. This performs a line reset, which causes all DPs to be selected. After
+        # any line reset on a multi-drop SWD setup there must be a target selection sequence.
+        session.options['dap_swj_enable'] = False
+
+    def create_init_sequence(self):
+        seq = super().create_init_sequence()
+        
+        seq.insert_before('load_svd', ('check_probe', self._check_probe)) \
+            .insert_before('dp_init', ('select_core0', self._select_core))
+
+        return seq
+    
+    def _check_probe(self):
+        # Have to import here to avoid a circular import
+        from ...probe.debug_probe import DebugProbe
+        if DebugProbe.Capability.SWD_SEQUENCE not in self.session.probe.capabilities:
+            raise exceptions.TargetSupportError("RP2040 requires a debug probe with SWD sequence capability")
+
+    def _select_core(self):
+        self.select_dp(self._core_targetsel)
+
+    def select_dp(self, targetsel):
+        """! @brief Select the DP with the matching TARGETSEL."""
+        probe = self.session.probe
+        
+        # Have to connect the probe first, or SWCLK will not be enabled.
+        probe.connect(DebugProbe.Protocol.SWD)
+
+        # First perform the dormant to SWD sequence. An SW-DPv2 implementing multi-drop SWD will cold
+        # reset into dormant mode.
+        swj = SWJSequenceSender(self.session.probe, True)
+        swj.dormant_to_swd()
+
+        # SWD line reset to activate all DPs.
+        swj.line_reset()
+        swj.idle_cycles(2)
+        
+        # Send multi-drop SWD target selection sequence to select the requested DP.
+        probe.swd_sequence([
+            # DP TARGETSEL write
+            # output 8 cycles:
+            #   - Start = 1
+            #   - APnDP = 0
+            #   - RnW = 0
+            #   - A[2:3] = 2'b11
+            #   - Parity = 0
+            #   - Stop = 0
+            #   - Park = 1
+            # -> LSB first, that's 0b10011001 or 0x99
+            (8, 0x99),
+            
+            # 5 cycles with SWDIO as input
+            (5,),
+            
+            # DP TARGETSEL value
+            # output 32 + 1 cycles
+            (33, targetsel | mask.parity32_high(targetsel)),
+
+            # 2 idle cycles
+            (2, 0x00),
+            ])
+
+        DP_IDR = 0x00
+        dpidr = probe.read_dp(DP_IDR)
+        LOG.debug("DP IDR after writing TARGETSEL: 0x%08x", dpidr)
+        
+        probe.write_dp(0x8, 0x2) # DPBANKSEL=2 to select TARGETID
+        targetid = probe.read_dp(0x4)
+        LOG.debug("DP TARGETID: 0x%08x", targetid)
+        
+        probe.write_dp(0x8, 0x3) # DPBANKSEL=3 to select DLPIDR
+        dlpidr = probe.read_dp(0x4)
+        LOG.debug("DP DLPIDR: 0x%08x", dlpidr)
+        
+        probe.write_dp(0x8, 0x0) # restore DPBANKSEL=0
+
+class RP2040Core0(RP2040Base):
+    """! @brief RP2040 target for core 0."""
+
+    def __init__(self, session):
+        super().__init__(session)
+        self._core_targetsel = self.Targetsel.CORE_0
+
+class RP2040Core1(RP2040Base):
+    """! @brief RP2040 target for core 1."""
+    
+    def __init__(self, session):
+        super().__init__(session)
+        self._core_targetsel = self.Targetsel.CORE_1
+

--- a/pyocd/target/builtin/target_RP2040.py
+++ b/pyocd/target/builtin/target_RP2040.py
@@ -18,10 +18,10 @@ import logging
 
 from ...core import exceptions
 from ...coresight.coresight_target import CoreSightTarget
-from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, DeviceRegion, MemoryMap)
+from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 from ...probe.swj import SWJSequenceSender
 from ...probe.debug_probe import DebugProbe
-from ...utility import (conversion, mask)
+from ...utility import mask
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -150,3 +150,18 @@ def round_up_div(value, divisor):
     """! @brief Return value divided by the divisor, rounding up to the nearest multiple of the divisor."""
     return (value + divisor - 1) // divisor
 
+def parity32_high(n):
+    """! @brief Compute parity over a 32-bit value.
+
+    This function is intended to be used for computing parity over a 32-bit value transferred in an Arm
+    ADI AP/DP register transfer. The result is returned in bit 32, ready to be OR'd into the register
+    value to form the 33-bit data + parity for the AP/DP register transfer.
+
+    @param n 32-bit integer.
+    @return Integer with 1-bit parity placed at bit 32. The lower 32 bits are 0.
+    """
+    n ^= n >> 16
+    n ^= n >> 8
+    n ^= n >> 4
+    n &= 0xf
+    return (0xD32C0000 << n) & (1 << 32)

--- a/scripts/generate_flash_algo.py
+++ b/scripts/generate_flash_algo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # pyOCD debugger
-# Copyright (c) 2011-2020 Arm Limited
+# Copyright (c) 2011-2021 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -26,14 +26,14 @@ from pyocd.target.pack.flash_algo import PackFlashAlgo
 
 # TODO
 # FIXED LENGTH - remove and these (shrink offset to 4 for bkpt only)
-BLOB_HEADER = '0xE00ABE00, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,'
-HEADER_SIZE = 0x20
+BLOB_HEADER = '0xe00abe00,' #, 0x062D780D, 0x24084068, 0xD3000040, 0x1E644058, 0x1C49D1FA, 0x2A001E52, 0x4770D1F2,'
+HEADER_SIZE = 4 #0x20
 
 STACK_SIZE = 0x200
 
 PYOCD_TEMPLATE = \
 """# pyOCD debugger
-# Copyright (c) 2017-2020 Arm Limited
+# Copyright (c) 2017-2021 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -48,7 +48,7 @@ PYOCD_TEMPLATE = \
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FLASH_ALGO_{{name|upper}} = {
+FLASH_ALGO = {
     'load_address' : {{'0x%08x' % entry}},
 
     # Flash algorithm as a hex string
@@ -90,6 +90,7 @@ FLASH_ALGO_{{name|upper}} = {
     {%- endfor %}
     )
 }
+
 """
 
 def str_to_num(val):
@@ -119,7 +120,7 @@ class PackFlashAlgoGenerator(PackFlashAlgo):
         if fmt == "hex":
             blob = binascii.b2a_hex(self.algo_data)
             line_list = []
-            for i in xrange(0, len(blob), group_size):
+            for i in range(0, len(blob), group_size):
                 line_list.append('"' + blob[i:i + group_size] + '"')
             return ("\n" + padding).join(line_list)
         elif fmt == "c":
@@ -166,7 +167,7 @@ def main():
     parser.add_argument("elf_path", help="Elf, axf, or flm to extract "
                         "flash algo from")
     parser.add_argument("--blob_start", default=0x20000000, type=str_to_num, help="Starting "
-                        "address of the flash blob. Used only for DAPLink.")
+                        "address of the flash blob.")
     args = parser.parse_args()
 
     with open(args.elf_path, "rb") as file_handle:

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ setup(
         'pyocd.probe': [
             'cmsisdap = pyocd.probe.cmsis_dap_probe:CMSISDAPProbePlugin',
             'jlink = pyocd.probe.jlink_probe:JLinkProbePlugin',
+            'picoprobe = pyocd.probe.picoprobe:PicoprobePlugin',
             'remote = pyocd.probe.tcp_client_probe:TCPClientProbePlugin',
             'stlink = pyocd.probe.stlink_probe:StlinkProbePlugin',
         ],

--- a/udev/50-picoprobe.rules
+++ b/udev/50-picoprobe.rules
@@ -1,0 +1,8 @@
+# 2e8a:0004 Raspberry Pi picoprobe
+# https://github.com/raspberrypi/picoprobe
+SUBSYSTEM=="usb", ATTR{idVendor}=="2e8a", ATTR{idProduct}=="0004", MODE:="666"
+
+# If you share your linux system with other users, or just don't like the
+# idea of write permission for everybody, you can replace MODE:="0666" with
+# OWNER:="yourusername" to create the device owned by you, or with
+# GROUP:="somegroupname" and mange access using standard unix groups.


### PR DESCRIPTION
This PR includes a number of changes and additions.

Major changes:
- RP2040 targets: `rp2040_core0`, `rp2040_core1`, `rp2040` (alias for core 0). Only one core can be accessed at a time for now, pending full multi-drop SWD support.
- [picoprobe](https://github.com/raspberrypi/picoprobe) support thanks to @newbrain.

Other changes:
- The CMSIS-DAP protocol version is read.
- Added `jtag_sequence()` debug probe API.
- Added `swd_sequence()` debug probe API.
- Refactored the `SWJSequenceSender` class to allow sending fragments of sequences and perform any single step of the SWD <—> dormant <—> JTAG transitions.
- Flash algo generation improvements, used to generate the RP2040 flash algo from  https://github.com/rp-rs/flash-algo.
