### PR TITLE
CMSIS-DAP: add more checks of DAP_Info responses

### DIFF
--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -46,6 +46,7 @@ class DAPAccessIntf(object):
         DEVICE_VENDOR = 5
         DEVICE_NAME = 6
         CAPABILITIES = 0xf0
+        TEST_DOMAIN_TIMER = 0xf1
         SWO_BUFFER_SIZE = 0xfd
         MAX_PACKET_COUNT = 0xfe
         MAX_PACKET_SIZE = 0xff


### PR DESCRIPTION
Add some additional verification of the reply to a CMSIS-DAP DAP_Info command, to help with #1110. An exception will still be raised if the probe sends invalid data, but it will now be a device error and not an internal pyocd type error.