### PR TITLE
J-Link cleanup of DP_SELECT handling

### DIFF
--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -260,6 +260,7 @@ class DebugPort(object):
         self._probe_managed_ap_select = False
         self._probe_managed_dpbanksel = False
         self._probe_supports_dpbanksel = False
+        self._probe_supports_apv2_addresses = False
         self._have_probe_capabilities = False
         self._did_check_version = False
         
@@ -366,6 +367,7 @@ class DebugPort(object):
         self._probe_managed_ap_select = (DebugProbe.Capability.MANAGED_AP_SELECTION in caps)
         self._probe_managed_dpbanksel = (DebugProbe.Capability.MANAGED_DPBANKSEL in caps)
         self._probe_supports_dpbanksel = (DebugProbe.Capability.BANKED_DP_REGISTERS in caps)
+        self._probe_supports_apv2_addresses = (DebugProbe.Capability.APv2_ADDRESSES in caps)
         self._have_probe_capabilities = True
 
     def _connect(self):
@@ -381,6 +383,10 @@ class DebugPort(object):
     def _check_version(self):
         self._is_dpv3 = (self.dpidr.version == 3)
         if self._is_dpv3:
+            # Check that the probe will be able to access ADIv6 APs.
+            if self._probe_managed_ap_select and not self._probe_supports_apv2_addresses:
+                raise exceptions.ProbeError("connected to ADIv6 target with probe that does not support APv2 addresses")
+            
             idr1 = self.read_reg(DP_IDR1)
             
             self._addr_size = idr1 & DPIDR1_ASIZE_MASK

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -598,6 +598,8 @@ class DebugPort(object):
             return False
 
     def read_dp(self, addr, now=True):
+        if (addr & DPADDR_MASK) % 4 != 0:
+            raise ValueError("DP address must be word aligned")
         num = self.next_access_number
         
         # Update DPBANKSEL if required.
@@ -636,6 +638,8 @@ class DebugPort(object):
             return read_dp_cb
 
     def write_dp(self, addr, data):
+        if (addr & DPADDR_MASK) % 4 != 0:
+            raise ValueError("DP address must be word aligned")
         num = self.next_access_number
         
         # Update DPBANKSEL if required.

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -45,9 +45,16 @@ class DebugProbe(object):
         SWO = 1
 
         ## @brief Whether the probe can access banked DP registers.
+        #
+        # Currently only used to verify that the probe supports banked DP registers when the #MANAGED_DPBANKSEL
+        # capability is present.
         BANKED_DP_REGISTERS = 2
         
         ## @brief Whether the probe can access APv2 registers.
+        #
+        # This capability is currently only used to verify that a probe with the #MANAGED_AP_SELECTION capability
+        # can support the wider AP addresses used in version 2 APs. For probes without #MANAGED_AP_SELECTION,
+        # DP_SELECT is written directly by the DAP layer when selecting an AP.
         APv2_ADDRESSES = 3
         
         ## @brief Whether the probe automatically handles AP selection in the DP.

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +17,14 @@
 
 import six
 import logging
-import pylink
 from time import sleep
+import pylink
 from pylink.errors import (JLinkException, JLinkWriteException, JLinkReadException)
 
 from .debug_probe import DebugProbe
 from ..core import (exceptions, memory_interface)
 from ..core.plugin import Plugin
 from ..core.options import OptionInfo
-from ..core.target import Target
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Remove the handling of the `DP_SELECT` register in `JLinkProbe`. This is now fully managed by the `DebugPort` class. 

Added a check in `DebugPort` that the probe can support the larger AP addresses used in ADIv6, for the case where the probe manages AP selection itself.

Also tossed in a check that register addresses passed to the `DebugPort` DP register r/w methods are word aligned.