### PR TITLE
CMSIS-DAP backend synthetic UID and device detection

### DIFF
--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -62,16 +62,17 @@ class HidApiUSB(Interface):
 
         devices = hid.enumerate()
 
-        if not devices:
-            return []
-
         boards = []
 
         for deviceInfo in devices:
             product_name = to_str_safe(deviceInfo['product_string'])
-            if (product_name.find("CMSIS-DAP") < 0):
-                # Skip non cmsis-dap devices
-                continue
+            if ("CMSIS-DAP" not in product_name):
+                # Check the device path as a backup. Even though we can't get the interface name from
+                # hidapi, it may appear in the path. At least, it does on macOS.
+                device_path = to_str_safe(deviceInfo['path'])
+                if "CMSIS-DAP" not in device_path:
+                    # Skip non cmsis-dap devices
+                    continue
             
             vid = deviceInfo['vendor_id']
             pid = deviceInfo['product_id']

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -19,7 +19,10 @@ import logging
 import six
 
 from .interface import Interface
-from .common import filter_device_by_usage_page
+from .common import (
+    filter_device_by_usage_page,
+    generate_device_unique_id,
+    )
 from ..dap_access_api import DAPAccessIntf
 from ....utility.compatibility import to_str_safe
 
@@ -85,11 +88,12 @@ class HidApiUSB(Interface):
 
             # Create the USB interface object for this device.
             new_board = HidApiUSB()
-            new_board.vendor_name = deviceInfo['manufacturer_string']
-            new_board.product_name = deviceInfo['product_string']
-            new_board.serial_number = deviceInfo['serial_number']
             new_board.vid = vid
             new_board.pid = pid
+            new_board.vendor_name = deviceInfo['manufacturer_string'] or f"{vid:#06x}"
+            new_board.product_name = deviceInfo['product_string'] or f"{pid:#06x}"
+            new_board.serial_number = deviceInfo['serial_number'] \
+                    or generate_device_unique_id(vid, pid, six.ensure_str(deviceInfo['path']))
             new_board.device_info = deviceInfo
             new_board.device = dev
             boards.append(new_board)

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2006-2021 Arm Limited
 # Copyright (c) 2020 Patrick Huesmann
 # Copyright (c) 2021 mentha
+# Copyright (c) Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -167,9 +168,10 @@ class PyUSB(Interface):
             new_board = PyUSB()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product or hex(board.idProduct)
-            new_board.vendor_name = board.manufacturer or hex(board.idVendor)
-            new_board.serial_number = board.serial_number or generate_device_unique_id(board)
+            new_board.product_name = board.product or f"{board.idProduct:#06x}"
+            new_board.vendor_name = board.manufacturer or f"{board.idVendor:#06x}"
+            new_board.serial_number = board.serial_number \
+                    or generate_device_unique_id(board.idProduct, board.idVendor, board.bus, board.address)
             boards.append(new_board)
 
         return boards

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2019-2021 Arm Limited
 # Copyright (c) 2021 mentha
+# Copyright (c) Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -187,9 +188,10 @@ class PyUSBv2(Interface):
             new_board = PyUSBv2()
             new_board.vid = board.idVendor
             new_board.pid = board.idProduct
-            new_board.product_name = board.product or hex(board.idProduct)
-            new_board.vendor_name = board.manufacturer or hex(board.idVendor)
-            new_board.serial_number = board.serial_number or generate_device_unique_id(board)
+            new_board.product_name = board.product or f"{board.idProduct:#06x}"
+            new_board.vendor_name = board.manufacturer or f"{board.idVendor:#06x}"
+            new_board.serial_number = board.serial_number \
+                    or generate_device_unique_id(board.idProduct, board.idVendor, board.bus, board.address)
             boards.append(new_board)
 
         return boards

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -21,7 +21,10 @@ from time import sleep
 import six
 
 from .interface import Interface
-from .common import filter_device_by_usage_page
+from .common import (
+    filter_device_by_usage_page,
+    generate_device_unique_id,
+    )
 from ..dap_access_api import DAPAccessIntf
 from ....utility.timeout import Timeout
 
@@ -120,9 +123,10 @@ class PyWinUSB(Interface):
                 new_board = PyWinUSB()
                 new_board.report = report[0]
                 new_board.packet_size = len(new_board.report.get_raw_data()) - 1
-                new_board.vendor_name = dev.vendor_name
-                new_board.product_name = dev.product_name
-                new_board.serial_number = dev.serial_number
+                new_board.vendor_name = dev.vendor_name or f"{dev.vendor_id:#06x}"
+                new_board.product_name = dev.product_name or f"{dev.product_id:#06x}"
+                new_board.serial_number = dev.serial_number \
+                        or generate_device_unique_id(dev.vendor_id, dev.product_id, dev.device_path)
                 new_board.vid = dev.vendor_id
                 new_board.pid = dev.product_id
                 new_board.device = dev

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -103,7 +103,7 @@ class PyWinUSB(Interface):
         # find devices with good vid/pid
         all_mbed_devices = []
         for d in all_devices:
-            if (d.product_name.find("CMSIS-DAP") >= 0):
+            if ("CMSIS-DAP" in d.product_name):
                 all_mbed_devices.append(d)
 
         boards = []
@@ -130,11 +130,11 @@ class PyWinUSB(Interface):
                 new_board.vid = dev.vendor_id
                 new_board.pid = dev.product_id
                 new_board.device = dev
-                dev.close()
                 boards.append(new_board)
             except Exception as e:
                 if (str(e) != "Failure to get HID pre parsed data"):
                     LOG.error("Receiving Exception: %s", e)
+            finally:
                 dev.close()
 
         return boards


### PR DESCRIPTION
This PR includes some changes for the CMSIS-DAP USB backends.

The hidapi and pywinusb backends will generate a synthetic UID if the device has no USB serial number, to behave the same as the pyusb backends. The common `generate_device_unique_id()` function is modified to accept device info parameters instead of a pyusb device.

The hidapi backend checks the `path` device info key for the "CMSIS-DAP" string in addition to the product name. This is done to attempt to detect CMSIS-DAP devices with the "CMSIS-DAP" string in the interface name, which is not directly available via hidapi but may appear in the OS-specific path.

Some other small improvements are included.

Fixes #1121 