### PR TITLE
Fix for missing usb backend in picoprobe

### DIFF
--- a/pyocd/probe/common.py
+++ b/pyocd/probe/common.py
@@ -33,15 +33,15 @@ def show_no_libusb_warning():
     """! @brief Logs a warning about missing libusb library only the first time it is called."""
     global did_show_no_libusb_warning
     if not did_show_no_libusb_warning:
-        LOG.warning("STLink and CMSIS-DAPv2 probes are not supported because no libusb library was found.")
+        LOG.warning("STLink, CMSIS-DAPv2 and PicoProbe probes are not supported because no libusb library was found.")
         did_show_no_libusb_warning = True
-    
+
 def should_show_libusb_device_error(vidpid):
     """! @brief Returns whether a debug warning should be shown for the given VID/PID pair.
-    
+
     The first time a given VID/PID is passed to this function, the result will be True. Any
     subsequent times, False will be returned for the same VID/PID pair.
-    
+
     @param vidpi A bi-tuple of USB VID and PID, in that order.
     """
     should_log = vidpid not in libusb_error_device_set

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -26,6 +26,7 @@ import logging
 from typing import List
 
 from .debug_probe import DebugProbe
+from .common import show_no_libusb_warning
 from ..core import exceptions
 from ..core.options import OptionInfo
 from ..core.plugin import Plugin
@@ -108,9 +109,8 @@ class PicoLink(object):
             # Use a custom matcher to make sure the probe is a Picoprobe and accessible.
             return [PicoLink(probe) for probe in core.find(find_all=True, custom_match=FindPicoprobe(uid))]
         except core.NoBackendError:
-            LOG.debug(" No usb backend found")
+            show_no_libusb_warning()
             return []
-
 
     def q_read_bits(self, bits):
         """! @brief Queue a read request for 'bits' bits to the probe """

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -104,8 +104,13 @@ class PicoLink(object):
     @classmethod
     def enumerate_picoprobes(cls, uid=None) -> List["PicoLink"]:
         """! @brief Find and return all Picoprobes """
-        # Use a custom matcher to make sure the probe is a Picoprobe and accessible.
-        return [PicoLink(probe) for probe in core.find(find_all=True, custom_match=FindPicoprobe(uid))]
+        try:
+            # Use a custom matcher to make sure the probe is a Picoprobe and accessible.
+            return [PicoLink(probe) for probe in core.find(find_all=True, custom_match=FindPicoprobe(uid))]
+        except core.NoBackendError:
+            LOG.debug(" No usb backend found")
+            return []
+
 
     def q_read_bits(self, bits):
         """! @brief Queue a read request for 'bits' bits to the probe """


### PR DESCRIPTION
<ins>Preliminary</ins> Fix for #1126:

Catch the unhandled exception NoBackendError from pyusb.

It seems that I'm unable to eradicate libusb-win32 from my machines (tried some different methods).
So to test this I'll have to setup a clean VM/physical machine.
I will update here when done.

@lennvn: if not asking too much, could you please try it? 