### PR TITLE
Update of HDSC MCU.

### DIFF
--- a/pyocd/debug/svd/data/HC32F160.svd
+++ b/pyocd/debug/svd/data/HC32F160.svd
@@ -1,0 +1,20358 @@
+<?xml version="1.0" ?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
+    <vendor>HDSC Co.,Ltd.</vendor>
+    <vendorID>HDSC</vendorID>
+    <name>HDSC_HC32F160</name>
+    <series>ARMCM0P</series>
+    <version>1.0</version>
+    <cpu>
+        <name>CM0P</name>
+        <revision>r0p1</revision>
+        <endian>little</endian>
+        <mpuPresent>true</mpuPresent>
+        <fpuPresent>true</fpuPresent>
+        <nvicPrioBits>4</nvicPrioBits>
+        <vendorSystickConfig>false</vendorSystickConfig>
+    </cpu>
+    <addressUnitBits>8</addressUnitBits>
+    <width>32</width>
+    <size>32</size>
+    <access>read-write</access>
+    <resetValue>0x0</resetValue>
+    <resetMask>0x0</resetMask>
+    <peripherals>
+        <peripheral>
+            <name>ADC</name>
+            <description>desc ADC</description>
+            <baseAddress>0x4000B800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0xB1</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>STR</name>
+                    <description>desc STR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>STRT</name>
+                            <description>desc STRT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR0</name>
+                    <description>desc CR0</description>
+                    <addressOffset>0x2</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF3</resetMask>
+                    <fields>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ACCSEL</name>
+                            <description>desc ACCSEL</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLREN</name>
+                            <description>desc CLREN</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DFMT</name>
+                            <description>desc DFMT</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x4</resetMask>
+                    <fields>
+                        <field>
+                            <name>RSCHSEL</name>
+                            <description>desc RSCHSEL</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>TRGSR</name>
+                    <description>desc TRGSR</description>
+                    <addressOffset>0xA</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x8383</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSELA</name>
+                            <description>desc TRGSELA</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TRGENA</name>
+                            <description>desc TRGENA</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TRGSELB</name>
+                            <description>desc TRGSELB</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TRGENB</name>
+                            <description>desc TRGENB</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CHSELRA0</name>
+                    <description>desc CHSELRA0</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3FFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CHSELA</name>
+                            <description>desc CHSELA</description>
+                            <msb>13</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CHSELRB0</name>
+                    <description>desc CHSELRB0</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3FFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CHSELB</name>
+                            <description>desc CHSELB</description>
+                            <msb>13</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EXCHSELR</name>
+                    <description>desc EXCHSELR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>EXCHSEL</name>
+                            <description>desc EXCHSEL</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SSTR</name>
+                    <description>desc SSTR</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0xB</resetValue>
+                    <resetMask>0xFF</resetMask>
+                </register>
+                <register>
+                    <name>ISR</name>
+                    <description>desc ISR</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EOCAF</name>
+                            <description>desc EOCAF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>EOCBF</name>
+                            <description>desc EOCBF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICR</name>
+                    <description>desc ICR</description>
+                    <addressOffset>0x45</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x3</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EOCAIEN</name>
+                            <description>desc EOCAIEN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EOCBIEN</name>
+                            <description>desc EOCBIEN</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISCLRR</name>
+                    <description>desc ISCLRR</description>
+                    <addressOffset>0x46</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CLREOCAF</name>
+                            <description>desc CLREOCAF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CLREOCBF</name>
+                            <description>desc CLREOCBF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR0</name>
+                    <description>desc DR0</description>
+                    <addressOffset>0x50</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR1</name>
+                    <description>desc DR1</description>
+                    <addressOffset>0x52</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR2</name>
+                    <description>desc DR2</description>
+                    <addressOffset>0x54</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR3</name>
+                    <description>desc DR3</description>
+                    <addressOffset>0x56</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR4</name>
+                    <description>desc DR4</description>
+                    <addressOffset>0x58</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR5</name>
+                    <description>desc DR5</description>
+                    <addressOffset>0x5A</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR6</name>
+                    <description>desc DR6</description>
+                    <addressOffset>0x5C</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR7</name>
+                    <description>desc DR7</description>
+                    <addressOffset>0x5E</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR8</name>
+                    <description>desc DR8</description>
+                    <addressOffset>0x60</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR9</name>
+                    <description>desc DR9</description>
+                    <addressOffset>0x62</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR10</name>
+                    <description>desc DR10</description>
+                    <addressOffset>0x64</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DR11</name>
+                    <description>desc DR11</description>
+                    <addressOffset>0x66</addressOffset>
+                    <size>16</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AWDCR</name>
+                    <description>desc AWDCR</description>
+                    <addressOffset>0xA0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x377</resetMask>
+                    <fields>
+                        <field>
+                            <name>AWD0EN</name>
+                            <description>desc AWD0EN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWD0IEN</name>
+                            <description>desc AWD0IEN</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWD0MD</name>
+                            <description>desc AWD0MD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWD1EN</name>
+                            <description>desc AWD1EN</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWD1IEN</name>
+                            <description>desc AWD1IEN</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWD1MD</name>
+                            <description>desc AWD1MD</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AWDCM</name>
+                            <description>desc AWDCM</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>AWDSR</name>
+                    <description>desc AWDSR</description>
+                    <addressOffset>0xA2</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13</resetMask>
+                    <fields>
+                        <field>
+                            <name>AWD0F</name>
+                            <description>desc AWD0F</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>AWD1F</name>
+                            <description>desc AWD1F</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>AWDCMF</name>
+                            <description>desc AWDCMF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>AWDSCLRR</name>
+                    <description>desc AWDSCLRR</description>
+                    <addressOffset>0xA3</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13</resetMask>
+                    <fields>
+                        <field>
+                            <name>CLRAWD0F</name>
+                            <description>desc CLRAWD0F</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CLRAWD1F</name>
+                            <description>desc CLRAWD1F</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CLRAWDCMF</name>
+                            <description>desc CLRAWDCMF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>AWD0DR0</name>
+                    <description>desc AWD0DR0</description>
+                    <addressOffset>0xA4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AWD0DR1</name>
+                    <description>desc AWD0DR1</description>
+                    <addressOffset>0xA6</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AWD0CHSR</name>
+                    <description>desc AWD0CHSR</description>
+                    <addressOffset>0xA8</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>AWDCH</name>
+                            <description>desc AWDCH</description>
+                            <msb>4</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>AWD1DR0</name>
+                    <description>desc AWD1DR0</description>
+                    <addressOffset>0xAC</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AWD1DR1</name>
+                    <description>desc AWD1DR1</description>
+                    <addressOffset>0xAE</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AWD1CHSR</name>
+                    <description>desc AWD1CHSR</description>
+                    <addressOffset>0xB0</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>AWDCH</name>
+                            <description>desc AWDCH</description>
+                            <msb>4</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>AOS</name>
+            <description>desc AOS</description>
+            <baseAddress>0x40000C00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x88</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>INTC_STRGCR</name>
+                    <description>desc INTC_STRGCR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>STRG</name>
+                            <description>desc STRG</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>TMR0_HTSSR</name>
+                    <description>desc TMR0_HTSSR</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>TMRB_HTSSR</name>
+                    <description>desc TMRB_HTSSR</description>
+                    <addressOffset>0x50</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ADC_ITRGSELR0</name>
+                    <description>desc ADC_ITRGSELR0</description>
+                    <addressOffset>0x60</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ADC_ITRGSELR1</name>
+                    <description>desc ADC_ITRGSELR1</description>
+                    <addressOffset>0x64</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DMA0_TRGSEL</name>
+                    <description>desc DMA0_TRGSEL</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DMA1_TRGSEL</name>
+                    <description>desc DMA1_TRGSEL</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7F</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>CMU</name>
+            <description>desc CMU</description>
+            <baseAddress>0x40014400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x3D</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>PERICKSEL</name>
+                    <description>desc PERICKSEL</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>PERICKSEL</name>
+                            <description>desc PERICKSEL</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTALSTDSR</name>
+                    <description>desc XTALSTDSR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTDF</name>
+                            <description>desc XTALSTDF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SCKDIVR</name>
+                    <description>desc SCKDIVR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>SCKDIV</name>
+                            <description>desc SCKDIV</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CKSWR</name>
+                    <description>desc CKSWR</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CKSW</name>
+                            <description>desc CKSW</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTALCR</name>
+                    <description>desc XTALCR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTP</name>
+                            <description>desc XTALSTP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTALCFGR</name>
+                    <description>desc XTALCFGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x80</resetValue>
+                    <resetMask>0xF0</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALDRV</name>
+                            <description>desc XTALDRV</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>XTALMS</name>
+                            <description>desc XTALMS</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SUPDRV</name>
+                            <description>desc SUPDRV</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTALSTBCR</name>
+                    <description>desc XTALSTBCR</description>
+                    <addressOffset>0x15</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTB</name>
+                            <description>desc XTALSTB</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HRCCR</name>
+                    <description>desc HRCCR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>HRCSTP</name>
+                            <description>desc HRCSTP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>OSCSTBSR</name>
+                    <description>desc OSCSTBSR</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x19</resetMask>
+                    <fields>
+                        <field>
+                            <name>HRCSTBF</name>
+                            <description>desc HRCSTBF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>XTALSTBF</name>
+                            <description>desc XTALSTBF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>XTAL32STBF</name>
+                            <description>desc XTAL32STBF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>MCO1CFGR</name>
+                    <description>desc MCO1CFGR</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>MCO1SEL</name>
+                            <description>desc MCO1SEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MCO1DIV</name>
+                            <description>desc MCO1DIV</description>
+                            <msb>6</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MCO1EN</name>
+                            <description>desc MCO1EN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTALSTDCR</name>
+                    <description>desc XTALSTDCR</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x87</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTDIE</name>
+                            <description>desc XTALSTDIE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>XTALSTDRE</name>
+                            <description>desc XTALSTDRE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>XTALSTDRIS</name>
+                            <description>desc XTALSTDRIS</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>XTALSTDE</name>
+                            <description>desc XTALSTDE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FCG</name>
+                    <description>desc FCG</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0xFF81FFB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>ADC</name>
+                            <description>desc ADC</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTC</name>
+                            <description>desc CTC</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AOS</name>
+                            <description>desc AOS</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DMA</name>
+                            <description>desc DMA</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CRC</name>
+                            <description>desc CRC</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB1</name>
+                            <description>desc TIMB1</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB2</name>
+                            <description>desc TIMB2</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB3</name>
+                            <description>desc TIMB3</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB4</name>
+                            <description>desc TIMB4</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB5</name>
+                            <description>desc TIMB5</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB6</name>
+                            <description>desc TIMB6</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB7</name>
+                            <description>desc TIMB7</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIMB8</name>
+                            <description>desc TIMB8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TIM0</name>
+                            <description>desc TIM0</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTC</name>
+                            <description>desc RTC</description>
+                            <msb>23</msb>
+                            <lsb>23</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART1</name>
+                            <description>desc UART1</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART2</name>
+                            <description>desc UART2</description>
+                            <msb>25</msb>
+                            <lsb>25</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART3</name>
+                            <description>desc UART3</description>
+                            <msb>26</msb>
+                            <lsb>26</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART4</name>
+                            <description>desc UART4</description>
+                            <msb>27</msb>
+                            <lsb>27</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>IIC</name>
+                            <description>desc IIC</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SPI</name>
+                            <description>desc SPI</description>
+                            <msb>29</msb>
+                            <lsb>29</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART5</name>
+                            <description>desc UART5</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UART6</name>
+                            <description>desc UART6</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTAL32CR</name>
+                    <description>desc XTAL32CR</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTAL32STP</name>
+                            <description>desc XTAL32STP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTAL32CFGR</name>
+                    <description>desc XTAL32CFGR</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTAL32DRV</name>
+                            <description>desc XTAL32DRV</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>XTAL32NFR</name>
+                    <description>desc XTAL32NFR</description>
+                    <addressOffset>0x39</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTAL32NF</name>
+                            <description>desc XTAL32NF</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>LRCCR</name>
+                    <description>desc LRCCR</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>LRCSTP</name>
+                            <description>desc LRCSTP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>CRC</name>
+            <description>desc CRC</description>
+            <baseAddress>0x40015400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x100</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CR</name>
+                    <description>desc CR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1C</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CR</name>
+                            <description>desc CR</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FLAG</name>
+                            <description>desc FLAG</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>RESLT</name>
+                    <description>desc RESLT</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x7800</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT0</name>
+                    <description>desc DAT0</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT1</name>
+                    <description>desc DAT1</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT2</name>
+                    <description>desc DAT2</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT3</name>
+                    <description>desc DAT3</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT4</name>
+                    <description>desc DAT4</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT5</name>
+                    <description>desc DAT5</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT6</name>
+                    <description>desc DAT6</description>
+                    <addressOffset>0x98</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT7</name>
+                    <description>desc DAT7</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT8</name>
+                    <description>desc DAT8</description>
+                    <addressOffset>0xA0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT9</name>
+                    <description>desc DAT9</description>
+                    <addressOffset>0xA4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT10</name>
+                    <description>desc DAT10</description>
+                    <addressOffset>0xA8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT11</name>
+                    <description>desc DAT11</description>
+                    <addressOffset>0xAC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT12</name>
+                    <description>desc DAT12</description>
+                    <addressOffset>0xB0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT13</name>
+                    <description>desc DAT13</description>
+                    <addressOffset>0xB4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT14</name>
+                    <description>desc DAT14</description>
+                    <addressOffset>0xB8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT15</name>
+                    <description>desc DAT15</description>
+                    <addressOffset>0xBC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT16</name>
+                    <description>desc DAT16</description>
+                    <addressOffset>0xC0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT17</name>
+                    <description>desc DAT17</description>
+                    <addressOffset>0xC4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT18</name>
+                    <description>desc DAT18</description>
+                    <addressOffset>0xC8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT19</name>
+                    <description>desc DAT19</description>
+                    <addressOffset>0xCC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT20</name>
+                    <description>desc DAT20</description>
+                    <addressOffset>0xD0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT21</name>
+                    <description>desc DAT21</description>
+                    <addressOffset>0xD4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT22</name>
+                    <description>desc DAT22</description>
+                    <addressOffset>0xD8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT23</name>
+                    <description>desc DAT23</description>
+                    <addressOffset>0xDC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT24</name>
+                    <description>desc DAT24</description>
+                    <addressOffset>0xE0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT25</name>
+                    <description>desc DAT25</description>
+                    <addressOffset>0xE4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT26</name>
+                    <description>desc DAT26</description>
+                    <addressOffset>0xE8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT27</name>
+                    <description>desc DAT27</description>
+                    <addressOffset>0xEC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT28</name>
+                    <description>desc DAT28</description>
+                    <addressOffset>0xF0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT29</name>
+                    <description>desc DAT29</description>
+                    <addressOffset>0xF4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT30</name>
+                    <description>desc DAT30</description>
+                    <addressOffset>0xF8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAT31</name>
+                    <description>desc DAT31</description>
+                    <addressOffset>0xFC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>CTC</name>
+            <description>desc CTC</description>
+            <baseAddress>0x40000000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F37F7</resetMask>
+                    <fields>
+                        <field>
+                            <name>REFPSC</name>
+                            <description>desc REFPSC</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>REFCKS</name>
+                            <description>desc REFCKS</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ERRIE</name>
+                            <description>desc ERRIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTCEN</name>
+                            <description>desc CTCEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HRCPSC</name>
+                            <description>desc HRCPSC</description>
+                            <msb>10</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>REFEDG</name>
+                            <description>desc REFEDG</description>
+                            <msb>13</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TRMVAL</name>
+                            <description>desc TRMVAL</description>
+                            <msb>21</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF00FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>OFSVAL</name>
+                            <description>desc OFSVAL</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RLDVAL</name>
+                            <description>desc RLDVAL</description>
+                            <msb>31</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STR</name>
+                    <description>desc STR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRIMOK</name>
+                            <description>desc TRIMOK</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TRMOVF</name>
+                            <description>desc TRMOVF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TRMUDF</name>
+                            <description>desc TRMUDF</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>CTCBSY</name>
+                            <description>desc CTCBSY</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CNT</name>
+                    <description>desc CNT</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CTCCNT</name>
+                            <description>desc CTCCNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>DBGC</name>
+            <description>desc DBGC</description>
+            <baseAddress>0x40015000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x8</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>MCUDBGSTAT</name>
+                    <description>desc MCUDBGSTAT</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CDBGPWRUPREQ</name>
+                            <description>desc CDBGPWRUPREQ</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CDBGPWRUPACK</name>
+                            <description>desc CDBGPWRUPACK</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>MCUSTPCTL</name>
+                    <description>desc MCUSTPCTL</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xFF00400D</resetMask>
+                    <fields>
+                        <field>
+                            <name>SWDTSTP</name>
+                            <description>desc SWDTSTP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTCSTP</name>
+                            <description>desc RTCSTP</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PVDSTP</name>
+                            <description>desc PVDSTP</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMR01STP</name>
+                            <description>desc TMR01STP</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB1STP</name>
+                            <description>desc TMRB1STP</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB2STP</name>
+                            <description>desc TMRB2STP</description>
+                            <msb>25</msb>
+                            <lsb>25</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB3STP</name>
+                            <description>desc TMRB3STP</description>
+                            <msb>26</msb>
+                            <lsb>26</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB4STP</name>
+                            <description>desc TMRB4STP</description>
+                            <msb>27</msb>
+                            <lsb>27</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB5STP</name>
+                            <description>desc TMRB5STP</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB6STP</name>
+                            <description>desc TMRB6STP</description>
+                            <msb>29</msb>
+                            <lsb>29</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB7STP</name>
+                            <description>desc TMRB7STP</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMRB8STP</name>
+                            <description>desc TMRB8STP</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>DBGC_T</name>
+            <description>desc DBGC_T</description>
+            <baseAddress>0xE0042000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x1C</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>AUTHID0</name>
+                    <description>desc AUTHID0</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AUTHID1</name>
+                    <description>desc AUTHID1</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>AUTHID2</name>
+                    <description>desc AUTHID2</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>RESV0</name>
+                    <description>desc RESV0</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>MCUSTAT</name>
+                    <description>desc MCUSTAT</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30F</resetMask>
+                    <fields>
+                        <field>
+                            <name>AUTH</name>
+                            <description>desc AUTH</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>REMVLOCK</name>
+                            <description>desc REMVLOCK</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SAFTYLOCK1</name>
+                            <description>desc SAFTYLOCK1</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SAFTYLOCK2</name>
+                            <description>desc SAFTYLOCK2</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MCUSTAT0</name>
+                            <description>desc MCUSTAT0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MCUSTAT1</name>
+                            <description>desc MCUSTAT1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>MCUCTL</name>
+                    <description>desc MCUCTL</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x103</resetMask>
+                    <fields>
+                        <field>
+                            <name>EDBGRQ</name>
+                            <description>desc EDBGRQ</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RESTART</name>
+                            <description>desc RESTART</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIRQ</name>
+                            <description>desc DIRQ</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FMCCTL</name>
+                    <description>desc FMCCTL</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>ERASEREQ</name>
+                            <description>desc ERASEREQ</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ERASEACK</name>
+                            <description>desc ERASEACK</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ERASEERR</name>
+                            <description>desc ERASEERR</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>DMA</name>
+            <description>desc DMA</description>
+            <baseAddress>0x40013000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x90</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>EN</name>
+                    <description>desc EN</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>EN</name>
+                            <description>desc EN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTSTAT0</name>
+                    <description>desc INTSTAT0</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRNERR</name>
+                            <description>desc TRNERR</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>REQERR</name>
+                            <description>desc REQERR</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTSTAT1</name>
+                    <description>desc INTSTAT1</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>BTC</name>
+                            <description>desc BTC</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTMASK0</name>
+                    <description>desc INTMASK0</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>MSKTRNERR</name>
+                            <description>desc MSKTRNERR</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MSKREQERR</name>
+                            <description>desc MSKREQERR</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTMASK1</name>
+                    <description>desc INTMASK1</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>MSKTC</name>
+                            <description>desc MSKTC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MSKBTC</name>
+                            <description>desc MSKBTC</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTCLR0</name>
+                    <description>desc INTCLR0</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>CLRTRNERR</name>
+                            <description>desc CLRTRNERR</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CLRREQERR</name>
+                            <description>desc CLRREQERR</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>INTCLR1</name>
+                    <description>desc INTCLR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30003</resetMask>
+                    <fields>
+                        <field>
+                            <name>CLRTC</name>
+                            <description>desc CLRTC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CLRBTC</name>
+                            <description>desc CLRBTC</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CHEN</name>
+                    <description>desc CHEN</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CHEN</name>
+                            <description>desc CHEN</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CHSTAT</name>
+                    <description>desc CHSTAT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x30001</resetMask>
+                    <fields>
+                        <field>
+                            <name>DMAACT</name>
+                            <description>desc DMAACT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>CHACT</name>
+                            <description>desc CHACT</description>
+                            <msb>17</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BASE1_LLP</name>
+                    <description>desc BASE1_LLP</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x20000000</resetValue>
+                    <resetMask>0xFFFFC000</resetMask>
+                    <fields>
+                        <field>
+                            <name>LLP</name>
+                            <description>desc LLP</description>
+                            <msb>31</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BASE2_LLP</name>
+                    <description>desc BASE2_LLP</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFC000</resetMask>
+                    <fields>
+                        <field>
+                            <name>LLP</name>
+                            <description>desc LLP</description>
+                            <msb>31</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CHENCLR</name>
+                    <description>desc CHENCLR</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>CHENCLR</name>
+                            <description>desc CHENCLR</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SAR0</name>
+                    <description>desc SAR0</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAR0</name>
+                    <description>desc DAR0</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>CH0CTL0</name>
+                    <description>desc CH0CTL0</description>
+                    <addressOffset>0x48</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>BLKSIZE</name>
+                            <description>desc BLKSIZE</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>17</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLP</name>
+                            <description>desc LLP</description>
+                            <msb>27</msb>
+                            <lsb>18</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPEN</name>
+                            <description>desc LLPEN</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPRUN</name>
+                            <description>desc LLPRUN</description>
+                            <msb>29</msb>
+                            <lsb>29</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSIZE</name>
+                            <description>desc HSIZE</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CH0CTL1</name>
+                    <description>desc CH0CTL1</description>
+                    <addressOffset>0x4C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>OFFSET</name>
+                            <description>desc OFFSET</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSCNT</name>
+                            <description>desc RPTNSCNT</description>
+                            <msb>23</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSEN</name>
+                            <description>desc RPTNSEN</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSSEL</name>
+                            <description>desc RPTNSSEL</description>
+                            <msb>26</msb>
+                            <lsb>25</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPSEL</name>
+                            <description>desc LLPSEL</description>
+                            <msb>27</msb>
+                            <lsb>27</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SINC</name>
+                            <description>desc SINC</description>
+                            <msb>29</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DINC</name>
+                            <description>desc DINC</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SAR1</name>
+                    <description>desc SAR1</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>DAR1</name>
+                    <description>desc DAR1</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>CH1CTL0</name>
+                    <description>desc CH1CTL0</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>BLKSIZE</name>
+                            <description>desc BLKSIZE</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>17</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLP</name>
+                            <description>desc LLP</description>
+                            <msb>27</msb>
+                            <lsb>18</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPEN</name>
+                            <description>desc LLPEN</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPRUN</name>
+                            <description>desc LLPRUN</description>
+                            <msb>29</msb>
+                            <lsb>29</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSIZE</name>
+                            <description>desc HSIZE</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CH1CTL1</name>
+                    <description>desc CH1CTL1</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>OFFSET</name>
+                            <description>desc OFFSET</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSCNT</name>
+                            <description>desc RPTNSCNT</description>
+                            <msb>23</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSEN</name>
+                            <description>desc RPTNSEN</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPTNSSEL</name>
+                            <description>desc RPTNSSEL</description>
+                            <msb>26</msb>
+                            <lsb>25</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LLPSEL</name>
+                            <description>desc LLPSEL</description>
+                            <msb>27</msb>
+                            <lsb>27</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SINC</name>
+                            <description>desc SINC</description>
+                            <msb>29</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DINC</name>
+                            <description>desc DINC</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>EFM</name>
+            <description>desc EFM</description>
+            <baseAddress>0x40000800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x286</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>FAPRT</name>
+                    <description>desc FAPRT</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>FAPRT</name>
+                            <description>desc FAPRT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FSTP</name>
+                    <description>desc FSTP</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>FSTP</name>
+                            <description>desc FSTP</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FRMC</name>
+                    <description>desc FRMC</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0x20003</resetMask>
+                    <fields>
+                        <field>
+                            <name>FLWT</name>
+                            <description>desc FLWT</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PREFETE</name>
+                            <description>desc PREFETE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FWMC</name>
+                    <description>desc FWMC</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x10171</resetMask>
+                    <fields>
+                        <field>
+                            <name>PEMODE</name>
+                            <description>desc PEMODE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PEMOD</name>
+                            <description>desc PEMOD</description>
+                            <msb>6</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>BUSHLDCTL</name>
+                            <description>desc BUSHLDCTL</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ERCALE</name>
+                            <description>desc ERCALE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FSR</name>
+                    <description>desc FSR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x100</resetValue>
+                    <resetMask>0x17B</resetMask>
+                    <fields>
+                        <field>
+                            <name>PEWERR</name>
+                            <description>desc PEWERR</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PEPRTERR</name>
+                            <description>desc PEPRTERR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PGMISMTCH</name>
+                            <description>desc PGMISMTCH</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>OPTEND</name>
+                            <description>desc OPTEND</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>COLERR</name>
+                            <description>desc COLERR</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ERCAL</name>
+                            <description>desc ERCAL</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDY</name>
+                            <description>desc RDY</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FSCLR</name>
+                    <description>desc FSCLR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7B</resetMask>
+                    <fields>
+                        <field>
+                            <name>PEWERRCLR</name>
+                            <description>desc PEWERRCLR</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PEPRTERRCLR</name>
+                            <description>desc PEPRTERRCLR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PGMISMTCHCLR</name>
+                            <description>desc PGMISMTCHCLR</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OPTENDCLR</name>
+                            <description>desc OPTENDCLR</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COLERRCLR</name>
+                            <description>desc COLERRCLR</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ERCALCLR</name>
+                            <description>desc ERCALCLR</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FITE</name>
+                    <description>desc FITE</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>PEERRITE</name>
+                            <description>desc PEERRITE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OPTENDITE</name>
+                            <description>desc OPTENDITE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COLERRITE</name>
+                            <description>desc COLERRITE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FPMTSW</name>
+                    <description>desc FPMTSW</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3FFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>FPMTSW</name>
+                            <description>desc FPMTSW</description>
+                            <msb>17</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FPMTEW</name>
+                    <description>desc FPMTEW</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3FFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>FPMTEW</name>
+                            <description>desc FPMTEW</description>
+                            <msb>17</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>UQID0</name>
+                    <description>desc UQID0</description>
+                    <addressOffset>0x50</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>UQID1</name>
+                    <description>desc UQID1</description>
+                    <addressOffset>0x54</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>UQID2</name>
+                    <description>desc UQID2</description>
+                    <addressOffset>0x58</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFFFFFF</resetMask>
+                </register>
+                <register>
+                    <name>HRCCFGR</name>
+                    <description>desc HRCCFGR</description>
+                    <addressOffset>0x282</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>HRCFREQS</name>
+                            <description>desc HRCFREQS</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>LVDICGCR</name>
+                    <description>desc LVDICGCR</description>
+                    <addressOffset>0x284</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFF07</resetMask>
+                    <fields>
+                        <field>
+                            <name>DFS</name>
+                            <description>desc DFS</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DFDIS</name>
+                            <description>desc DFDIS</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LVDLVL</name>
+                            <description>desc LVDLVL</description>
+                            <msb>11</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NMIS</name>
+                            <description>desc NMIS</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>IRS</name>
+                            <description>desc IRS</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>IRDIS</name>
+                            <description>desc IRDIS</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LVDDIS</name>
+                            <description>desc LVDDIS</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>GPIO</name>
+            <description>desc GPIO</description>
+            <baseAddress>0x40013800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x5F</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>PIDR0</name>
+                    <description>desc PIDR0</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN5</name>
+                            <description>desc PIN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN6</name>
+                            <description>desc PIN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR1</name>
+                    <description>desc PIDR1</description>
+                    <addressOffset>0x1</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN5</name>
+                            <description>desc PIN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN6</name>
+                            <description>desc PIN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN7</name>
+                            <description>desc PIN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR2</name>
+                    <description>desc PIDR2</description>
+                    <addressOffset>0x2</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN5</name>
+                            <description>desc PIN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN6</name>
+                            <description>desc PIN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN7</name>
+                            <description>desc PIN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR3</name>
+                    <description>desc PIDR3</description>
+                    <addressOffset>0x3</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR4</name>
+                    <description>desc PIDR4</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR5</name>
+                    <description>desc PIDR5</description>
+                    <addressOffset>0x5</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN5</name>
+                            <description>desc PIN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR6</name>
+                    <description>desc PIDR6</description>
+                    <addressOffset>0x6</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR7</name>
+                    <description>desc PIDR7</description>
+                    <addressOffset>0x7</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN5</name>
+                            <description>desc PIN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN6</name>
+                            <description>desc PIN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN7</name>
+                            <description>desc PIN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR12</name>
+                    <description>desc PIDR12</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN2</name>
+                            <description>desc PIN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN3</name>
+                            <description>desc PIN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN4</name>
+                            <description>desc PIN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR13</name>
+                    <description>desc PIDR13</description>
+                    <addressOffset>0xD</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN7</name>
+                            <description>desc PIN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PIDR14</name>
+                    <description>desc PIDR14</description>
+                    <addressOffset>0xE</addressOffset>
+                    <size>8</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PIN0</name>
+                            <description>desc PIN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN1</name>
+                            <description>desc PIN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN6</name>
+                            <description>desc PIN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PIN7</name>
+                            <description>desc PIN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR0</name>
+                    <description>desc PODR0</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT5</name>
+                            <description>desc POUT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT6</name>
+                            <description>desc POUT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR1</name>
+                    <description>desc PODR1</description>
+                    <addressOffset>0x11</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT5</name>
+                            <description>desc POUT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT6</name>
+                            <description>desc POUT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT7</name>
+                            <description>desc POUT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR2</name>
+                    <description>desc PODR2</description>
+                    <addressOffset>0x12</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT5</name>
+                            <description>desc POUT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT6</name>
+                            <description>desc POUT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT7</name>
+                            <description>desc POUT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR3</name>
+                    <description>desc PODR3</description>
+                    <addressOffset>0x13</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR4</name>
+                    <description>desc PODR4</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR5</name>
+                    <description>desc PODR5</description>
+                    <addressOffset>0x15</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT5</name>
+                            <description>desc POUT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR6</name>
+                    <description>desc PODR6</description>
+                    <addressOffset>0x16</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR7</name>
+                    <description>desc PODR7</description>
+                    <addressOffset>0x17</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT5</name>
+                            <description>desc POUT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT6</name>
+                            <description>desc POUT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT7</name>
+                            <description>desc POUT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR12</name>
+                    <description>desc PODR12</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT2</name>
+                            <description>desc POUT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT3</name>
+                            <description>desc POUT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT4</name>
+                            <description>desc POUT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR13</name>
+                    <description>desc PODR13</description>
+                    <addressOffset>0x1D</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT7</name>
+                            <description>desc POUT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PODR14</name>
+                    <description>desc PODR14</description>
+                    <addressOffset>0x1E</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT0</name>
+                            <description>desc POUT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT1</name>
+                            <description>desc POUT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT6</name>
+                            <description>desc POUT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUT7</name>
+                            <description>desc POUT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER0</name>
+                    <description>desc POER0</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE5</name>
+                            <description>desc POUTE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE6</name>
+                            <description>desc POUTE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER1</name>
+                    <description>desc POER1</description>
+                    <addressOffset>0x21</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE5</name>
+                            <description>desc POUTE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE6</name>
+                            <description>desc POUTE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE7</name>
+                            <description>desc POUTE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER2</name>
+                    <description>desc POER2</description>
+                    <addressOffset>0x22</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE5</name>
+                            <description>desc POUTE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE6</name>
+                            <description>desc POUTE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE7</name>
+                            <description>desc POUTE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER3</name>
+                    <description>desc POER3</description>
+                    <addressOffset>0x23</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER4</name>
+                    <description>desc POER4</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER5</name>
+                    <description>desc POER5</description>
+                    <addressOffset>0x25</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE5</name>
+                            <description>desc POUTE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER6</name>
+                    <description>desc POER6</description>
+                    <addressOffset>0x26</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER7</name>
+                    <description>desc POER7</description>
+                    <addressOffset>0x27</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE5</name>
+                            <description>desc POUTE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE6</name>
+                            <description>desc POUTE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE7</name>
+                            <description>desc POUTE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER12</name>
+                    <description>desc POER12</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE2</name>
+                            <description>desc POUTE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE3</name>
+                            <description>desc POUTE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE4</name>
+                            <description>desc POUTE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER13</name>
+                    <description>desc POER13</description>
+                    <addressOffset>0x2D</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE7</name>
+                            <description>desc POUTE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POER14</name>
+                    <description>desc POER14</description>
+                    <addressOffset>0x2E</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUTE0</name>
+                            <description>desc POUTE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE1</name>
+                            <description>desc POUTE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE6</name>
+                            <description>desc POUTE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE7</name>
+                            <description>desc POUTE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR0</name>
+                    <description>desc POSR0</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS5</name>
+                            <description>desc POS5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS6</name>
+                            <description>desc POS6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR1</name>
+                    <description>desc POSR1</description>
+                    <addressOffset>0x31</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS5</name>
+                            <description>desc POS5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS6</name>
+                            <description>desc POS6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS7</name>
+                            <description>desc POS7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR2</name>
+                    <description>desc POSR2</description>
+                    <addressOffset>0x32</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS5</name>
+                            <description>desc POS5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS6</name>
+                            <description>desc POS6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS7</name>
+                            <description>desc POS7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR3</name>
+                    <description>desc POSR3</description>
+                    <addressOffset>0x33</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR4</name>
+                    <description>desc POSR4</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR5</name>
+                    <description>desc POSR5</description>
+                    <addressOffset>0x35</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS5</name>
+                            <description>desc POS5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR6</name>
+                    <description>desc POSR6</description>
+                    <addressOffset>0x36</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR7</name>
+                    <description>desc POSR7</description>
+                    <addressOffset>0x37</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS5</name>
+                            <description>desc POS5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS6</name>
+                            <description>desc POS6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS7</name>
+                            <description>desc POS7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR12</name>
+                    <description>desc POSR12</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS2</name>
+                            <description>desc POS2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS3</name>
+                            <description>desc POS3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS4</name>
+                            <description>desc POS4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR13</name>
+                    <description>desc POSR13</description>
+                    <addressOffset>0x3D</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS7</name>
+                            <description>desc POS7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POSR14</name>
+                    <description>desc POSR14</description>
+                    <addressOffset>0x3E</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POS0</name>
+                            <description>desc POS0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS1</name>
+                            <description>desc POS1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS6</name>
+                            <description>desc POS6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POS7</name>
+                            <description>desc POS7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR0</name>
+                    <description>desc PORR0</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR5</name>
+                            <description>desc POR5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR6</name>
+                            <description>desc POR6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR1</name>
+                    <description>desc PORR1</description>
+                    <addressOffset>0x41</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR5</name>
+                            <description>desc POR5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR6</name>
+                            <description>desc POR6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR7</name>
+                            <description>desc POR7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR2</name>
+                    <description>desc PORR2</description>
+                    <addressOffset>0x42</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR5</name>
+                            <description>desc POR5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR6</name>
+                            <description>desc POR6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR7</name>
+                            <description>desc POR7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR3</name>
+                    <description>desc PORR3</description>
+                    <addressOffset>0x43</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR4</name>
+                    <description>desc PORR4</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR5</name>
+                    <description>desc PORR5</description>
+                    <addressOffset>0x45</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR5</name>
+                            <description>desc POR5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR6</name>
+                    <description>desc PORR6</description>
+                    <addressOffset>0x46</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR7</name>
+                    <description>desc PORR7</description>
+                    <addressOffset>0x47</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR5</name>
+                            <description>desc POR5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR6</name>
+                            <description>desc POR6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR7</name>
+                            <description>desc POR7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR12</name>
+                    <description>desc PORR12</description>
+                    <addressOffset>0x4C</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR2</name>
+                            <description>desc POR2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR3</name>
+                            <description>desc POR3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR4</name>
+                            <description>desc POR4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR13</name>
+                    <description>desc PORR13</description>
+                    <addressOffset>0x4D</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR7</name>
+                            <description>desc POR7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PORR14</name>
+                    <description>desc PORR14</description>
+                    <addressOffset>0x4E</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POR0</name>
+                            <description>desc POR0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR1</name>
+                            <description>desc POR1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR6</name>
+                            <description>desc POR6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POR7</name>
+                            <description>desc POR7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR0</name>
+                    <description>desc POTR0</description>
+                    <addressOffset>0x50</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT5</name>
+                            <description>desc POT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT6</name>
+                            <description>desc POT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR1</name>
+                    <description>desc POTR1</description>
+                    <addressOffset>0x51</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT5</name>
+                            <description>desc POT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT6</name>
+                            <description>desc POT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT7</name>
+                            <description>desc POT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR2</name>
+                    <description>desc POTR2</description>
+                    <addressOffset>0x52</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT5</name>
+                            <description>desc POT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT6</name>
+                            <description>desc POT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT7</name>
+                            <description>desc POT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR3</name>
+                    <description>desc POTR3</description>
+                    <addressOffset>0x53</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR4</name>
+                    <description>desc POTR4</description>
+                    <addressOffset>0x54</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR5</name>
+                    <description>desc POTR5</description>
+                    <addressOffset>0x55</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT5</name>
+                            <description>desc POT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR6</name>
+                    <description>desc POTR6</description>
+                    <addressOffset>0x56</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR7</name>
+                    <description>desc POTR7</description>
+                    <addressOffset>0x57</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT5</name>
+                            <description>desc POT5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT6</name>
+                            <description>desc POT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT7</name>
+                            <description>desc POT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR12</name>
+                    <description>desc POTR12</description>
+                    <addressOffset>0x5C</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT2</name>
+                            <description>desc POT2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT3</name>
+                            <description>desc POT3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT4</name>
+                            <description>desc POT4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR13</name>
+                    <description>desc POTR13</description>
+                    <addressOffset>0x5D</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT7</name>
+                            <description>desc POT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>POTR14</name>
+                    <description>desc POTR14</description>
+                    <addressOffset>0x5E</addressOffset>
+                    <size>8</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC3</resetMask>
+                    <fields>
+                        <field>
+                            <name>POT0</name>
+                            <description>desc POT0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT1</name>
+                            <description>desc POT1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT6</name>
+                            <description>desc POT6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>POT7</name>
+                            <description>desc POT7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR00</name>
+                    <description>desc PCR00</description>
+                    <addressOffset>0x400</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR01</name>
+                    <description>desc PCR01</description>
+                    <addressOffset>0x402</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR02</name>
+                    <description>desc PCR02</description>
+                    <addressOffset>0x404</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR03</name>
+                    <description>desc PCR03</description>
+                    <addressOffset>0x406</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR04</name>
+                    <description>desc PCR04</description>
+                    <addressOffset>0x408</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR05</name>
+                    <description>desc PCR05</description>
+                    <addressOffset>0x40A</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR06</name>
+                    <description>desc PCR06</description>
+                    <addressOffset>0x40C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR10</name>
+                    <description>desc PCR10</description>
+                    <addressOffset>0x410</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR11</name>
+                    <description>desc PCR11</description>
+                    <addressOffset>0x412</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR12</name>
+                    <description>desc PCR12</description>
+                    <addressOffset>0x414</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR13</name>
+                    <description>desc PCR13</description>
+                    <addressOffset>0x416</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR14</name>
+                    <description>desc PCR14</description>
+                    <addressOffset>0x418</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR15</name>
+                    <description>desc PCR15</description>
+                    <addressOffset>0x41A</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR16</name>
+                    <description>desc PCR16</description>
+                    <addressOffset>0x41C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR17</name>
+                    <description>desc PCR17</description>
+                    <addressOffset>0x41E</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR20</name>
+                    <description>desc PCR20</description>
+                    <addressOffset>0x420</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR21</name>
+                    <description>desc PCR21</description>
+                    <addressOffset>0x422</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR22</name>
+                    <description>desc PCR22</description>
+                    <addressOffset>0x424</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR23</name>
+                    <description>desc PCR23</description>
+                    <addressOffset>0x426</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR24</name>
+                    <description>desc PCR24</description>
+                    <addressOffset>0x428</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR25</name>
+                    <description>desc PCR25</description>
+                    <addressOffset>0x42A</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR26</name>
+                    <description>desc PCR26</description>
+                    <addressOffset>0x42C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR27</name>
+                    <description>desc PCR27</description>
+                    <addressOffset>0x42E</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR30</name>
+                    <description>desc PCR30</description>
+                    <addressOffset>0x430</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR31</name>
+                    <description>desc PCR31</description>
+                    <addressOffset>0x432</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR40</name>
+                    <description>desc PCR40</description>
+                    <addressOffset>0x440</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR41</name>
+                    <description>desc PCR41</description>
+                    <addressOffset>0x442</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR42</name>
+                    <description>desc PCR42</description>
+                    <addressOffset>0x444</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR43</name>
+                    <description>desc PCR43</description>
+                    <addressOffset>0x446</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR50</name>
+                    <description>desc PCR50</description>
+                    <addressOffset>0x450</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR51</name>
+                    <description>desc PCR51</description>
+                    <addressOffset>0x452</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR52</name>
+                    <description>desc PCR52</description>
+                    <addressOffset>0x454</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR53</name>
+                    <description>desc PCR53</description>
+                    <addressOffset>0x456</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR54</name>
+                    <description>desc PCR54</description>
+                    <addressOffset>0x458</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR55</name>
+                    <description>desc PCR55</description>
+                    <addressOffset>0x45A</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR60</name>
+                    <description>desc PCR60</description>
+                    <addressOffset>0x460</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR61</name>
+                    <description>desc PCR61</description>
+                    <addressOffset>0x462</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR62</name>
+                    <description>desc PCR62</description>
+                    <addressOffset>0x464</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR63</name>
+                    <description>desc PCR63</description>
+                    <addressOffset>0x466</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR70</name>
+                    <description>desc PCR70</description>
+                    <addressOffset>0x470</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR71</name>
+                    <description>desc PCR71</description>
+                    <addressOffset>0x472</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR72</name>
+                    <description>desc PCR72</description>
+                    <addressOffset>0x474</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR73</name>
+                    <description>desc PCR73</description>
+                    <addressOffset>0x476</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR74</name>
+                    <description>desc PCR74</description>
+                    <addressOffset>0x478</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR75</name>
+                    <description>desc PCR75</description>
+                    <addressOffset>0x47A</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR76</name>
+                    <description>desc PCR76</description>
+                    <addressOffset>0x47C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR77</name>
+                    <description>desc PCR77</description>
+                    <addressOffset>0x47E</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR120</name>
+                    <description>desc PCR120</description>
+                    <addressOffset>0x4C0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR121</name>
+                    <description>desc PCR121</description>
+                    <addressOffset>0x4C2</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR122</name>
+                    <description>desc PCR122</description>
+                    <addressOffset>0x4C4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR123</name>
+                    <description>desc PCR123</description>
+                    <addressOffset>0x4C6</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR124</name>
+                    <description>desc PCR124</description>
+                    <addressOffset>0x4C8</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR130</name>
+                    <description>desc PCR130</description>
+                    <addressOffset>0x4D0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7777</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR137</name>
+                    <description>desc PCR137</description>
+                    <addressOffset>0x4DE</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR140</name>
+                    <description>desc PCR140</description>
+                    <addressOffset>0x4E0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR141</name>
+                    <description>desc PCR141</description>
+                    <addressOffset>0x4E2</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR146</name>
+                    <description>desc PCR146</description>
+                    <addressOffset>0x4EC</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCR147</name>
+                    <description>desc PCR147</description>
+                    <addressOffset>0x4EE</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F77</resetMask>
+                    <fields>
+                        <field>
+                            <name>POUT</name>
+                            <description>desc POUT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>POUTE</name>
+                            <description>desc POUTE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOD</name>
+                            <description>desc NOD</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DRV</name>
+                            <description>desc DRV</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LTE</name>
+                            <description>desc LTE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PUU</name>
+                            <description>desc PUU</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PIN</name>
+                            <description>desc PIN</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>INVE</name>
+                            <description>desc INVE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CINSEL</name>
+                            <description>desc CINSEL</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTE</name>
+                            <description>desc INTE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FSEL</name>
+                            <description>desc FSEL</description>
+                            <msb>14</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PSPCR</name>
+                    <description>desc PSPCR</description>
+                    <addressOffset>0x500</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x3</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>SPFE</name>
+                            <description>desc SPFE</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCCR</name>
+                    <description>desc PCCR</description>
+                    <addressOffset>0x504</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x4000</resetValue>
+                    <resetMask>0xC000</resetMask>
+                    <fields>
+                        <field>
+                            <name>RDWT</name>
+                            <description>desc RDWT</description>
+                            <msb>15</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PINAER</name>
+                    <description>desc PINAER</description>
+                    <addressOffset>0x506</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x70FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PINAE0</name>
+                            <description>desc PINAE0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE1</name>
+                            <description>desc PINAE1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE2</name>
+                            <description>desc PINAE2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE3</name>
+                            <description>desc PINAE3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE4</name>
+                            <description>desc PINAE4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE5</name>
+                            <description>desc PINAE5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE6</name>
+                            <description>desc PINAE6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE7</name>
+                            <description>desc PINAE7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE12</name>
+                            <description>desc PINAE12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE13</name>
+                            <description>desc PINAE13</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINAE14</name>
+                            <description>desc PINAE14</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PWPR</name>
+                    <description>desc PWPR</description>
+                    <addressOffset>0x508</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF01</resetMask>
+                    <fields>
+                        <field>
+                            <name>WE</name>
+                            <description>desc WE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>WP</name>
+                            <description>desc WP</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>I2C</name>
+            <description>desc I2C</description>
+            <baseAddress>0x40004800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x34</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x40</resetValue>
+                    <resetMask>0x87FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBUS</name>
+                            <description>desc SMBUS</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBALRTEN</name>
+                            <description>desc SMBALRTEN</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBDEFAULTEN</name>
+                            <description>desc SMBDEFAULTEN</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBHOSTEN</name>
+                            <description>desc SMBHOSTEN</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FACKEN</name>
+                            <description>desc FACKEN</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GCEN</name>
+                            <description>desc GCEN</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RESTART</name>
+                            <description>desc RESTART</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ACK</name>
+                            <description>desc ACK</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SWRST</name>
+                            <description>desc SWRST</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF012DF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STARTIE</name>
+                            <description>desc STARTIE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLADDR0IE</name>
+                            <description>desc SLADDR0IE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLADDR1IE</name>
+                            <description>desc SLADDR1IE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TENDIE</name>
+                            <description>desc TENDIE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOPIE</name>
+                            <description>desc STOPIE</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RFULLIE</name>
+                            <description>desc RFULLIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TEMPTYIE</name>
+                            <description>desc TEMPTYIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ARLOIE</name>
+                            <description>desc ARLOIE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NACKIE</name>
+                            <description>desc NACKIE</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GENCALLIE</name>
+                            <description>desc GENCALLIE</description>
+                            <msb>20</msb>
+                            <lsb>20</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBDEFAULTIE</name>
+                            <description>desc SMBDEFAULTIE</description>
+                            <msb>21</msb>
+                            <lsb>21</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBHOSTIE</name>
+                            <description>desc SMBHOSTIE</description>
+                            <msb>22</msb>
+                            <lsb>22</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SMBALRTIE</name>
+                            <description>desc SMBALRTIE</description>
+                            <msb>23</msb>
+                            <lsb>23</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLR0</name>
+                    <description>desc SLR0</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1000</resetValue>
+                    <resetMask>0x93FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>SLADDR0</name>
+                            <description>desc SLADDR0</description>
+                            <msb>9</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLADDR0EN</name>
+                            <description>desc SLADDR0EN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ADDRMOD0</name>
+                            <description>desc ADDRMOD0</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SLR1</name>
+                    <description>desc SLR1</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x93FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>SLADDR1</name>
+                            <description>desc SLADDR1</description>
+                            <msb>9</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLADDR1EN</name>
+                            <description>desc SLADDR1EN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ADDRMOD1</name>
+                            <description>desc ADDRMOD1</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF716DF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STARTF</name>
+                            <description>desc STARTF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SLADDR0F</name>
+                            <description>desc SLADDR0F</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SLADDR1F</name>
+                            <description>desc SLADDR1F</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TENDF</name>
+                            <description>desc TENDF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>STOPF</name>
+                            <description>desc STOPF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RFULLF</name>
+                            <description>desc RFULLF</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TEMPTYF</name>
+                            <description>desc TEMPTYF</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ARLOF</name>
+                            <description>desc ARLOF</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ACKRF</name>
+                            <description>desc ACKRF</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>NACKF</name>
+                            <description>desc NACKF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MSL</name>
+                            <description>desc MSL</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>BUSY</name>
+                            <description>desc BUSY</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TRA</name>
+                            <description>desc TRA</description>
+                            <msb>18</msb>
+                            <lsb>18</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>GENCALLF</name>
+                            <description>desc GENCALLF</description>
+                            <msb>20</msb>
+                            <lsb>20</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SMBDEFAULTF</name>
+                            <description>desc SMBDEFAULTF</description>
+                            <msb>21</msb>
+                            <lsb>21</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SMBHOSTF</name>
+                            <description>desc SMBHOSTF</description>
+                            <msb>22</msb>
+                            <lsb>22</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SMBALRTF</name>
+                            <description>desc SMBALRTF</description>
+                            <msb>23</msb>
+                            <lsb>23</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CLR</name>
+                    <description>desc CLR</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>32</size>
+                    <access>write-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF012DF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STARTFCLR</name>
+                            <description>desc STARTFCLR</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>SLADDR0FCLR</name>
+                            <description>desc SLADDR0FCLR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>SLADDR1FCLR</name>
+                            <description>desc SLADDR1FCLR</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>TENDFCLR</name>
+                            <description>desc TENDFCLR</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>STOPFCLR</name>
+                            <description>desc STOPFCLR</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>RFULLFCLR</name>
+                            <description>desc RFULLFCLR</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>TEMPTYFCLR</name>
+                            <description>desc TEMPTYFCLR</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>ARLOFCLR</name>
+                            <description>desc ARLOFCLR</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>NACKFCLR</name>
+                            <description>desc NACKFCLR</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>GENCALLFCLR</name>
+                            <description>desc GENCALLFCLR</description>
+                            <msb>20</msb>
+                            <lsb>20</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>SMBDEFAULTFCLR</name>
+                            <description>desc SMBDEFAULTFCLR</description>
+                            <msb>21</msb>
+                            <lsb>21</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>SMBHOSTFCLR</name>
+                            <description>desc SMBHOSTFCLR</description>
+                            <msb>22</msb>
+                            <lsb>22</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>SMBALRTFCLR</name>
+                            <description>desc SMBALRTFCLR</description>
+                            <msb>23</msb>
+                            <lsb>23</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DTR</name>
+                    <description>desc DTR</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>DT</name>
+                            <description>desc DT</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DRR</name>
+                    <description>desc DRR</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>DR</name>
+                            <description>desc DR</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCR</name>
+                    <description>desc CCR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1F1F</resetValue>
+                    <resetMask>0x71F1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>SLOWW</name>
+                            <description>desc SLOWW</description>
+                            <msb>4</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SHIGHW</name>
+                            <description>desc SHIGHW</description>
+                            <msb>12</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>18</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FLTR</name>
+                    <description>desc FLTR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x10</resetValue>
+                    <resetMask>0x13</resetMask>
+                    <fields>
+                        <field>
+                            <name>DNF</name>
+                            <description>desc DNF</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DNFEN</name>
+                            <description>desc DNFEN</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>ICG</name>
+            <description>desc ICG</description>
+            <baseAddress>0x000000C0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x1C</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>ICG0</name>
+                    <description>desc ICG0</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0xFC0F1FFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>SWDTAUTS</name>
+                            <description>desc SWDTAUTS</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTITS</name>
+                            <description>desc SWDTITS</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTPERI</name>
+                            <description>desc SWDTPERI</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTCKS</name>
+                            <description>desc SWDTCKS</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTWDPT</name>
+                            <description>desc SWDTWDPT</description>
+                            <msb>11</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTSLPOFF</name>
+                            <description>desc SWDTSLPOFF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>HRCREQS</name>
+                            <description>desc HRCREQS</description>
+                            <msb>19</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICG1</name>
+                    <description>desc ICG1</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x1FF07</resetMask>
+                    <fields>
+                        <field>
+                            <name>DFS</name>
+                            <description>desc DFS</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>DFDIS</name>
+                            <description>desc DFDIS</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>LVDLVL</name>
+                            <description>desc LVDLVL</description>
+                            <msb>11</msb>
+                            <lsb>8</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>NMIS</name>
+                            <description>desc NMIS</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>IRS</name>
+                            <description>desc IRS</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>IRDIS</name>
+                            <description>desc IRDIS</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>LVDDIS</name>
+                            <description>desc LVDDIS</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>LKUPDIS</name>
+                            <description>desc LKUPDIS</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICG2</name>
+                    <description>desc ICG2</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x0</resetMask>
+                </register>
+                <register>
+                    <name>ICG3</name>
+                    <description>desc ICG3</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x0</resetMask>
+                </register>
+                <register>
+                    <name>ICG4</name>
+                    <description>desc ICG4</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x0</resetMask>
+                </register>
+                <register>
+                    <name>ICG5</name>
+                    <description>desc ICG5</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x0</resetMask>
+                </register>
+                <register>
+                    <name>ICG6</name>
+                    <description>desc ICG6</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xFFFFFFFF</resetValue>
+                    <resetMask>0x0</resetMask>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>INTC</name>
+            <description>desc INTC</description>
+            <baseAddress>0x40011000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x100</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>NMIER</name>
+                    <description>desc NMIER</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xE</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTPEN</name>
+                            <description>desc XTALSTPEN</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SWDTEN</name>
+                            <description>desc SWDTEN</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PVDEN</name>
+                            <description>desc PVDEN</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>NMIFR</name>
+                    <description>desc NMIFR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xE</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTPF</name>
+                            <description>desc XTALSTPF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>SWDTF</name>
+                            <description>desc SWDTF</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>PVDF</name>
+                            <description>desc PVDF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>NMICLR</name>
+                    <description>desc NMICLR</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xE</resetMask>
+                    <fields>
+                        <field>
+                            <name>XTALSTPCL</name>
+                            <description>desc XTALSTPCL</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SWDTCL</name>
+                            <description>desc SWDTCL</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PVDCL</name>
+                            <description>desc PVDCL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EVTER</name>
+                    <description>desc EVTER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>EVTEN0</name>
+                            <description>desc EVTEN0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN1</name>
+                            <description>desc EVTEN1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN2</name>
+                            <description>desc EVTEN2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN3</name>
+                            <description>desc EVTEN3</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN4</name>
+                            <description>desc EVTEN4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN5</name>
+                            <description>desc EVTEN5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN6</name>
+                            <description>desc EVTEN6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EVTEN7</name>
+                            <description>desc EVTEN7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EKEYCR</name>
+                    <description>desc EKEYCR</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>EKEY0EN</name>
+                            <description>desc EKEY0EN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY1EN</name>
+                            <description>desc EKEY1EN</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY2EN</name>
+                            <description>desc EKEY2EN</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY3EN</name>
+                            <description>desc EKEY3EN</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY4EN</name>
+                            <description>desc EKEY4EN</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY5EN</name>
+                            <description>desc EKEY5EN</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY6EN</name>
+                            <description>desc EKEY6EN</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEY7EN</name>
+                            <description>desc EKEY7EN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FPRCR</name>
+                    <description>desc FPRCR</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>FPRC</name>
+                            <description>desc FPRC</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR0</name>
+                    <description>desc EIRQCR0</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR1</name>
+                    <description>desc EIRQCR1</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR2</name>
+                    <description>desc EIRQCR2</description>
+                    <addressOffset>0x48</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR3</name>
+                    <description>desc EIRQCR3</description>
+                    <addressOffset>0x4C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR4</name>
+                    <description>desc EIRQCR4</description>
+                    <addressOffset>0x50</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR5</name>
+                    <description>desc EIRQCR5</description>
+                    <addressOffset>0x54</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR6</name>
+                    <description>desc EIRQCR6</description>
+                    <addressOffset>0x58</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR7</name>
+                    <description>desc EIRQCR7</description>
+                    <addressOffset>0x5C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR8</name>
+                    <description>desc EIRQCR8</description>
+                    <addressOffset>0x60</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR9</name>
+                    <description>desc EIRQCR9</description>
+                    <addressOffset>0x64</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR10</name>
+                    <description>desc EIRQCR10</description>
+                    <addressOffset>0x68</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCR11</name>
+                    <description>desc EIRQCR11</description>
+                    <addressOffset>0x6C</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1</resetValue>
+                    <resetMask>0xB3</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQTRG</name>
+                            <description>desc EIRQTRG</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFCLK</name>
+                            <description>desc EIRQFCLK</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIRQFEN</name>
+                            <description>desc EIRQFEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>WUPENR</name>
+                    <description>desc WUPENR</description>
+                    <addressOffset>0x70</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1C70FFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQWUEN</name>
+                            <description>desc EIRQWUEN</description>
+                            <msb>11</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SWDTWUEN</name>
+                            <description>desc SWDTWUEN</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EKEYWUEN</name>
+                            <description>desc EKEYWUEN</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TMR0CMPWUEN</name>
+                            <description>desc TMR0CMPWUEN</description>
+                            <msb>18</msb>
+                            <lsb>18</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PVDWUEN</name>
+                            <description>desc PVDWUEN</description>
+                            <msb>22</msb>
+                            <lsb>22</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTCALMWUEN</name>
+                            <description>desc RTCALMWUEN</description>
+                            <msb>23</msb>
+                            <lsb>23</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RTCPRDWUEN</name>
+                            <description>desc RTCPRDWUEN</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQFR</name>
+                    <description>desc EIRQFR</description>
+                    <addressOffset>0x74</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQF</name>
+                            <description>desc EIRQF</description>
+                            <msb>11</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>EIRQCLR</name>
+                    <description>desc EIRQCLR</description>
+                    <addressOffset>0x78</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>EIRQCL</name>
+                            <description>desc EIRQCL</description>
+                            <msb>11</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR8</name>
+                    <description>desc ISELR8</description>
+                    <addressOffset>0xA0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR9</name>
+                    <description>desc ISELR9</description>
+                    <addressOffset>0xA4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR10</name>
+                    <description>desc ISELR10</description>
+                    <addressOffset>0xA8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR11</name>
+                    <description>desc ISELR11</description>
+                    <addressOffset>0xAC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR12</name>
+                    <description>desc ISELR12</description>
+                    <addressOffset>0xB0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR13</name>
+                    <description>desc ISELR13</description>
+                    <addressOffset>0xB4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR14</name>
+                    <description>desc ISELR14</description>
+                    <addressOffset>0xB8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR15</name>
+                    <description>desc ISELR15</description>
+                    <addressOffset>0xBC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR16</name>
+                    <description>desc ISELR16</description>
+                    <addressOffset>0xC0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR17</name>
+                    <description>desc ISELR17</description>
+                    <addressOffset>0xC4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR18</name>
+                    <description>desc ISELR18</description>
+                    <addressOffset>0xC8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR19</name>
+                    <description>desc ISELR19</description>
+                    <addressOffset>0xCC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR20</name>
+                    <description>desc ISELR20</description>
+                    <addressOffset>0xD0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR21</name>
+                    <description>desc ISELR21</description>
+                    <addressOffset>0xD4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR22</name>
+                    <description>desc ISELR22</description>
+                    <addressOffset>0xD8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR23</name>
+                    <description>desc ISELR23</description>
+                    <addressOffset>0xDC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR24</name>
+                    <description>desc ISELR24</description>
+                    <addressOffset>0xE0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR25</name>
+                    <description>desc ISELR25</description>
+                    <addressOffset>0xE4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR26</name>
+                    <description>desc ISELR26</description>
+                    <addressOffset>0xE8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR27</name>
+                    <description>desc ISELR27</description>
+                    <addressOffset>0xEC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR28</name>
+                    <description>desc ISELR28</description>
+                    <addressOffset>0xF0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR29</name>
+                    <description>desc ISELR29</description>
+                    <addressOffset>0xF4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR30</name>
+                    <description>desc ISELR30</description>
+                    <addressOffset>0xF8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ISELR31</name>
+                    <description>desc ISELR31</description>
+                    <addressOffset>0xFC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>ISEL</name>
+                            <description>desc ISEL</description>
+                            <msb>15</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>PWC</name>
+            <description>desc PWC</description>
+            <baseAddress>0x40014000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x41</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>STPMCR</name>
+                    <description>desc STPMCR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x8B</resetMask>
+                    <fields>
+                        <field>
+                            <name>FLNWT</name>
+                            <description>desc FLNWT</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKSHRC</name>
+                            <description>desc CKSHRC</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HAPORDIS</name>
+                            <description>desc HAPORDIS</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PWRC</name>
+                    <description>desc PWRC</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF</resetValue>
+                    <resetMask>0xCF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PWDRV</name>
+                            <description>desc PWDRV</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DVS</name>
+                            <description>desc DVS</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>VHRCE</name>
+                            <description>desc VHRCE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HRCPWRDY</name>
+                            <description>desc HRCPWRDY</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PWRMON</name>
+                    <description>desc PWRMON</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PWMONSEL</name>
+                            <description>desc PWMONSEL</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PWMONE</name>
+                            <description>desc PWMONE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>RAMCR</name>
+                    <description>desc RAMCR</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x10</resetValue>
+                    <resetMask>0x33</resetMask>
+                    <fields>
+                        <field>
+                            <name>RPRTA</name>
+                            <description>desc RPRTA</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPERDIS</name>
+                            <description>desc RPERDIS</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RPERF</name>
+                            <description>desc RPERF</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>LVDCSR</name>
+                    <description>desc LVDCSR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x99</resetMask>
+                    <fields>
+                        <field>
+                            <name>EXVCCINEN</name>
+                            <description>desc EXVCCINEN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LVIF</name>
+                            <description>desc LVIF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DETF</name>
+                            <description>desc DETF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPOE</name>
+                            <description>desc CMPOE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>FPRC</name>
+                    <description>desc FPRC</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CKRWE</name>
+                            <description>desc CKRWE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PWRWE</name>
+                            <description>desc PWRWE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCB2</name>
+                            <description>desc FPRCB2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LVRWE</name>
+                            <description>desc LVRWE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCB4</name>
+                            <description>desc FPRCB4</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCB5</name>
+                            <description>desc FPRCB5</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCB6</name>
+                            <description>desc FPRCB6</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCB7</name>
+                            <description>desc FPRCB7</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FPRCWE</name>
+                            <description>desc FPRCWE</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>write-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DBGC</name>
+                    <description>desc DBGC</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>DBGEN</name>
+                            <description>desc DBGEN</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>RMU</name>
+            <description>desc RMU</description>
+            <baseAddress>0x40014100</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x2</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>RSTF0</name>
+                    <description>desc RSTF0</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF527</resetMask>
+                    <fields>
+                        <field>
+                            <name>PORF</name>
+                            <description>desc PORF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PINRF</name>
+                            <description>desc PINRF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LVRF</name>
+                            <description>desc LVRF</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>WDRF</name>
+                            <description>desc WDRF</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SWRF</name>
+                            <description>desc SWRF</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RAMPERF</name>
+                            <description>desc RAMPERF</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPULKUPRF</name>
+                            <description>desc CPULKUPRF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>XTALERF</name>
+                            <description>desc XTALERF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MULTIRF</name>
+                            <description>desc MULTIRF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLRF</name>
+                            <description>desc CLRF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>RTC</name>
+            <description>desc RTC</description>
+            <baseAddress>0x4000D400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x40</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CR0</name>
+                    <description>desc CR0</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>RESET</name>
+                            <description>desc RESET</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xAF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PRDS</name>
+                            <description>desc PRDS</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>AMPM</name>
+                            <description>desc AMPM</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ONEHZOE</name>
+                            <description>desc ONEHZOE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xEF</resetMask>
+                    <fields>
+                        <field>
+                            <name>RWREQ</name>
+                            <description>desc RWREQ</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RWEN</name>
+                            <description>desc RWEN</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PRDF</name>
+                            <description>desc PRDF</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ALMF</name>
+                            <description>desc ALMF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PRDIE</name>
+                            <description>desc PRDIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ALMIE</name>
+                            <description>desc ALMIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ALME</name>
+                            <description>desc ALME</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x90</resetMask>
+                    <fields>
+                        <field>
+                            <name>LRCEN</name>
+                            <description>desc LRCEN</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RCKSEL</name>
+                            <description>desc RCKSEL</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SEC</name>
+                    <description>desc SEC</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>SECU</name>
+                            <description>desc SECU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SECD</name>
+                            <description>desc SECD</description>
+                            <msb>6</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>MIN</name>
+                    <description>desc MIN</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>MINU</name>
+                            <description>desc MINU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MIND</name>
+                            <description>desc MIND</description>
+                            <msb>6</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HOUR</name>
+                    <description>desc HOUR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x12</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>HOURU</name>
+                            <description>desc HOURU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HOURD</name>
+                            <description>desc HOURD</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>WEEK</name>
+                    <description>desc WEEK</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7</resetMask>
+                    <fields>
+                        <field>
+                            <name>WEEK</name>
+                            <description>desc WEEK</description>
+                            <msb>2</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DAY</name>
+                    <description>desc DAY</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>DAYU</name>
+                            <description>desc DAYU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DAYD</name>
+                            <description>desc DAYD</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>MON</name>
+                    <description>desc MON</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F</resetMask>
+                    <fields>
+                        <field>
+                            <name>MON</name>
+                            <description>desc MON</description>
+                            <msb>4</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>YEAR</name>
+                    <description>desc YEAR</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>YEARU</name>
+                            <description>desc YEARU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>YEARD</name>
+                            <description>desc YEARD</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ALMMIN</name>
+                    <description>desc ALMMIN</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x12</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>ALMMINU</name>
+                            <description>desc ALMMINU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ALMMIND</name>
+                            <description>desc ALMMIND</description>
+                            <msb>6</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ALMHOUR</name>
+                    <description>desc ALMHOUR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3F</resetMask>
+                    <fields>
+                        <field>
+                            <name>ALMHOURU</name>
+                            <description>desc ALMHOURU</description>
+                            <msb>3</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ALMHOURD</name>
+                            <description>desc ALMHOURD</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ALMWEEK</name>
+                    <description>desc ALMWEEK</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7F</resetMask>
+                    <fields>
+                        <field>
+                            <name>ALMWEEK</name>
+                            <description>desc ALMWEEK</description>
+                            <msb>6</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ERRCRH</name>
+                    <description>desc ERRCRH</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x81</resetMask>
+                    <fields>
+                        <field>
+                            <name>COMP8</name>
+                            <description>desc COMP8</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMPEN</name>
+                            <description>desc COMPEN</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ERRCRL</name>
+                    <description>desc ERRCRL</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>8</size>
+                    <access>read-write</access>
+                    <resetValue>0x20</resetValue>
+                    <resetMask>0xFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>COMP</name>
+                            <description>desc COMP</description>
+                            <msb>7</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>SPI</name>
+            <description>desc SPI</description>
+            <baseAddress>0x40003800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x1C</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>SPD</name>
+                            <description>desc SPD</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFF7B</resetMask>
+                    <fields>
+                        <field>
+                            <name>SPIMDS</name>
+                            <description>desc SPIMDS</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXMDS</name>
+                            <description>desc TXMDS</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MSTR</name>
+                            <description>desc MSTR</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SPLPBK</name>
+                            <description>desc SPLPBK</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SPLPBK2</name>
+                            <description>desc SPLPBK2</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SPE</name>
+                            <description>desc SPE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>EIE</name>
+                            <description>desc EIE</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXIE</name>
+                            <description>desc TXIE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RXIE</name>
+                            <description>desc RXIE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>IDIE</name>
+                            <description>desc IDIE</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODFE</name>
+                            <description>desc MODFE</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PATE</name>
+                            <description>desc PATE</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PAOE</name>
+                            <description>desc PAOE</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PAE</name>
+                            <description>desc PAE</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CFG1</name>
+                    <description>desc CFG1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x10</resetValue>
+                    <resetMask>0x100</resetMask>
+                    <fields>
+                        <field>
+                            <name>SS0PV</name>
+                            <description>desc SS0PV</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x20</resetValue>
+                    <resetMask>0xBF</resetMask>
+                    <fields>
+                        <field>
+                            <name>OVRERF</name>
+                            <description>desc OVRERF</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>IDLNF</name>
+                            <description>desc IDLNF</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MODFERF</name>
+                            <description>desc MODFERF</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERF</name>
+                            <description>desc PERF</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDRERF</name>
+                            <description>desc UDRERF</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TDEF</name>
+                            <description>desc TDEF</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDFF</name>
+                            <description>desc RDFF</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CFG2</name>
+                    <description>desc CFG2</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x31D</resetValue>
+                    <resetMask>0x111F</resetMask>
+                    <fields>
+                        <field>
+                            <name>CPHA</name>
+                            <description>desc CPHA</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPOL</name>
+                            <description>desc CPOL</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MBR</name>
+                            <description>desc MBR</description>
+                            <msb>4</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DSIZE</name>
+                            <description>desc DSIZE</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LSBF</name>
+                            <description>desc LSBF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>SWDT</name>
+            <description>desc SWDT</description>
+            <baseAddress>0x4000CC00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0xC</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CR</name>
+                    <description>desc CR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80010FF3</resetValue>
+                    <resetMask>0x80010FF3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PERI</name>
+                            <description>desc PERI</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKS</name>
+                            <description>desc CKS</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>WDPT</name>
+                            <description>desc WDPT</description>
+                            <msb>11</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLPOFF</name>
+                            <description>desc SLPOFF</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITS</name>
+                            <description>desc ITS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3FFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>UDF</name>
+                            <description>desc UDF</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>REF</name>
+                            <description>desc REF</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>RR</name>
+                    <description>desc RR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>RF</name>
+                            <description>desc RF</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMR0</name>
+            <description>desc TMR0</description>
+            <baseAddress>0x40005800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x18</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTAR</name>
+                    <description>desc CNTAR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNTA</name>
+                            <description>desc CNTA</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPA</name>
+                            <description>desc CMPA</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCONR</name>
+                    <description>desc BCONR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xF7F7</resetMask>
+                    <fields>
+                        <field>
+                            <name>CSTA</name>
+                            <description>desc CSTA</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CAPMDA</name>
+                            <description>desc CAPMDA</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>INTENA</name>
+                            <description>desc INTENA</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIVA</name>
+                            <description>desc CKDIVA</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNSA</name>
+                            <description>desc SYNSA</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNCLKA</name>
+                            <description>desc SYNCLKA</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ASYNCLKA</name>
+                            <description>desc ASYNCLKA</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTAA</name>
+                            <description>desc HSTAA</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTPA</name>
+                            <description>desc HSTPA</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLEA</name>
+                            <description>desc HCLEA</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICPA</name>
+                            <description>desc HICPA</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMFA</name>
+                            <description>desc CMFA</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB1</name>
+            <description>desc TMRB1</description>
+            <baseAddress>0x40007800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB2</name>
+            <description>desc TMRB2</description>
+            <baseAddress>0x40007C00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB3</name>
+            <description>desc TMRB3</description>
+            <baseAddress>0x40008000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB4</name>
+            <description>desc TMRB4</description>
+            <baseAddress>0x40008400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB5</name>
+            <description>desc TMRB5</description>
+            <baseAddress>0x40008800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB6</name>
+            <description>desc TMRB6</description>
+            <baseAddress>0x40008C00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB7</name>
+            <description>desc TMRB7</description>
+            <baseAddress>0x40009000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>TMRB8</name>
+            <description>desc TMRB8</description>
+            <baseAddress>0x40009400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x144</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CNTER</name>
+                    <description>desc CNTER</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CNT</name>
+                            <description>desc CNT</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PERAR</name>
+                    <description>desc PERAR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>PER</name>
+                            <description>desc PER</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CMPAR</name>
+                    <description>desc CMPAR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0xFFFF</resetValue>
+                    <resetMask>0xFFFF</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMP</name>
+                            <description>desc CMP</description>
+                            <msb>15</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BCSTR</name>
+                    <description>desc BCSTR</description>
+                    <addressOffset>0x80</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x2</resetValue>
+                    <resetMask>0xF1FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>START</name>
+                            <description>desc START</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>DIR</name>
+                            <description>desc DIR</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MODE</name>
+                            <description>desc MODE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SYNST</name>
+                            <description>desc SYNST</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CKDIV</name>
+                            <description>desc CKDIV</description>
+                            <msb>7</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVSTP</name>
+                            <description>desc OVSTP</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENOVF</name>
+                            <description>desc ITENOVF</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ITENUDF</name>
+                            <description>desc ITENUDF</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVFF</name>
+                            <description>desc OVFF</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>UDFF</name>
+                            <description>desc UDFF</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCONR</name>
+                    <description>desc HCONR</description>
+                    <addressOffset>0x84</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3777</resetMask>
+                    <fields>
+                        <field>
+                            <name>HSTA0</name>
+                            <description>desc HSTA0</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA1</name>
+                            <description>desc HSTA1</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTA2</name>
+                            <description>desc HSTA2</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP0</name>
+                            <description>desc HSTP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP1</name>
+                            <description>desc HSTP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HSTP2</name>
+                            <description>desc HSTP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE0</name>
+                            <description>desc HCLE0</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE1</name>
+                            <description>desc HCLE1</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE2</name>
+                            <description>desc HCLE2</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE3</name>
+                            <description>desc HCLE3</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCLE4</name>
+                            <description>desc HCLE4</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCUPR</name>
+                    <description>desc HCUPR</description>
+                    <addressOffset>0x88</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCUP8</name>
+                            <description>desc HCUP8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP9</name>
+                            <description>desc HCUP9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP10</name>
+                            <description>desc HCUP10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP11</name>
+                            <description>desc HCUP11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCUP12</name>
+                            <description>desc HCUP12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>HCDOR</name>
+                    <description>desc HCDOR</description>
+                    <addressOffset>0x8C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1F00</resetMask>
+                    <fields>
+                        <field>
+                            <name>HCDO8</name>
+                            <description>desc HCDO8</description>
+                            <msb>8</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO9</name>
+                            <description>desc HCDO9</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO10</name>
+                            <description>desc HCDO10</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO11</name>
+                            <description>desc HCDO11</description>
+                            <msb>11</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HCDO12</name>
+                            <description>desc HCDO12</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ICONR</name>
+                    <description>desc ICONR</description>
+                    <addressOffset>0x90</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ITEN1</name>
+                            <description>desc ITEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>ECONR</name>
+                    <description>desc ECONR</description>
+                    <addressOffset>0x94</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>ETEN1</name>
+                            <description>desc ETEN1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>STFLR</name>
+                    <description>desc STFLR</description>
+                    <addressOffset>0x9C</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x1</resetMask>
+                    <fields>
+                        <field>
+                            <name>CMPF1</name>
+                            <description>desc CMPF1</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CCONR</name>
+                    <description>desc CCONR</description>
+                    <addressOffset>0x100</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7071</resetMask>
+                    <fields>
+                        <field>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP0</name>
+                            <description>desc HICP0</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP1</name>
+                            <description>desc HICP1</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>HICP2</name>
+                            <description>desc HICP2</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFIENCP</name>
+                            <description>desc NOFIENCP</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NOFICKCP</name>
+                            <description>desc NOFICKCP</description>
+                            <msb>14</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PCONR</name>
+                    <description>desc PCONR</description>
+                    <addressOffset>0x140</addressOffset>
+                    <size>16</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x13FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>STAC</name>
+                            <description>desc STAC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STPC</name>
+                            <description>desc STPC</description>
+                            <msb>3</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CMPC</name>
+                            <description>desc CMPC</description>
+                            <msb>5</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PERC</name>
+                            <description>desc PERC</description>
+                            <msb>7</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FORC</name>
+                            <description>desc FORC</description>
+                            <msb>9</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OUTEN</name>
+                            <description>desc OUTEN</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART1</name>
+            <description>desc USART1</description>
+            <baseAddress>0x40001800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART2</name>
+            <description>desc USART2</description>
+            <baseAddress>0x40001C00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART3</name>
+            <description>desc USART3</description>
+            <baseAddress>0x40002000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART4</name>
+            <description>desc USART4</description>
+            <baseAddress>0x40002400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART5</name>
+            <description>desc USART5</description>
+            <baseAddress>0x40002800</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+        <peripheral>
+            <name>USART6</name>
+            <description>desc USART6</description>
+            <baseAddress>0x40002C00</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>SR</name>
+                    <description>desc SR</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-only</access>
+                    <resetValue>0xC0</resetValue>
+                    <resetMask>0x100EB</resetMask>
+                    <fields>
+                        <field>
+                            <name>PE</name>
+                            <description>desc PE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>FE</name>
+                            <description>desc FE</description>
+                            <msb>1</msb>
+                            <lsb>1</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>ORE</name>
+                            <description>desc ORE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>RXNE</name>
+                            <description>desc RXNE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TC</name>
+                            <description>desc TC</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>TXE</name>
+                            <description>desc TXE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-only</access>
+                        </field>
+                        <field>
+                            <name>MPB</name>
+                            <description>desc MPB</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-only</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>DR</name>
+                    <description>desc DR</description>
+                    <addressOffset>0x4</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
+                    <resetMask>0x1FF03FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TDR</name>
+                            <description>desc TDR</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>MPID</name>
+                            <description>desc MPID</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RDR</name>
+                            <description>desc RDR</description>
+                            <msb>24</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>BRR</name>
+                    <description>desc BRR</description>
+                    <addressOffset>0x8</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0xFF00</resetValue>
+                    <resetMask>0xFF00</resetMask>
+                    <fields>
+                        <field>
+                            <name>DIV_INTEGER</name>
+                            <description>desc DIV_INTEGER</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR1</name>
+                    <description>desc CR1</description>
+                    <addressOffset>0xC</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <resetMask>0xD10B96FC</resetMask>
+                    <fields>
+                        <field>
+                            <name>RE</name>
+                            <description>desc RE</description>
+                            <msb>2</msb>
+                            <lsb>2</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TE</name>
+                            <description>desc TE</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SLME</name>
+                            <description>desc SLME</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>RIE</name>
+                            <description>desc RIE</description>
+                            <msb>5</msb>
+                            <lsb>5</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TCIE</name>
+                            <description>desc TCIE</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>TXEIE</name>
+                            <description>desc TXEIE</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PS</name>
+                            <description>desc PS</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PCE</name>
+                            <description>desc PCE</description>
+                            <msb>10</msb>
+                            <lsb>10</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>M</name>
+                            <description>desc M</description>
+                            <msb>12</msb>
+                            <lsb>12</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>OVER8</name>
+                            <description>desc OVER8</description>
+                            <msb>15</msb>
+                            <lsb>15</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CPE</name>
+                            <description>desc CPE</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CFE</name>
+                            <description>desc CFE</description>
+                            <msb>17</msb>
+                            <lsb>17</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>CORE</name>
+                            <description>desc CORE</description>
+                            <msb>19</msb>
+                            <lsb>19</lsb>
+                            <access>write-only</access>
+                        </field>
+                        <field>
+                            <name>MS</name>
+                            <description>desc MS</description>
+                            <msb>24</msb>
+                            <lsb>24</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>ML</name>
+                            <description>desc ML</description>
+                            <msb>28</msb>
+                            <lsb>28</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>NFE</name>
+                            <description>desc NFE</description>
+                            <msb>30</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>SBS</name>
+                            <description>desc SBS</description>
+                            <msb>31</msb>
+                            <lsb>31</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR2</name>
+                    <description>desc CR2</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x7801</resetMask>
+                    <fields>
+                        <field>
+                            <name>MPE</name>
+                            <description>desc MPE</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CLKC</name>
+                            <description>desc CLKC</description>
+                            <msb>12</msb>
+                            <lsb>11</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>STOP</name>
+                            <description>desc STOP</description>
+                            <msb>13</msb>
+                            <lsb>13</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>LINEN</name>
+                            <description>desc LINEN</description>
+                            <msb>14</msb>
+                            <lsb>14</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CR3</name>
+                    <description>desc CR3</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x208</resetMask>
+                    <fields>
+                        <field>
+                            <name>HDSEL</name>
+                            <description>desc HDSEL</description>
+                            <msb>3</msb>
+                            <lsb>3</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>CTSE</name>
+                            <description>desc CTSE</description>
+                            <msb>9</msb>
+                            <lsb>9</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>PR</name>
+                    <description>desc PR</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x3</resetMask>
+                    <fields>
+                        <field>
+                            <name>PSC</name>
+                            <description>desc PSC</description>
+                            <msb>1</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>
+    </peripherals>
+</device>

--- a/pyocd/debug/svd/data/HC32F460.svd
+++ b/pyocd/debug/svd/data/HC32F460.svd
@@ -2,7 +2,7 @@
 <device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD.xsd">
     <vendor>HDSC Co.,Ltd.</vendor>
     <vendorID>HDSC</vendorID>
-    <name>HDSC_HC32F460PETB</name>
+    <name>HDSC_HC32F46X</name>
     <series>ARMCM4</series>
     <version>1.0</version>
     <cpu>
@@ -1112,13 +1112,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1130,13 +1137,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1148,13 +1162,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1166,13 +1187,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1184,13 +1212,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1202,13 +1237,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1220,13 +1262,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1238,13 +1287,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1256,13 +1312,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1274,13 +1337,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1292,13 +1362,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1310,7 +1387,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
@@ -1319,22 +1396,36 @@
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
                     </fields>
                 </register>
                 <register>
-                    <name>DMATRGSELRC</name>
-                    <description>desc DMATRGSELRC</description>
+                    <name>DMA_TRGSELRC</name>
+                    <description>desc DMA_TRGSELRC</description>
                     <addressOffset>0x34</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1346,13 +1437,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1364,13 +1462,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1382,13 +1487,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1400,13 +1512,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1418,13 +1537,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1436,13 +1562,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1454,13 +1587,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1472,13 +1612,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1490,13 +1637,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1508,13 +1662,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1526,13 +1687,20 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0x1FF</resetMask>
+                    <resetMask>0xC00001FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -1544,6 +1712,31 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
+                    <resetMask>0xC00001FF</resetMask>
+                    <fields>
+                        <field>
+                            <name>TRGSEL</name>
+                            <description>desc TRGSEL</description>
+                            <msb>8</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>COMTRG_EN</name>
+                            <description>desc COMTRG_EN</description>
+                            <msb>31</msb>
+                            <lsb>30</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>COMTRG1</name>
+                    <description>desc COMTRG1</description>
+                    <addressOffset>0x68</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x1FF</resetValue>
                     <resetMask>0x1FF</resetMask>
                     <fields>
                         <field>
@@ -1556,51 +1749,19 @@
                     </fields>
                 </register>
                 <register>
-                    <name>COMTRG1</name>
-                    <description>desc COMTRG1</description>
-                    <addressOffset>0x68</addressOffset>
-                    <size>32</size>
-                    <access>read-write</access>
-                    <resetValue>0x1FF</resetValue>
-                    <resetMask>0xC00001FF</resetMask>
-                    <fields>
-                        <field>
-                            <name>TRGSEL</name>
-                            <description>desc TRGSEL</description>
-                            <msb>8</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>COMTRG_EN</name>
-                            <description>desc COMTRG_EN</description>
-                            <msb>31</msb>
-                            <lsb>30</lsb>
-                            <access>read-write</access>
-                        </field>
-                    </fields>
-                </register>
-                <register>
                     <name>COMTRG2</name>
                     <description>desc COMTRG2</description>
                     <addressOffset>0x6C</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x1FF</resetValue>
-                    <resetMask>0xC00001FF</resetMask>
+                    <resetMask>0x1FF</resetMask>
                     <fields>
                         <field>
                             <name>TRGSEL</name>
                             <description>desc TRGSEL</description>
                             <msb>8</msb>
                             <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>COMTRG_EN</name>
-                            <description>desc COMTRG_EN</description>
-                            <msb>31</msb>
-                            <lsb>30</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -5128,8 +5289,8 @@
             </addressBlock>
             <registers>
                 <register>
-                    <name>RBUF0</name>
-                    <description>desc RBUF0</description>
+                    <name>RBUF</name>
+                    <description>desc RBUF</description>
                     <addressOffset>0x0</addressOffset>
                     <size>32</size>
                     <access>read-only</access>
@@ -5137,63 +5298,9 @@
                     <resetMask>0xFFFFFFFF</resetMask>
                 </register>
                 <register>
-                    <name>RBUF1</name>
-                    <description>desc RBUF1</description>
-                    <addressOffset>0x4</addressOffset>
-                    <size>32</size>
-                    <access>read-only</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>RBUF2</name>
-                    <description>desc RBUF2</description>
-                    <addressOffset>0x8</addressOffset>
-                    <size>32</size>
-                    <access>read-only</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>RBUF3</name>
-                    <description>desc RBUF3</description>
-                    <addressOffset>0xC</addressOffset>
-                    <size>32</size>
-                    <access>read-only</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>TBUF0</name>
-                    <description>desc TBUF0</description>
+                    <name>TBUF</name>
+                    <description>desc TBUF</description>
                     <addressOffset>0x50</addressOffset>
-                    <size>32</size>
-                    <access>read-write</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>TBUF1</name>
-                    <description>desc TBUF1</description>
-                    <addressOffset>0x54</addressOffset>
-                    <size>32</size>
-                    <access>read-write</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>TBUF2</name>
-                    <description>desc TBUF2</description>
-                    <addressOffset>0x58</addressOffset>
-                    <size>32</size>
-                    <access>read-write</access>
-                    <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFFFFF</resetMask>
-                </register>
-                <register>
-                    <name>TBUF3</name>
-                    <description>desc TBUF3</description>
-                    <addressOffset>0x5C</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
@@ -6316,6 +6423,13 @@
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
+                        <field>
+                            <name>WPRT</name>
+                            <description>desc WPRT</description>
+                            <msb>15</msb>
+                            <lsb>8</lsb>
+                            <access>read-write</access>
+                        </field>
                     </fields>
                 </register>
             </registers>
@@ -6339,8 +6453,8 @@
                     <resetMask>0x1E</resetMask>
                     <fields>
                         <field>
-                            <name>SEL</name>
-                            <description>desc SEL</description>
+                            <name>CRC_SEL</name>
+                            <description>desc CRC_SEL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
@@ -6903,22 +7017,22 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>VDU0STP</name>
-                            <description>desc VDU0STP</description>
+                            <name>PVD0STP</name>
+                            <description>desc PVD0STP</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>VDU1STP</name>
-                            <description>desc VDU1STP</description>
+                            <name>PVD1STP</name>
+                            <description>desc PVD1STP</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>VDU2STP</name>
-                            <description>desc VDU2STP</description>
+                            <name>PVD2STP</name>
+                            <description>desc PVD2STP</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
@@ -7033,17 +7147,17 @@
                     <resetMask>0x7</resetMask>
                     <fields>
                         <field>
-                            <name>TRACEIOEN</name>
-                            <description>desc TRACEIOEN</description>
-                            <msb>0</msb>
+                            <name>TRACEMODE</name>
+                            <description>desc TRACEMODE</description>
+                            <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>TRACEMODE</name>
-                            <description>desc TRACEMODE</description>
+                            <name>TRACEIOEN</name>
+                            <description>desc TRACEIOEN</description>
                             <msb>2</msb>
-                            <lsb>1</lsb>
+                            <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -7856,8 +7970,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRTPEN</name>
-                            <description>desc SRTPEN</description>
+                            <name>SRPTEN</name>
+                            <description>desc SRPTEN</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
@@ -8266,8 +8380,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRTPEN</name>
-                            <description>desc SRTPEN</description>
+                            <name>SRPTEN</name>
+                            <description>desc SRPTEN</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
@@ -8676,8 +8790,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRTPEN</name>
-                            <description>desc SRTPEN</description>
+                            <name>SRPTEN</name>
+                            <description>desc SRPTEN</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
@@ -9086,8 +9200,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRTPEN</name>
-                            <description>desc SRTPEN</description>
+                            <name>SRPTEN</name>
+                            <description>desc SRPTEN</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
@@ -9278,7 +9392,7 @@
             <baseAddress>0x40010400</baseAddress>
             <addressBlock>
                 <offset>0x0</offset>
-                <size>0x10C</size>
+                <size>0x208</size>
             </addressBlock>
             <registers>
                 <register>
@@ -9440,8 +9554,8 @@
                             <access>read-only</access>
                         </field>
                         <field>
-                            <name>RDCOLERR</name>
-                            <description>desc RDCOLERR</description>
+                            <name>COLERR</name>
+                            <description>desc COLERR</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-only</access>
@@ -9500,8 +9614,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>RDCOLERRCLR</name>
-                            <description>desc RDCOLERRCLR</description>
+                            <name>COLERRCLR</name>
+                            <description>desc COLERRCLR</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
@@ -9532,8 +9646,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>RDCOLERRITE</name>
-                            <description>desc RDCOLERRITE</description>
+                            <name>COLERRITE</name>
+                            <description>desc COLERRITE</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
@@ -9565,12 +9679,12 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFF</resetMask>
+                    <resetMask>0x7FFFF</resetMask>
                     <fields>
                         <field>
                             <name>FPMTSW</name>
                             <description>desc FPMTSW</description>
-                            <msb>19</msb>
+                            <msb>18</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
@@ -9583,12 +9697,12 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xFFFFF</resetMask>
+                    <resetMask>0x7FFFF</resetMask>
                     <fields>
                         <field>
                             <name>FPMTEW</name>
                             <description>desc FPMTEW</description>
-                            <msb>19</msb>
+                            <msb>18</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
@@ -9703,6 +9817,31 @@
                         </field>
                     </fields>
                 </register>
+                <register>
+                    <name>EFM_FRANDS</name>
+                    <description>desc EFM_FRANDS</description>
+                    <addressOffset>0x204</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0x17FFE</resetMask>
+                    <fields>
+                        <field>
+                            <name>FRANDS</name>
+                            <description>desc FRANDS</description>
+                            <msb>14</msb>
+                            <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>FRANDFG</name>
+                            <description>desc FRANDFG</description>
+                            <msb>16</msb>
+                            <lsb>16</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
             </registers>
         </peripheral>
         <peripheral>
@@ -9745,8 +9884,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PWMSEL</name>
-                            <description>desc PWMSEL</description>
+                            <name>PWMSEN</name>
+                            <description>desc PWMSEN</description>
                             <msb>8</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -10684,8 +10823,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SMHOSTIE</name>
-                            <description>desc SMHOSTIE</description>
+                            <name>SMBHOSTIE</name>
+                            <description>desc SMBHOSTIE</description>
                             <msb>22</msb>
                             <lsb>22</lsb>
                             <access>read-write</access>
@@ -11077,7 +11216,7 @@
                     <name>DTR</name>
                     <description>desc DTR</description>
                     <addressOffset>0x24</addressOffset>
-                    <size>32</size>
+                    <size>8</size>
                     <access>write-only</access>
                     <resetValue>0xFF</resetValue>
                     <resetMask>0xFF</resetMask>
@@ -11095,7 +11234,7 @@
                     <name>DRR</name>
                     <description>desc DRR</description>
                     <addressOffset>0x28</addressOffset>
-                    <size>32</size>
+                    <size>8</size>
                     <access>read-only</access>
                     <resetValue>0x0</resetValue>
                     <resetMask>0xFF</resetMask>
@@ -11370,8 +11509,8 @@
                             <access>read-only</access>
                         </field>
                         <field>
-                            <name>TXBUF</name>
-                            <description>desc TXBUF</description>
+                            <name>TXBF</name>
+                            <description>desc TXBF</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-only</access>
@@ -11384,8 +11523,8 @@
                             <access>read-only</access>
                         </field>
                         <field>
-                            <name>RXBUF</name>
-                            <description>desc RXBUF</description>
+                            <name>RXBF</name>
+                            <description>desc RXBF</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-only</access>
@@ -11803,7 +11942,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF3F</resetMask>
+                    <resetMask>0xF2F</resetMask>
                     <fields>
                         <field>
                             <name>NMIENR</name>
@@ -11831,13 +11970,6 @@
                             <description>desc PVD2ENR</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32STPENR</name>
-                            <description>desc XTAL32STPENR</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -11884,7 +12016,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF3F</resetMask>
+                    <resetMask>0xF2F</resetMask>
                     <fields>
                         <field>
                             <name>NMIFR</name>
@@ -11912,13 +12044,6 @@
                             <description>desc PVD2FR</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32STPFR</name>
-                            <description>desc XTAL32STPFR</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -11965,7 +12090,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF3F</resetMask>
+                    <resetMask>0xF2F</resetMask>
                     <fields>
                         <field>
                             <name>NMICFR</name>
@@ -11993,13 +12118,6 @@
                             <description>desc PVD2CFR</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32STPCFR</name>
-                            <description>desc XTAL32STPCFR</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -12624,8 +12742,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SCIWEN</name>
-                            <description>desc SCIWEN</description>
+                            <name>RXWUEN</name>
+                            <description>desc RXWUEN</description>
                             <msb>25</msb>
                             <lsb>25</lsb>
                             <access>read-write</access>
@@ -19729,7 +19847,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x3</resetMask>
+                    <resetMask>0x7</resetMask>
                     <fields>
                         <field>
                             <name>INDEX</name>
@@ -21372,29 +21490,29 @@
                     <resetMask>0x8FF3C511</resetMask>
                     <fields>
                         <field>
-                            <name>RAMHS</name>
-                            <description>desc RAMHS</description>
+                            <name>SRAMH</name>
+                            <description>desc SRAMH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>RAM0</name>
-                            <description>desc RAM0</description>
+                            <name>SRAM12</name>
+                            <description>desc SRAM12</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ECCRAM</name>
-                            <description>desc ECCRAM</description>
+                            <name>SRAM3</name>
+                            <description>desc SRAM3</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>RETRAM</name>
-                            <description>desc RETRAM</description>
+                            <name>SRAMRET</name>
+                            <description>desc SRAMRET</description>
                             <msb>10</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
@@ -21766,7 +21884,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0xFFFFFFFF</resetValue>
-                    <resetMask>0x1113</resetMask>
+                    <resetMask>0x1103</resetMask>
                     <fields>
                         <field>
                             <name>ADC1</name>
@@ -21780,13 +21898,6 @@
                             <description>desc ADC2</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>DAC</name>
-                            <description>desc DAC</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -21888,120 +21999,6 @@
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
                     <resetMask>0xFFFF</resetMask>
-                    <fields>
-                        <field>
-                            <name>TSDC0</name>
-                            <description>desc TSDC0</description>
-                            <msb>0</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC1</name>
-                            <description>desc TSDC1</description>
-                            <msb>1</msb>
-                            <lsb>1</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC2</name>
-                            <description>desc TSDC2</description>
-                            <msb>2</msb>
-                            <lsb>2</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC3</name>
-                            <description>desc TSDC3</description>
-                            <msb>3</msb>
-                            <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC4</name>
-                            <description>desc TSDC4</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC5</name>
-                            <description>desc TSDC5</description>
-                            <msb>5</msb>
-                            <lsb>5</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC6</name>
-                            <description>desc TSDC6</description>
-                            <msb>6</msb>
-                            <lsb>6</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC7</name>
-                            <description>desc TSDC7</description>
-                            <msb>7</msb>
-                            <lsb>7</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC8</name>
-                            <description>desc TSDC8</description>
-                            <msb>8</msb>
-                            <lsb>8</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC9</name>
-                            <description>desc TSDC9</description>
-                            <msb>9</msb>
-                            <lsb>9</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC10</name>
-                            <description>desc TSDC10</description>
-                            <msb>10</msb>
-                            <lsb>10</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC11</name>
-                            <description>desc TSDC11</description>
-                            <msb>11</msb>
-                            <lsb>11</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC12</name>
-                            <description>desc TSDC12</description>
-                            <msb>12</msb>
-                            <lsb>12</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC13</name>
-                            <description>desc TSDC13</description>
-                            <msb>13</msb>
-                            <lsb>13</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC14</name>
-                            <description>desc TSDC14</description>
-                            <msb>14</msb>
-                            <lsb>14</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC15</name>
-                            <description>desc TSDC15</description>
-                            <msb>15</msb>
-                            <lsb>15</lsb>
-                            <access>read-write</access>
-                        </field>
-                    </fields>
                 </register>
                 <register>
                     <name>DR2</name>
@@ -22011,120 +22008,6 @@
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
                     <resetMask>0xFFFF</resetMask>
-                    <fields>
-                        <field>
-                            <name>TSDC0</name>
-                            <description>desc TSDC0</description>
-                            <msb>0</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC1</name>
-                            <description>desc TSDC1</description>
-                            <msb>1</msb>
-                            <lsb>1</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC2</name>
-                            <description>desc TSDC2</description>
-                            <msb>2</msb>
-                            <lsb>2</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC3</name>
-                            <description>desc TSDC3</description>
-                            <msb>3</msb>
-                            <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC4</name>
-                            <description>desc TSDC4</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC5</name>
-                            <description>desc TSDC5</description>
-                            <msb>5</msb>
-                            <lsb>5</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC6</name>
-                            <description>desc TSDC6</description>
-                            <msb>6</msb>
-                            <lsb>6</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC7</name>
-                            <description>desc TSDC7</description>
-                            <msb>7</msb>
-                            <lsb>7</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC8</name>
-                            <description>desc TSDC8</description>
-                            <msb>8</msb>
-                            <lsb>8</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC9</name>
-                            <description>desc TSDC9</description>
-                            <msb>9</msb>
-                            <lsb>9</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC10</name>
-                            <description>desc TSDC10</description>
-                            <msb>10</msb>
-                            <lsb>10</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC11</name>
-                            <description>desc TSDC11</description>
-                            <msb>11</msb>
-                            <lsb>11</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC12</name>
-                            <description>desc TSDC12</description>
-                            <msb>12</msb>
-                            <lsb>12</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC13</name>
-                            <description>desc TSDC13</description>
-                            <msb>13</msb>
-                            <lsb>13</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC14</name>
-                            <description>desc TSDC14</description>
-                            <msb>14</msb>
-                            <lsb>14</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSDC15</name>
-                            <description>desc TSDC15</description>
-                            <msb>15</msb>
-                            <lsb>15</lsb>
-                            <access>read-write</access>
-                        </field>
-                    </fields>
                 </register>
                 <register>
                     <name>ECR</name>
@@ -22134,120 +22017,6 @@
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
                     <resetMask>0xFFFF</resetMask>
-                    <fields>
-                        <field>
-                            <name>TSEC0</name>
-                            <description>desc TSEC0</description>
-                            <msb>0</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC1</name>
-                            <description>desc TSEC1</description>
-                            <msb>1</msb>
-                            <lsb>1</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC2</name>
-                            <description>desc TSEC2</description>
-                            <msb>2</msb>
-                            <lsb>2</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC3</name>
-                            <description>desc TSEC3</description>
-                            <msb>3</msb>
-                            <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC4</name>
-                            <description>desc TSEC4</description>
-                            <msb>4</msb>
-                            <lsb>4</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC5</name>
-                            <description>desc TSEC5</description>
-                            <msb>5</msb>
-                            <lsb>5</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC6</name>
-                            <description>desc TSEC6</description>
-                            <msb>6</msb>
-                            <lsb>6</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC7</name>
-                            <description>desc TSEC7</description>
-                            <msb>7</msb>
-                            <lsb>7</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC8</name>
-                            <description>desc TSEC8</description>
-                            <msb>8</msb>
-                            <lsb>8</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC9</name>
-                            <description>desc TSEC9</description>
-                            <msb>9</msb>
-                            <lsb>9</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC10</name>
-                            <description>desc TSEC10</description>
-                            <msb>10</msb>
-                            <lsb>10</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC11</name>
-                            <description>desc TSEC11</description>
-                            <msb>11</msb>
-                            <lsb>11</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC12</name>
-                            <description>desc TSEC12</description>
-                            <msb>12</msb>
-                            <lsb>12</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC13</name>
-                            <description>desc TSEC13</description>
-                            <msb>13</msb>
-                            <lsb>13</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC14</name>
-                            <description>desc TSEC14</description>
-                            <msb>14</msb>
-                            <lsb>14</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>TSEC15</name>
-                            <description>desc TSEC15</description>
-                            <msb>15</msb>
-                            <lsb>15</lsb>
-                            <access>read-write</access>
-                        </field>
-                    </fields>
                 </register>
                 <register>
                     <name>LPR</name>
@@ -22317,27 +22086,13 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF</resetMask>
+                    <resetMask>0xA</resetMask>
                     <fields>
-                        <field>
-                            <name>ABINT1</name>
-                            <description>desc ABINT1</description>
-                            <msb>0</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
                         <field>
                             <name>SELMMC1</name>
                             <description>desc SELMMC1</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>ABINT2</name>
-                            <description>desc ABINT2</description>
-                            <msb>2</msb>
-                            <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -35538,15 +35293,15 @@
                     <resetMask>0xEB</resetMask>
                     <fields>
                         <field>
-                            <name>WAIT</name>
-                            <description>desc WAIT</description>
+                            <name>RWREQ</name>
+                            <description>desc RWREQ</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>WAITF</name>
-                            <description>desc WAITF</description>
+                            <name>RWEN</name>
+                            <description>desc RWEN</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
@@ -37316,22 +37071,22 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NXTDLE</name>
-                            <description>desc NXTDLE</description>
+                            <name>MIDIE</name>
+                            <description>desc MIDIE</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SSDLE</name>
-                            <description>desc SSDLE</description>
+                            <name>MSSDLE</name>
+                            <description>desc MSSDLE</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SCKDLE</name>
-                            <description>desc SCKDLE</description>
+                            <name>MSSIE</name>
+                            <description>desc MSSIE</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -37386,57 +37141,57 @@
                     <resetMask>0x77777777</resetMask>
                     <fields>
                         <field>
-                            <name>SRAMSYSRWT</name>
-                            <description>desc SRAMSYSRWT</description>
+                            <name>SRAM12_RWT</name>
+                            <description>desc SRAM12_RWT</description>
                             <msb>2</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMSYSWWT</name>
-                            <description>desc SRAMSYSWWT</description>
+                            <name>SRAM12_WWT</name>
+                            <description>desc SRAM12_WWT</description>
                             <msb>6</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMECCRWT</name>
-                            <description>desc SRAMECCRWT</description>
+                            <name>SRAM3_RWT</name>
+                            <description>desc SRAM3_RWT</description>
                             <msb>10</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMECCWWT</name>
-                            <description>desc SRAMECCWWT</description>
+                            <name>SRAM3_WWT</name>
+                            <description>desc SRAM3_WWT</description>
                             <msb>14</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMHSRWT</name>
-                            <description>desc SRAMHSRWT</description>
+                            <name>SRAMH_RWT</name>
+                            <description>desc SRAMH_RWT</description>
                             <msb>18</msb>
                             <lsb>16</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMHSWWT</name>
-                            <description>desc SRAMHSWWT</description>
+                            <name>SRAMH_WWT</name>
+                            <description>desc SRAMH_WWT</description>
                             <msb>22</msb>
                             <lsb>20</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMBKRWT</name>
-                            <description>desc SRAMBKRWT</description>
+                            <name>SRAMR_RWT</name>
+                            <description>desc SRAMR_RWT</description>
                             <msb>26</msb>
                             <lsb>24</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMBKWWT</name>
-                            <description>desc SRAMBKWWT</description>
+                            <name>SRAMR_WWT</name>
+                            <description>desc SRAMR_WWT</description>
                             <msb>30</msb>
                             <lsb>28</lsb>
                             <access>read-write</access>
@@ -37535,36 +37290,36 @@
                     <resetMask>0x1F</resetMask>
                     <fields>
                         <field>
-                            <name>SRAMECC1ERR</name>
-                            <description>desc SRAMECC1ERR</description>
+                            <name>SRAM3_1ERR</name>
+                            <description>desc SRAM3_1ERR</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMECC2ERR</name>
-                            <description>desc SRAMECC2ERR</description>
+                            <name>SRAM3_2ERR</name>
+                            <description>desc SRAM3_2ERR</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMSYSPYERR</name>
-                            <description>desc SRAMSYSPYERR</description>
+                            <name>SRAM12_PYERR</name>
+                            <description>desc SRAM12_PYERR</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMHSPYERR</name>
-                            <description>desc SRAMHSPYERR</description>
+                            <name>SRAMH_PYERR</name>
+                            <description>desc SRAMH_PYERR</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>SRAMBKPYERR</name>
-                            <description>desc SRAMBKPYERR</description>
+                            <name>SRAMR_PYERR</name>
+                            <description>desc SRAMR_PYERR</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
@@ -37649,7 +37404,7 @@
                     <addressOffset>0xC</addressOffset>
                     <size>16</size>
                     <access>read-write</access>
-                    <resetValue>0x0</resetValue>
+                    <resetValue>0x4000</resetValue>
                     <resetMask>0x8003</resetMask>
                     <fields>
                         <field>
@@ -37810,19 +37565,10 @@
                     <name>PWR_RAMOPM</name>
                     <description>desc PWR_RAMOPM</description>
                     <addressOffset>0x18</addressOffset>
-                    <size>32</size>
+                    <size>16</size>
                     <access>read-write</access>
                     <resetValue>0x8043</resetValue>
                     <resetMask>0xFFFF</resetMask>
-                    <fields>
-                        <field>
-                            <name>RAMOPM</name>
-                            <description>desc RAMOPM</description>
-                            <msb>15</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                    </fields>
                 </register>
                 <register>
                     <name>MPU_IPPR</name>
@@ -38600,13 +38346,27 @@
                     <size>8</size>
                     <access>read-write</access>
                     <resetValue>0x11</resetValue>
-                    <resetMask>0x22</resetMask>
+                    <resetMask>0x33</resetMask>
                     <fields>
+                        <field>
+                            <name>PVD1MON</name>
+                            <description>desc PVD1MON</description>
+                            <msb>0</msb>
+                            <lsb>0</lsb>
+                            <access>read-write</access>
+                        </field>
                         <field>
                             <name>PVD1DETFLG</name>
                             <description>desc PVD1DETFLG</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>PVD2MON</name>
+                            <description>desc PVD2MON</description>
+                            <msb>4</msb>
+                            <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -38872,7 +38632,7 @@
                     <addressOffset>0x403</addressOffset>
                     <size>8</size>
                     <access>read-write</access>
-                    <resetValue>0x0</resetValue>
+                    <resetValue>0x7</resetValue>
                     <resetMask>0x4</resetMask>
                     <fields>
                         <field>
@@ -39025,7 +38785,7 @@
                     <size>8</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF7</resetMask>
+                    <resetMask>0xB7</resetMask>
                     <fields>
                         <field>
                             <name>VD1WKE</name>
@@ -39060,13 +38820,6 @@
                             <description>desc RTCALMWKE</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32ERWKE</name>
-                            <description>desc XTAL32ERWKE</description>
-                            <msb>6</msb>
-                            <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -39205,15 +38958,8 @@
                     <size>8</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0xF8</resetMask>
+                    <resetMask>0xB8</resetMask>
                     <fields>
-                        <field>
-                            <name>RXD0WKF</name>
-                            <description>desc RXD0WKF</description>
-                            <msb>3</msb>
-                            <lsb>3</lsb>
-                            <access>read-write</access>
-                        </field>
                         <field>
                             <name>RTCPRDWKF</name>
                             <description>desc RTCPRDWKF</description>
@@ -39226,13 +38972,6 @@
                             <description>desc RTCALMWKF</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32ERWKF</name>
-                            <description>desc XTAL32ERWKF</description>
-                            <msb>6</msb>
-                            <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -39482,15 +39221,8 @@
                         <field>
                             <name>XTAL32DRV</name>
                             <description>desc XTAL32DRV</description>
-                            <msb>1</msb>
-                            <lsb>0</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>XTAL32SUPDRV</name>
-                            <description>desc XTAL32SUPDRV</description>
                             <msb>2</msb>
-                            <lsb>2</lsb>
+                            <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -39546,7 +39278,7 @@
                     <addressOffset>0x42B</addressOffset>
                     <size>8</size>
                     <access>read-write</access>
-                    <resetValue>0x0</resetValue>
+                    <resetValue>0x2</resetValue>
                     <resetMask>0x80</resetMask>
                     <fields>
                         <field>
@@ -39915,57 +39647,57 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCEHU</name>
-                            <description>desc OCEHU</description>
+                            <name>OCEH</name>
+                            <description>desc OCEH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCELU</name>
-                            <description>desc OCELU</description>
+                            <name>OCEL</name>
+                            <description>desc OCEL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPHU</name>
-                            <description>desc OCPHU</description>
+                            <name>OCPH</name>
+                            <description>desc OCPH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPLU</name>
-                            <description>desc OCPLU</description>
+                            <name>OCPL</name>
+                            <description>desc OCPL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIEHU</name>
-                            <description>desc OCIEHU</description>
+                            <name>OCIEH</name>
+                            <description>desc OCIEH</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIELU</name>
-                            <description>desc OCIELU</description>
+                            <name>OCIEL</name>
+                            <description>desc OCIEL</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFHU</name>
-                            <description>desc OCFHU</description>
+                            <name>OCFH</name>
+                            <description>desc OCFH</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFLU</name>
-                            <description>desc OCFLU</description>
+                            <name>OCFL</name>
+                            <description>desc OCFL</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -39982,71 +39714,71 @@
                     <resetMask>0x3FFF</resetMask>
                     <fields>
                         <field>
-                            <name>CHBUFENU</name>
-                            <description>desc CHBUFENU</description>
+                            <name>CHBUFEN</name>
+                            <description>desc CHBUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>CLBUFENU</name>
-                            <description>desc CLBUFENU</description>
+                            <name>CLBUFEN</name>
+                            <description>desc CLBUFEN</description>
                             <msb>3</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MHBUFENU</name>
-                            <description>desc MHBUFENU</description>
+                            <name>MHBUFEN</name>
+                            <description>desc MHBUFEN</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MLBUFENU</name>
-                            <description>desc MLBUFENU</description>
+                            <name>MLBUFEN</name>
+                            <description>desc MLBUFEN</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCHU</name>
-                            <description>desc LMCHU</description>
+                            <name>LMCH</name>
+                            <description>desc LMCH</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCLU</name>
-                            <description>desc LMCLU</description>
+                            <name>LMCL</name>
+                            <description>desc LMCL</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMHU</name>
-                            <description>desc LMMHU</description>
+                            <name>LMMH</name>
+                            <description>desc LMMH</description>
                             <msb>10</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMLU</name>
-                            <description>desc LMMLU</description>
+                            <name>LMML</name>
+                            <description>desc LMML</description>
                             <msb>11</msb>
                             <lsb>11</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECHU</name>
-                            <description>desc MCECHU</description>
+                            <name>MCECH</name>
+                            <description>desc MCECH</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECLU</name>
-                            <description>desc MCECLU</description>
+                            <name>MCECL</name>
+                            <description>desc MCECL</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
@@ -40063,57 +39795,57 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCEHV</name>
-                            <description>desc OCEHV</description>
+                            <name>OCEH</name>
+                            <description>desc OCEH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCELV</name>
-                            <description>desc OCELV</description>
+                            <name>OCEL</name>
+                            <description>desc OCEL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPHV</name>
-                            <description>desc OCPHV</description>
+                            <name>OCPH</name>
+                            <description>desc OCPH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPLV</name>
-                            <description>desc OCPLV</description>
+                            <name>OCPL</name>
+                            <description>desc OCPL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIEHV</name>
-                            <description>desc OCIEHV</description>
+                            <name>OCIEH</name>
+                            <description>desc OCIEH</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIELV</name>
-                            <description>desc OCIELV</description>
+                            <name>OCIEL</name>
+                            <description>desc OCIEL</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFHV</name>
-                            <description>desc OCFHV</description>
+                            <name>OCFH</name>
+                            <description>desc OCFH</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFLV</name>
-                            <description>desc OCFLV</description>
+                            <name>OCFL</name>
+                            <description>desc OCFL</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -40130,71 +39862,71 @@
                     <resetMask>0x3FFF</resetMask>
                     <fields>
                         <field>
-                            <name>CHBUFENV</name>
-                            <description>desc CHBUFENV</description>
+                            <name>CHBUFEN</name>
+                            <description>desc CHBUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>CLBUFENV</name>
-                            <description>desc CLBUFENV</description>
+                            <name>CLBUFEN</name>
+                            <description>desc CLBUFEN</description>
                             <msb>3</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MHBUFENV</name>
-                            <description>desc MHBUFENV</description>
+                            <name>MHBUFEN</name>
+                            <description>desc MHBUFEN</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MLBUFENV</name>
-                            <description>desc MLBUFENV</description>
+                            <name>MLBUFEN</name>
+                            <description>desc MLBUFEN</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCHV</name>
-                            <description>desc LMCHV</description>
+                            <name>LMCH</name>
+                            <description>desc LMCH</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCLV</name>
-                            <description>desc LMCLV</description>
+                            <name>LMCL</name>
+                            <description>desc LMCL</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMHV</name>
-                            <description>desc LMMHV</description>
+                            <name>LMMH</name>
+                            <description>desc LMMH</description>
                             <msb>10</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMLV</name>
-                            <description>desc LMMLV</description>
+                            <name>LMML</name>
+                            <description>desc LMML</description>
                             <msb>11</msb>
                             <lsb>11</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECHV</name>
-                            <description>desc MCECHV</description>
+                            <name>MCECH</name>
+                            <description>desc MCECH</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECLV</name>
-                            <description>desc MCECLV</description>
+                            <name>MCECL</name>
+                            <description>desc MCECL</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
@@ -40211,57 +39943,57 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCEHW</name>
-                            <description>desc OCEHW</description>
+                            <name>OCEH</name>
+                            <description>desc OCEH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCELW</name>
-                            <description>desc OCELW</description>
+                            <name>OCEL</name>
+                            <description>desc OCEL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPHW</name>
-                            <description>desc OCPHW</description>
+                            <name>OCPH</name>
+                            <description>desc OCPH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCPLW</name>
-                            <description>desc OCPLW</description>
+                            <name>OCPL</name>
+                            <description>desc OCPL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIEHW</name>
-                            <description>desc OCIEHW</description>
+                            <name>OCIEH</name>
+                            <description>desc OCIEH</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCIELW</name>
-                            <description>desc OCIELW</description>
+                            <name>OCIEL</name>
+                            <description>desc OCIEL</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFHW</name>
-                            <description>desc OCFHW</description>
+                            <name>OCFH</name>
+                            <description>desc OCFH</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFLW</name>
-                            <description>desc OCFLW</description>
+                            <name>OCFL</name>
+                            <description>desc OCFL</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -40278,71 +40010,71 @@
                     <resetMask>0x3FFF</resetMask>
                     <fields>
                         <field>
-                            <name>CHBUFENW</name>
-                            <description>desc CHBUFENW</description>
+                            <name>CHBUFEN</name>
+                            <description>desc CHBUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>CLBUFENW</name>
-                            <description>desc CLBUFENW</description>
+                            <name>CLBUFEN</name>
+                            <description>desc CLBUFEN</description>
                             <msb>3</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MHBUFENW</name>
-                            <description>desc MHBUFENW</description>
+                            <name>MHBUFEN</name>
+                            <description>desc MHBUFEN</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MLBUFENW</name>
-                            <description>desc MLBUFENW</description>
+                            <name>MLBUFEN</name>
+                            <description>desc MLBUFEN</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCHW</name>
-                            <description>desc LMCHW</description>
+                            <name>LMCH</name>
+                            <description>desc LMCH</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCLW</name>
-                            <description>desc LMCLW</description>
+                            <name>LMCL</name>
+                            <description>desc LMCL</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMHW</name>
-                            <description>desc LMMHW</description>
+                            <name>LMMH</name>
+                            <description>desc LMMH</description>
                             <msb>10</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMMLW</name>
-                            <description>desc LMMLW</description>
+                            <name>LMML</name>
+                            <description>desc LMML</description>
                             <msb>11</msb>
                             <lsb>11</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECHW</name>
-                            <description>desc MCECHW</description>
+                            <name>MCECH</name>
+                            <description>desc MCECH</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MCECLW</name>
-                            <description>desc MCECLW</description>
+                            <name>MCECL</name>
+                            <description>desc MCECL</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
@@ -40350,8 +40082,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRUH</name>
-                    <description>desc OCMRUH</description>
+                    <name>OCMRHUH</name>
+                    <description>desc OCMRHUH</description>
                     <addressOffset>0x24</addressOffset>
                     <size>16</size>
                     <access>read-write</access>
@@ -40359,71 +40091,71 @@
                     <resetMask>0xFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCHUH</name>
-                            <description>desc OCFDCHUH</description>
+                            <name>OCFDCH</name>
+                            <description>desc OCFDCH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKHUH</name>
-                            <description>desc OCFPKHUH</description>
+                            <name>OCFPKH</name>
+                            <description>desc OCFPKH</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCHUH</name>
-                            <description>desc OCFUCHUH</description>
+                            <name>OCFUCH</name>
+                            <description>desc OCFUCH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRHUH</name>
-                            <description>desc OCFZRHUH</description>
+                            <name>OCFZRH</name>
+                            <description>desc OCFZRH</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCHUH</name>
-                            <description>desc OPDCHUH</description>
+                            <name>OPDCH</name>
+                            <description>desc OPDCH</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKHUH</name>
-                            <description>desc OPPKHUH</description>
+                            <name>OPPKH</name>
+                            <description>desc OPPKH</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCHUH</name>
-                            <description>desc OPUCHUH</description>
+                            <name>OPUCH</name>
+                            <description>desc OPUCH</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRHUH</name>
-                            <description>desc OPZRHUH</description>
+                            <name>OPZRH</name>
+                            <description>desc OPZRH</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKHUH</name>
-                            <description>desc OPNPKHUH</description>
+                            <name>OPNPKH</name>
+                            <description>desc OPNPKH</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRHUH</name>
-                            <description>desc OPNZRHUH</description>
+                            <name>OPNZRH</name>
+                            <description>desc OPNZRH</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
@@ -40431,8 +40163,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRUL</name>
-                    <description>desc OCMRUL</description>
+                    <name>OCMRLUL</name>
+                    <description>desc OCMRLUL</description>
                     <addressOffset>0x28</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
@@ -40440,127 +40172,127 @@
                     <resetMask>0xFFFFFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCLUL</name>
-                            <description>desc OCFDCLUL</description>
+                            <name>OCFDCL</name>
+                            <description>desc OCFDCL</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKLUL</name>
-                            <description>desc OCFPKLUL</description>
+                            <name>OCFPKL</name>
+                            <description>desc OCFPKL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCLUL</name>
-                            <description>desc OCFUCLUL</description>
+                            <name>OCFUCL</name>
+                            <description>desc OCFUCL</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRLUL</name>
-                            <description>desc OCFZRLUL</description>
+                            <name>OCFZRL</name>
+                            <description>desc OCFZRL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCLUL</name>
-                            <description>desc OPDCLUL</description>
+                            <name>OPDCL</name>
+                            <description>desc OPDCL</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKLUL</name>
-                            <description>desc OPPKLUL</description>
+                            <name>OPPKL</name>
+                            <description>desc OPPKL</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCLUL</name>
-                            <description>desc OPUCLUL</description>
+                            <name>OPUCL</name>
+                            <description>desc OPUCL</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRLUL</name>
-                            <description>desc OPZRLUL</description>
+                            <name>OPZRL</name>
+                            <description>desc OPZRL</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKLUL</name>
-                            <description>desc OPNPKLUL</description>
+                            <name>OPNPKL</name>
+                            <description>desc OPNPKL</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRLUL</name>
-                            <description>desc OPNZRLUL</description>
+                            <name>OPNZRL</name>
+                            <description>desc OPNZRL</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNDCLUL</name>
-                            <description>desc EOPNDCLUL</description>
+                            <name>EOPNDCL</name>
+                            <description>desc EOPNDCL</description>
                             <msb>17</msb>
                             <lsb>16</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNUCLUL</name>
-                            <description>desc EOPNUCLUL</description>
+                            <name>EOPNUCL</name>
+                            <description>desc EOPNUCL</description>
                             <msb>19</msb>
                             <lsb>18</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPDCLUL</name>
-                            <description>desc EOPDCLUL</description>
+                            <name>EOPDCL</name>
+                            <description>desc EOPDCL</description>
                             <msb>21</msb>
                             <lsb>20</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPPKLUL</name>
-                            <description>desc EOPPKLUL</description>
+                            <name>EOPPKL</name>
+                            <description>desc EOPPKL</description>
                             <msb>23</msb>
                             <lsb>22</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPUCLUL</name>
-                            <description>desc EOPUCLUL</description>
+                            <name>EOPUCL</name>
+                            <description>desc EOPUCL</description>
                             <msb>25</msb>
                             <lsb>24</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPZRLUL</name>
-                            <description>desc EOPZRLUL</description>
+                            <name>EOPZRL</name>
+                            <description>desc EOPZRL</description>
                             <msb>27</msb>
                             <lsb>26</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNPKLUL</name>
-                            <description>desc EOPNPKLUL</description>
+                            <name>EOPNPKL</name>
+                            <description>desc EOPNPKL</description>
                             <msb>29</msb>
                             <lsb>28</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNZRLUL</name>
-                            <description>desc EOPNZRLUL</description>
+                            <name>EOPNZRL</name>
+                            <description>desc EOPNZRL</description>
                             <msb>31</msb>
                             <lsb>30</lsb>
                             <access>read-write</access>
@@ -40568,8 +40300,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRVH</name>
-                    <description>desc OCMRVH</description>
+                    <name>OCMRHVH</name>
+                    <description>desc OCMRHVH</description>
                     <addressOffset>0x2C</addressOffset>
                     <size>16</size>
                     <access>read-write</access>
@@ -40577,71 +40309,71 @@
                     <resetMask>0xFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCHVH</name>
-                            <description>desc OCFDCHVH</description>
+                            <name>OCFDCH</name>
+                            <description>desc OCFDCH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKHVH</name>
-                            <description>desc OCFPKHVH</description>
+                            <name>OCFPKH</name>
+                            <description>desc OCFPKH</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCHVH</name>
-                            <description>desc OCFUCHVH</description>
+                            <name>OCFUCH</name>
+                            <description>desc OCFUCH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRHVH</name>
-                            <description>desc OCFZRHVH</description>
+                            <name>OCFZRH</name>
+                            <description>desc OCFZRH</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCHVH</name>
-                            <description>desc OPDCHVH</description>
+                            <name>OPDCH</name>
+                            <description>desc OPDCH</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKHVH</name>
-                            <description>desc OPPKHVH</description>
+                            <name>OPPKH</name>
+                            <description>desc OPPKH</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCHVH</name>
-                            <description>desc OPUCHVH</description>
+                            <name>OPUCH</name>
+                            <description>desc OPUCH</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRHVH</name>
-                            <description>desc OPZRHVH</description>
+                            <name>OPZRH</name>
+                            <description>desc OPZRH</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKHVH</name>
-                            <description>desc OPNPKHVH</description>
+                            <name>OPNPKH</name>
+                            <description>desc OPNPKH</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRHVH</name>
-                            <description>desc OPNZRHVH</description>
+                            <name>OPNZRH</name>
+                            <description>desc OPNZRH</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
@@ -40649,8 +40381,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRVL</name>
-                    <description>desc OCMRVL</description>
+                    <name>OCMRLVL</name>
+                    <description>desc OCMRLVL</description>
                     <addressOffset>0x30</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
@@ -40658,127 +40390,127 @@
                     <resetMask>0xFFFFFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCLVL</name>
-                            <description>desc OCFDCLVL</description>
+                            <name>OCFDCL</name>
+                            <description>desc OCFDCL</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKLVL</name>
-                            <description>desc OCFPKLVL</description>
+                            <name>OCFPKL</name>
+                            <description>desc OCFPKL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCLVL</name>
-                            <description>desc OCFUCLVL</description>
+                            <name>OCFUCL</name>
+                            <description>desc OCFUCL</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRLVL</name>
-                            <description>desc OCFZRLVL</description>
+                            <name>OCFZRL</name>
+                            <description>desc OCFZRL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCLVL</name>
-                            <description>desc OPDCLVL</description>
+                            <name>OPDCL</name>
+                            <description>desc OPDCL</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKLVL</name>
-                            <description>desc OPPKLVL</description>
+                            <name>OPPKL</name>
+                            <description>desc OPPKL</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCLVL</name>
-                            <description>desc OPUCLVL</description>
+                            <name>OPUCL</name>
+                            <description>desc OPUCL</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRLVL</name>
-                            <description>desc OPZRLVL</description>
+                            <name>OPZRL</name>
+                            <description>desc OPZRL</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKLVL</name>
-                            <description>desc OPNPKLVL</description>
+                            <name>OPNPKL</name>
+                            <description>desc OPNPKL</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRLVL</name>
-                            <description>desc OPNZRLVL</description>
+                            <name>OPNZRL</name>
+                            <description>desc OPNZRL</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNDCLVL</name>
-                            <description>desc EOPNDCLVL</description>
+                            <name>EOPNDCL</name>
+                            <description>desc EOPNDCL</description>
                             <msb>17</msb>
                             <lsb>16</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNUCLVL</name>
-                            <description>desc EOPNUCLVL</description>
+                            <name>EOPNUCL</name>
+                            <description>desc EOPNUCL</description>
                             <msb>19</msb>
                             <lsb>18</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPDCLVL</name>
-                            <description>desc EOPDCLVL</description>
+                            <name>EOPDCL</name>
+                            <description>desc EOPDCL</description>
                             <msb>21</msb>
                             <lsb>20</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPPKLVL</name>
-                            <description>desc EOPPKLVL</description>
+                            <name>EOPPKL</name>
+                            <description>desc EOPPKL</description>
                             <msb>23</msb>
                             <lsb>22</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPUCLVL</name>
-                            <description>desc EOPUCLVL</description>
+                            <name>EOPUCL</name>
+                            <description>desc EOPUCL</description>
                             <msb>25</msb>
                             <lsb>24</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPZRLVL</name>
-                            <description>desc EOPZRLVL</description>
+                            <name>EOPZRL</name>
+                            <description>desc EOPZRL</description>
                             <msb>27</msb>
                             <lsb>26</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNPKLVL</name>
-                            <description>desc EOPNPKLVL</description>
+                            <name>EOPNPKL</name>
+                            <description>desc EOPNPKL</description>
                             <msb>29</msb>
                             <lsb>28</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNZRLVL</name>
-                            <description>desc EOPNZRLVL</description>
+                            <name>EOPNZRL</name>
+                            <description>desc EOPNZRL</description>
                             <msb>31</msb>
                             <lsb>30</lsb>
                             <access>read-write</access>
@@ -40786,8 +40518,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRWH</name>
-                    <description>desc OCMRWH</description>
+                    <name>OCMRHWH</name>
+                    <description>desc OCMRHWH</description>
                     <addressOffset>0x34</addressOffset>
                     <size>16</size>
                     <access>read-write</access>
@@ -40795,71 +40527,71 @@
                     <resetMask>0xFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCHWH</name>
-                            <description>desc OCFDCHWH</description>
+                            <name>OCFDCH</name>
+                            <description>desc OCFDCH</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKHWH</name>
-                            <description>desc OCFPKHWH</description>
+                            <name>OCFPKH</name>
+                            <description>desc OCFPKH</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCHWH</name>
-                            <description>desc OCFUCHWH</description>
+                            <name>OCFUCH</name>
+                            <description>desc OCFUCH</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRHWH</name>
-                            <description>desc OCFZRHWH</description>
+                            <name>OCFZRH</name>
+                            <description>desc OCFZRH</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCHWH</name>
-                            <description>desc OPDCHWH</description>
+                            <name>OPDCH</name>
+                            <description>desc OPDCH</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKHWH</name>
-                            <description>desc OPPKHWH</description>
+                            <name>OPPKH</name>
+                            <description>desc OPPKH</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCHWH</name>
-                            <description>desc OPUCHWH</description>
+                            <name>OPUCH</name>
+                            <description>desc OPUCH</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRHWH</name>
-                            <description>desc OPZRHWH</description>
+                            <name>OPZRH</name>
+                            <description>desc OPZRH</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKHWH</name>
-                            <description>desc OPNPKHWH</description>
+                            <name>OPNPKH</name>
+                            <description>desc OPNPKH</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRHWH</name>
-                            <description>desc OPNZRHWH</description>
+                            <name>OPNZRH</name>
+                            <description>desc OPNZRH</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
@@ -40867,8 +40599,8 @@
                     </fields>
                 </register>
                 <register>
-                    <name>OCMRWL</name>
-                    <description>desc OCMRWL</description>
+                    <name>OCMRLWL</name>
+                    <description>desc OCMRLWL</description>
                     <addressOffset>0x38</addressOffset>
                     <size>32</size>
                     <access>read-write</access>
@@ -40876,127 +40608,127 @@
                     <resetMask>0xFFFFFFFF</resetMask>
                     <fields>
                         <field>
-                            <name>OCFDCLWL</name>
-                            <description>desc OCFDCLWL</description>
+                            <name>OCFDCL</name>
+                            <description>desc OCFDCL</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFPKLWL</name>
-                            <description>desc OCFPKLWL</description>
+                            <name>OCFPKL</name>
+                            <description>desc OCFPKL</description>
                             <msb>1</msb>
                             <lsb>1</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFUCLWL</name>
-                            <description>desc OCFUCLWL</description>
+                            <name>OCFUCL</name>
+                            <description>desc OCFUCL</description>
                             <msb>2</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OCFZRLWL</name>
-                            <description>desc OCFZRLWL</description>
+                            <name>OCFZRL</name>
+                            <description>desc OCFZRL</description>
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPDCLWL</name>
-                            <description>desc OPDCLWL</description>
+                            <name>OPDCL</name>
+                            <description>desc OPDCL</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPPKLWL</name>
-                            <description>desc OPPKLWL</description>
+                            <name>OPPKL</name>
+                            <description>desc OPPKL</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPUCLWL</name>
-                            <description>desc OPUCLWL</description>
+                            <name>OPUCL</name>
+                            <description>desc OPUCL</description>
                             <msb>9</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPZRLWL</name>
-                            <description>desc OPZRLWL</description>
+                            <name>OPZRL</name>
+                            <description>desc OPZRL</description>
                             <msb>11</msb>
                             <lsb>10</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNPKLWL</name>
-                            <description>desc OPNPKLWL</description>
+                            <name>OPNPKL</name>
+                            <description>desc OPNPKL</description>
                             <msb>13</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>OPNZRLWL</name>
-                            <description>desc OPNZRLWL</description>
+                            <name>OPNZRL</name>
+                            <description>desc OPNZRL</description>
                             <msb>15</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNDCLWL</name>
-                            <description>desc EOPNDCLWL</description>
+                            <name>EOPNDCL</name>
+                            <description>desc EOPNDCL</description>
                             <msb>17</msb>
                             <lsb>16</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNUCLWL</name>
-                            <description>desc EOPNUCLWL</description>
+                            <name>EOPNUCL</name>
+                            <description>desc EOPNUCL</description>
                             <msb>19</msb>
                             <lsb>18</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPDCLWL</name>
-                            <description>desc EOPDCLWL</description>
+                            <name>EOPDCL</name>
+                            <description>desc EOPDCL</description>
                             <msb>21</msb>
                             <lsb>20</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPPKLWL</name>
-                            <description>desc EOPPKLWL</description>
+                            <name>EOPPKL</name>
+                            <description>desc EOPPKL</description>
                             <msb>23</msb>
                             <lsb>22</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPUCLWL</name>
-                            <description>desc EOPUCLWL</description>
+                            <name>EOPUCL</name>
+                            <description>desc EOPUCL</description>
                             <msb>25</msb>
                             <lsb>24</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPZRLWL</name>
-                            <description>desc EOPZRLWL</description>
+                            <name>EOPZRL</name>
+                            <description>desc EOPZRL</description>
                             <msb>27</msb>
                             <lsb>26</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNPKLWL</name>
-                            <description>desc EOPNPKLWL</description>
+                            <name>EOPNPKL</name>
+                            <description>desc EOPNPKL</description>
                             <msb>29</msb>
                             <lsb>28</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EOPNZRLWL</name>
-                            <description>desc EOPNZRLWL</description>
+                            <name>EOPNZRL</name>
+                            <description>desc EOPNZRL</description>
                             <msb>31</msb>
                             <lsb>30</lsb>
                             <access>read-write</access>
@@ -41232,22 +40964,22 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>DIVCKU</name>
-                            <description>desc DIVCKU</description>
+                            <name>DIVCK</name>
+                            <description>desc DIVCK</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PWMMDU</name>
-                            <description>desc PWMMDU</description>
+                            <name>PWMMD</name>
+                            <description>desc PWMMD</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LVLSU</name>
-                            <description>desc LVLSU</description>
+                            <name>LVLS</name>
+                            <description>desc LVLS</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -41264,22 +40996,22 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>DIVCKV</name>
-                            <description>desc DIVCKV</description>
+                            <name>DIVCK</name>
+                            <description>desc DIVCK</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PWMMDV</name>
-                            <description>desc PWMMDV</description>
+                            <name>PWMMD</name>
+                            <description>desc PWMMD</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LVLSV</name>
-                            <description>desc LVLSV</description>
+                            <name>LVLS</name>
+                            <description>desc LVLS</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -41296,22 +41028,22 @@
                     <resetMask>0xFF</resetMask>
                     <fields>
                         <field>
-                            <name>DIVCKW</name>
-                            <description>desc DIVCKW</description>
+                            <name>DIVCK</name>
+                            <description>desc DIVCK</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PWMMDW</name>
-                            <description>desc PWMMDW</description>
+                            <name>PWMMD</name>
+                            <description>desc PWMMD</description>
                             <msb>5</msb>
                             <lsb>4</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LVLSW</name>
-                            <description>desc LVLSW</description>
+                            <name>LVLS</name>
+                            <description>desc LVLS</description>
                             <msb>7</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -41498,64 +41230,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENUH</name>
-                            <description>desc BUFENUH</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSUH</name>
-                            <description>desc EVTOSUH</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCUH</name>
-                            <description>desc LMCUH</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSUH</name>
-                            <description>desc EVTMSUH</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSUH</name>
-                            <description>desc EVTDSUH</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENUH</name>
-                            <description>desc DENUH</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENUH</name>
-                            <description>desc PENUH</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENUH</name>
-                            <description>desc UENUH</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENUH</name>
-                            <description>desc ZENUH</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -41572,22 +41304,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCUH</name>
-                            <description>desc AMCUH</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEUH</name>
-                            <description>desc MZCEUH</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEUH</name>
-                            <description>desc MPCEUH</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -41604,64 +41336,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENUL</name>
-                            <description>desc BUFENUL</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSUL</name>
-                            <description>desc EVTOSUL</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCUL</name>
-                            <description>desc LMCUL</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSUL</name>
-                            <description>desc EVTMSUL</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSUL</name>
-                            <description>desc EVTDSUL</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENUL</name>
-                            <description>desc DENUL</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENUL</name>
-                            <description>desc PENUL</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENUL</name>
-                            <description>desc UENUL</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENUL</name>
-                            <description>desc ZENUL</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -41678,22 +41410,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCUL</name>
-                            <description>desc AMCUL</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEUL</name>
-                            <description>desc MZCEUL</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEUL</name>
-                            <description>desc MPCEUL</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -41710,64 +41442,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENVH</name>
-                            <description>desc BUFENVH</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSVH</name>
-                            <description>desc EVTOSVH</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCVH</name>
-                            <description>desc LMCVH</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSVH</name>
-                            <description>desc EVTMSVH</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSVH</name>
-                            <description>desc EVTDSVH</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENVH</name>
-                            <description>desc DENVH</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENVH</name>
-                            <description>desc PENVH</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENVH</name>
-                            <description>desc UENVH</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENVH</name>
-                            <description>desc ZENVH</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -41784,22 +41516,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCVH</name>
-                            <description>desc AMCVH</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEVH</name>
-                            <description>desc MZCEVH</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEVH</name>
-                            <description>desc MPCEVH</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -41816,64 +41548,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENVL</name>
-                            <description>desc BUFENVL</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSVL</name>
-                            <description>desc EVTOSVL</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCVL</name>
-                            <description>desc LMCVL</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSVL</name>
-                            <description>desc EVTMSVL</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSVL</name>
-                            <description>desc EVTDSVL</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENVL</name>
-                            <description>desc DENVL</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENVL</name>
-                            <description>desc PENVL</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENVL</name>
-                            <description>desc UENVL</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENVL</name>
-                            <description>desc ZENVL</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -41890,22 +41622,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCVL</name>
-                            <description>desc AMCVL</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEVL</name>
-                            <description>desc MZCEVL</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEVL</name>
-                            <description>desc MPCEVL</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -41922,64 +41654,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENWH</name>
-                            <description>desc BUFENWH</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSWH</name>
-                            <description>desc EVTOSWH</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCWH</name>
-                            <description>desc LMCWH</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSWH</name>
-                            <description>desc EVTMSWH</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSWH</name>
-                            <description>desc EVTDSWH</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENWH</name>
-                            <description>desc DENWH</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENWH</name>
-                            <description>desc PENWH</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENWH</name>
-                            <description>desc UENWH</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENWH</name>
-                            <description>desc ZENWH</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -41996,22 +41728,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCWH</name>
-                            <description>desc AMCWH</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEWH</name>
-                            <description>desc MZCEWH</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEWH</name>
-                            <description>desc MPCEWH</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -42028,64 +41760,64 @@
                     <resetMask>0xF33F</resetMask>
                     <fields>
                         <field>
-                            <name>BUFENWL</name>
-                            <description>desc BUFENWL</description>
+                            <name>BUFEN</name>
+                            <description>desc BUFEN</description>
                             <msb>1</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTOSWL</name>
-                            <description>desc EVTOSWL</description>
+                            <name>EVTOS</name>
+                            <description>desc EVTOS</description>
                             <msb>4</msb>
                             <lsb>2</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>LMCWL</name>
-                            <description>desc LMCWL</description>
+                            <name>LMC</name>
+                            <description>desc LMC</description>
                             <msb>5</msb>
                             <lsb>5</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTMSWL</name>
-                            <description>desc EVTMSWL</description>
+                            <name>EVTMS</name>
+                            <description>desc EVTMS</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>EVTDSWL</name>
-                            <description>desc EVTDSWL</description>
+                            <name>EVTDS</name>
+                            <description>desc EVTDS</description>
                             <msb>9</msb>
                             <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>DENWL</name>
-                            <description>desc DENWL</description>
+                            <name>DEN</name>
+                            <description>desc DEN</description>
                             <msb>12</msb>
                             <lsb>12</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>PENWL</name>
-                            <description>desc PENWL</description>
+                            <name>PEN</name>
+                            <description>desc PEN</description>
                             <msb>13</msb>
                             <lsb>13</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>UENWL</name>
-                            <description>desc UENWL</description>
+                            <name>UEN</name>
+                            <description>desc UEN</description>
                             <msb>14</msb>
                             <lsb>14</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>ZENWL</name>
-                            <description>desc ZENWL</description>
+                            <name>ZEN</name>
+                            <description>desc ZEN</description>
                             <msb>15</msb>
                             <lsb>15</lsb>
                             <access>read-write</access>
@@ -42102,22 +41834,22 @@
                     <resetMask>0xCF</resetMask>
                     <fields>
                         <field>
-                            <name>AMCWL</name>
-                            <description>desc AMCWL</description>
+                            <name>AMC</name>
+                            <description>desc AMC</description>
                             <msb>3</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MZCEWL</name>
-                            <description>desc MZCEWL</description>
+                            <name>MZCE</name>
+                            <description>desc MZCE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>MPCEWL</name>
-                            <description>desc MPCEWL</description>
+                            <name>MPCE</name>
+                            <description>desc MPCE</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -42765,7 +42497,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x1FFF1FFF</resetMask>
+                    <resetMask>0x19FF19FF</resetMask>
                     <fields>
                         <field>
                             <name>CAPMDA</name>
@@ -42814,13 +42546,6 @@
                             <description>desc OUTENA</description>
                             <msb>8</msb>
                             <lsb>8</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>EMBSELA</name>
-                            <description>desc EMBSELA</description>
-                            <msb>10</msb>
-                            <lsb>9</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -42877,13 +42602,6 @@
                             <description>desc OUTENB</description>
                             <msb>24</msb>
                             <lsb>24</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>EMBSELB</name>
-                            <description>desc EMBSELB</description>
-                            <msb>26</msb>
-                            <lsb>25</lsb>
                             <access>read-write</access>
                         </field>
                         <field>
@@ -44998,8 +44716,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45065,8 +44783,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45132,8 +44850,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45199,8 +44917,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45266,8 +44984,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45333,8 +45051,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45400,8 +45118,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -45467,8 +45185,8 @@
                     <resetMask>0x7371</resetMask>
                     <fields>
                         <field>
-                            <name>CAPMDA</name>
-                            <description>desc CAPMDA</description>
+                            <name>CAPMD</name>
+                            <description>desc CAPMD</description>
                             <msb>0</msb>
                             <lsb>0</lsb>
                             <access>read-write</access>
@@ -46436,7 +46154,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x10003</resetMask>
+                    <resetMask>0x3</resetMask>
                     <fields>
                         <field>
                             <name>PSC</name>
@@ -46485,6 +46203,31 @@
                 <size>0xE04</size>
             </addressBlock>
             <registers>
+                <register>
+                    <name>USBFS_GVBUSCFG</name>
+                    <description>desc USBFS_GVBUSCFG</description>
+                    <addressOffset>0x0</addressOffset>
+                    <size>32</size>
+                    <access>read-write</access>
+                    <resetValue>0x0</resetValue>
+                    <resetMask>0xC0</resetMask>
+                    <fields>
+                        <field>
+                            <name>VBUSOVEN</name>
+                            <description>desc VBUSOVEN</description>
+                            <msb>6</msb>
+                            <lsb>6</lsb>
+                            <access>read-write</access>
+                        </field>
+                        <field>
+                            <name>VBUSVAL</name>
+                            <description>desc VBUSVAL</description>
+                            <msb>7</msb>
+                            <lsb>7</lsb>
+                            <access>read-write</access>
+                        </field>
+                    </fields>
+                </register>
                 <register>
                     <name>GAHBCFG</name>
                     <description>desc GAHBCFG</description>
@@ -46675,8 +46418,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>RXFLNE</name>
-                            <description>desc RXFLNE</description>
+                            <name>RXFNE</name>
+                            <description>desc RXFNE</description>
                             <msb>4</msb>
                             <lsb>4</lsb>
                             <access>read-only</access>
@@ -46696,8 +46439,8 @@
                             <access>read-only</access>
                         </field>
                         <field>
-                            <name>GOUTNAKEFF</name>
-                            <description>desc GOUTNAKEFF</description>
+                            <name>GONAKEFF</name>
+                            <description>desc GONAKEFF</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-only</access>
@@ -46766,8 +46509,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>IPXFR_INCOMPISO</name>
-                            <description>desc IPXFR_INCOMPISO</description>
+                            <name>IPXFR_INCOMPISOOUT</name>
+                            <description>desc IPXFR_INCOMPISOOUT</description>
                             <msb>21</msb>
                             <lsb>21</lsb>
                             <access>read-write</access>
@@ -46875,8 +46618,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>GOUTNAKEFFM</name>
-                            <description>desc GOUTNAKEFFM</description>
+                            <name>GONAKEFFM</name>
+                            <description>desc GONAKEFFM</description>
                             <msb>7</msb>
                             <lsb>7</lsb>
                             <access>read-write</access>
@@ -50740,7 +50483,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x2</resetValue>
-                    <resetMask>0xFFF</resetMask>
+                    <resetMask>0xF8F</resetMask>
                     <fields>
                         <field>
                             <name>RWUSIG</name>
@@ -50769,13 +50512,6 @@
                             <msb>3</msb>
                             <lsb>3</lsb>
                             <access>read-only</access>
-                        </field>
-                        <field>
-                            <name>TCTL</name>
-                            <description>desc TCTL</description>
-                            <msb>6</msb>
-                            <lsb>4</lsb>
-                            <access>read-write</access>
                         </field>
                         <field>
                             <name>SGINAK</name>
@@ -50898,8 +50634,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>IINEPNEM</name>
-                            <description>desc IINEPNEM</description>
+                            <name>INEPNEM</name>
+                            <description>desc INEPNEM</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -51132,8 +50868,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -51339,8 +51075,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -51361,7 +51097,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x7FFFFFFF</resetMask>
+                    <resetMask>0x1FFFFFFF</resetMask>
                     <fields>
                         <field>
                             <name>XFRSIZ</name>
@@ -51375,13 +51111,6 @@
                             <description>desc PKTCNT</description>
                             <msb>28</msb>
                             <lsb>19</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>MC</name>
-                            <description>desc MC</description>
-                            <msb>30</msb>
-                            <lsb>29</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -51553,8 +51282,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -51575,7 +51304,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x7FFFFFFF</resetMask>
+                    <resetMask>0x1FFFFFFF</resetMask>
                     <fields>
                         <field>
                             <name>XFRSIZ</name>
@@ -51589,13 +51318,6 @@
                             <description>desc PKTCNT</description>
                             <msb>28</msb>
                             <lsb>19</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>MC</name>
-                            <description>desc MC</description>
-                            <msb>30</msb>
-                            <lsb>29</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -51767,8 +51489,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -51789,7 +51511,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x7FFFFFFF</resetMask>
+                    <resetMask>0x1FFFFFFF</resetMask>
                     <fields>
                         <field>
                             <name>XFRSIZ</name>
@@ -51803,13 +51525,6 @@
                             <description>desc PKTCNT</description>
                             <msb>28</msb>
                             <lsb>19</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>MC</name>
-                            <description>desc MC</description>
-                            <msb>30</msb>
-                            <lsb>29</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -51981,8 +51696,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -52003,7 +51718,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x7FFFFFFF</resetMask>
+                    <resetMask>0x1FFFFFFF</resetMask>
                     <fields>
                         <field>
                             <name>XFRSIZ</name>
@@ -52017,13 +51732,6 @@
                             <description>desc PKTCNT</description>
                             <msb>28</msb>
                             <lsb>19</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>MC</name>
-                            <description>desc MC</description>
-                            <msb>30</msb>
-                            <lsb>29</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>
@@ -52195,8 +51903,8 @@
                             <access>read-write</access>
                         </field>
                         <field>
-                            <name>NEPNE</name>
-                            <description>desc NEPNE</description>
+                            <name>INEPNE</name>
+                            <description>desc INEPNE</description>
                             <msb>6</msb>
                             <lsb>6</lsb>
                             <access>read-write</access>
@@ -52217,7 +51925,7 @@
                     <size>32</size>
                     <access>read-write</access>
                     <resetValue>0x0</resetValue>
-                    <resetMask>0x7FFFFFFF</resetMask>
+                    <resetMask>0x1FFFFFFF</resetMask>
                     <fields>
                         <field>
                             <name>XFRSIZ</name>
@@ -52231,13 +51939,6 @@
                             <description>desc PKTCNT</description>
                             <msb>28</msb>
                             <lsb>19</lsb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>MC</name>
-                            <description>desc MC</description>
-                            <msb>30</msb>
-                            <lsb>29</lsb>
                             <access>read-write</access>
                         </field>
                     </fields>

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -100,9 +100,10 @@ from . import target_LPC55S28Jxxxxx
 from . import target_M251
 from . import target_M261
 from . import target_M480
-from . import target_HC32F46x
+from . import target_HC32F460
 from . import target_HC32F4A0
 from . import target_HC32M423
+from . import target_HC32F160
 from . import target_HC32x120
 from . import target_HC32L110
 from . import target_HC32L13x
@@ -224,13 +225,16 @@ BUILTIN_TARGETS = {
           'm252kg6ae' : target_M251.M252KG6AE,
           'm263kiaae' : target_M261.M263KIAAE,
           'm487jidae' : target_M480.M487JIDAE,
-          'hc32f46x' : target_HC32F46x.HC32F46x,
+          'hc32f460xc' : target_HC32F460.HC32F460xC,
+          'hc32f460xe' : target_HC32F460.HC32F460xE,
           'hc32f4a0xg' : target_HC32F4A0.HC32F4A0xG,
           'hc32f4a0xi' : target_HC32F4A0.HC32F4A0xI,
+          'hc32m423xa' : target_HC32M423.HC32M423xA,
           'hc32f120x6' : target_HC32x120.HC32F120x6TA,
           'hc32f120x8' : target_HC32x120.HC32F120x8TA,
           'hc32m120' : target_HC32x120.HC32M120,
-          'hc32m423' : target_HC32M423.HC32M423,
+          'hc32f160xa' : target_HC32F160.HC32F160xA,
+          'hc32f160xc' : target_HC32F160.HC32F160xC,
           'hc32l110' : target_HC32L110.HC32L110,
           'hc32f003' : target_HC32L110.HC32F003,
           'hc32f005' : target_HC32L110.HC32F005,

--- a/pyocd/target/builtin/target_HC32F460.py
+++ b/pyocd/target/builtin/target_HC32F460.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -152,7 +152,32 @@ FLASH_ALGO_OTP = {
 }
 
 
-class HC32F46x(CoreSightTarget):
+class HC32F460xC(CoreSightTarget):
+
+    VENDOR = "HDSC"
+
+    MEMORY_MAP = MemoryMap(
+        FlashRegion( start=0x00000000, length=0x40000, page_size=0x200, sector_size=0x2000,
+                        is_boot_memory=True,
+                        algo=FLASH_ALGO),
+        FlashRegion( start=0x03000C00, length=0x3FC, sector_size=0x3FC,
+                        is_boot_memory=False,
+                        is_default=False,
+                        algo=FLASH_ALGO_OTP),
+        RamRegion(   start=0x1FFF8000, length=0x2F000),
+        RamRegion(   start=0x200F0000, length=0x1000)
+        )
+
+    def __init__(self, session):
+        super(HC32F460xC, self).__init__(session, self.MEMORY_MAP)
+        self._svd_location = SVDFile.from_builtin("HC32F460.svd")
+
+    def post_connect_hook(self):
+        self.write32(DBGMCU.STCTL, DBGMCU.STCTL_VALUE)
+        self.write32(DBGMCU.TRACECTL, DBGMCU.TRACECTL_VALUE)
+
+
+class HC32F460xE(CoreSightTarget):
 
     VENDOR = "HDSC"
 
@@ -169,9 +194,10 @@ class HC32F46x(CoreSightTarget):
         )
 
     def __init__(self, session):
-        super(HC32F46x, self).__init__(session, self.MEMORY_MAP)
-        self._svd_location = SVDFile.from_builtin("HC32F46x.svd")
+        super(HC32F460xE, self).__init__(session, self.MEMORY_MAP)
+        self._svd_location = SVDFile.from_builtin("HC32F460.svd")
 
     def post_connect_hook(self):
         self.write32(DBGMCU.STCTL, DBGMCU.STCTL_VALUE)
         self.write32(DBGMCU.TRACECTL, DBGMCU.TRACECTL_VALUE)
+

--- a/pyocd/target/builtin/target_HC32F4A0.py
+++ b/pyocd/target/builtin/target_HC32F4A0.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/target/builtin/target_HC32L07x.py
+++ b/pyocd/target/builtin/target_HC32L07x.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/target/builtin/target_HC32L110.py
+++ b/pyocd/target/builtin/target_HC32L110.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/target/builtin/target_HC32L19x.py
+++ b/pyocd/target/builtin/target_HC32L19x.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/target/builtin/target_HC32M423.py
+++ b/pyocd/target/builtin/target_HC32M423.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -71,7 +71,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 }
 
 
-class HC32M423(CoreSightTarget):
+class HC32M423xA(CoreSightTarget):
 
     VENDOR = "HDSC"
 
@@ -83,7 +83,7 @@ class HC32M423(CoreSightTarget):
         )
 
     def __init__(self, session):
-        super(HC32M423, self).__init__(session, self.MEMORY_MAP)
+        super(HC32M423xA, self).__init__(session, self.MEMORY_MAP)
         self._svd_location = SVDFile.from_builtin("HC32M423.svd")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_HC32x120.py
+++ b/pyocd/target/builtin/target_HC32x120.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Huada Semiconductor Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
1. Added new MCU series HC32F160.
2. Changed MCU series name: from HC32F46x to HC32F460. Related changes: HC32F46x.svd -> HC32F460.svd; target_HC32F46x.py -> target_HC32F460.py. 
3. Added part numbers: hc32f460xc and hc32f460xe to HC32F460 series.
4. Changed part number hc32m423 to hc32m423xa.
5. Changed the copyright to HDSC of all target_HC32*.py files.