### PR TITLE
Remove warning about missing pywinusb on Windows

### DIFF
--- a/pyocd/probe/pydapaccess/interface/__init__.py
+++ b/pyocd/probe/pydapaccess/interface/__init__.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +17,7 @@
 
 import os
 import logging
+import platform
 from ..dap_access_api import DAPAccessIntf
 from .hidapi_backend import HidApiUSB
 from .pyusb_backend import PyUSB
@@ -40,8 +42,9 @@ if USB_BACKEND and ((USB_BACKEND not in INTERFACE) or (not INTERFACE[USB_BACKEND
     USB_BACKEND = ""
 
 # Select backend based on OS and availability.
+system = platform.system()
 if not USB_BACKEND:
-    if os.name == "nt":
+    if system == "Windows":
         # Prefer hidapi over pyWinUSB for Windows, since pyWinUSB has known bug(s)
         if HidApiUSB.isAvailable:
             USB_BACKEND = "hidapiusb"
@@ -49,12 +52,12 @@ if not USB_BACKEND:
             USB_BACKEND = "pywinusb"
         else:
             raise DAPAccessIntf.DeviceError("No USB backend found")
-    elif os.name == "posix":
-        # Select hidapi for OS X and pyUSB for Linux.
-        if os.uname()[0] == 'Darwin':
-            USB_BACKEND = "hidapiusb"
-        else:
-            USB_BACKEND = "pyusb"
+    # Default to hidapi for OS X.
+    elif system == "Darwin":
+        USB_BACKEND = "hidapiusb"
+    # Default to pyUSB for Linux.
+    elif system == "Linux":
+        USB_BACKEND = "pyusb"
     else:
         raise DAPAccessIntf.DeviceError("No USB backend found")
 

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import platform
 import six
 
 from .interface import Interface
@@ -28,8 +28,6 @@ LOG = logging.getLogger(__name__)
 try:
     import hid
 except:
-    if platform.system() == 'Darwin':
-        LOG.error("hidapi is required for CMSIS-DAP support on macOS")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -39,8 +39,6 @@ try:
     import usb.core
     import usb.util
 except:
-    if platform.system() == "Linux":
-        LOG.error("PyUSB is required for CMSIS-DAP support on Linux")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import platform
 import collections
 from time import sleep
 import six
@@ -32,8 +32,6 @@ LOG = logging.getLogger(__name__)
 try:
     import pywinusb.hid as hid
 except:
-    if platform.system() == "Windows":
-        LOG.error("PyWinUSB is required on a Windows Machine")
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True


### PR DESCRIPTION
PyOCD 0.30.0 replaces the pywinusb dependency in favour of using hidapi on Windows, since that seems to be more reliable (and pywinusb hasn’t been updated in years). But the pywinusb backend has been retained in case someone wants to use it. The check for pywinusb on Windows and warning message if it's not found were accidentally left in.

The similar warning for hidapi on macOS is also removed.