### PR TITLE
Refactor subcommands into classes

### DIFF
--- a/docs/target_support.md
+++ b/docs/target_support.md
@@ -124,22 +124,22 @@ index is downloaded, pyOCD can very quickly locate the DFP that provides support
 MCU part number. To learn more about the index, see the [CMSIS-Pack index
 files](http://arm-software.github.io/CMSIS_5/Pack/html/packIndexFile.html) documentation.
 
-The two most useful options for the `pack` subcommand are `--find` and `--install`. The options
-accept a glob-style pattern that is matched against MCU part numbers in the index. If the index
-has not been downloaded yet, that will be done first. `--find` will print out which DFPs provide
-support for matching part numbers. `--install` performs the same match, but downloads and installs
-the matching DFPs. The patterns are matched case-insensitively and as a starts-with comparison.
+The two most useful subcommands of the `pack` subcommand are `find` and `install`. The options accept a glob-style
+pattern that is matched against MCU part numbers in the index. If the index has not been downloaded yet, that will be
+done first, or you can run `pyocd pack update` yourself. The `find` subcommand will print out a list of matching part
+numbers and the names of the containing DFPs. `install` performs the same match, but downloads and installs the matching
+DFPs. The part number patterns are matched case-insensitively and as a contains comparison.
 
 For instance, if you know the specific part number of the device you are using, say STM32L073, you
 can run this command to install support:
 
-    $ pyocd pack --install stm32l073
+    $ pyocd pack install stm32l073
 
-This will download the index if required, then download the STM32L0xx_DFP pack.
+This will download the index if required, then download the STM32L0xx_DFP pack. The
 
 As another example, to find which pack(s) support the NXP MK26F family, you could run:
 
-    $ pyocd pack --find mk26
+    $ pyocd pack find k26
 
 This will print a table similar to:
 
@@ -152,6 +152,8 @@ This will print a table similar to:
 
 Once a DFP is installed, the `pyocd list --targets` command will show the new targets in its output,
 and you can immediately begin using the target support with the other `pyocd` subcommands.
+
+To get a list of all installed packs, use the `pack show` subcommand.
 
 
 #### Manual pack usage

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -18,49 +18,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import sys
 import logging
 import argparse
-import json
 import colorama
-import os
-import fnmatch
-import re
-import prettytable
-from time import sleep
+from typing import (Any, Optional, Sequence)
 
 from . import __version__
 from .core.session import Session
-from .core.helpers import ConnectHelper
-from .core.target import Target
 from .core import exceptions
-from .target import TARGET
-from .target.pack import pack_target
-from .gdbserver import GDBServer
-from .utility.cmdline import (
-    split_command_line,
-    VECTOR_CATCH_CHAR_MAP,
-    convert_vector_catch,
-    convert_session_options,
-    convert_reset_type,
-    convert_frequency,
-    )
 from .probe.pydapaccess import DAPAccess
-from .probe.tcp_probe_server import DebugProbeServer
-from .probe.shared_probe_proxy import SharedDebugProbeProxy
-from .tools.lists import ListGenerator
-from .commands.commander import PyOCDCommander
-from .flash.eraser import FlashEraser
-from .flash.file_programmer import FileProgrammer
 from .core import options
-from .coresight.generic_mem_ap import GenericMemAPTarget
-
-try:
-    import cmsis_pack_manager
-    CPM_AVAILABLE = True
-except ImportError:
-    CPM_AVAILABLE = False
+from .subcommands.base import SubcommandBase
+from .subcommands.commander_cmd import CommanderSubcommand
+from .subcommands.erase_cmd import EraseSubcommand
+from .subcommands.flash_cmd import FlashSubcommand
+from .subcommands.gdbserver_cmd import GdbserverSubcommand
+from .subcommands.json_cmd import JsonSubcommand
+from .subcommands.list_cmd import ListSubcommand
+from .subcommands.pack_cmd import PackSubcommand
+from .subcommands.reset_cmd import ResetSubcommand
+from .subcommands.server_cmd import ServerSubcommand
 
 ## @brief Default log format for all subcommands.
 LOG_FORMAT = "%(relativeCreated)07d:%(levelname)s:%(module)s:%(message)s"
@@ -68,341 +46,81 @@ LOG_FORMAT = "%(relativeCreated)07d:%(levelname)s:%(module)s:%(message)s"
 ## @brief Logger for this module.
 LOG = logging.getLogger("pyocd.tool")
 
-## @brief Default log levels for each of the subcommands.
-DEFAULT_CMD_LOG_LEVEL = {
-    'list':         logging.INFO,
-    'json':         logging.FATAL + 1,
-    'flash':        logging.WARNING,
-    'reset':        logging.WARNING,
-    'erase':        logging.WARNING,
-    'gdbserver':    logging.INFO,
-    'gdb':          logging.INFO,
-    'commander':    logging.WARNING,
-    'cmd':          logging.WARNING,
-    'pack':         logging.INFO,
-    'server':       logging.INFO,
-    }
-
-## @brief Valid erase mode options.
-ERASE_OPTIONS = [
-    'auto',
-    'chip',
-    'sector',
-    ]
-
-## @brief Map to convert plugin groups to user friendly names.
-PLUGIN_GROUP_NAMES = {
-    'pyocd.probe': "Debug Probe",
-    'pyocd.rtos': "RTOS",
-    }
-
-def flatten_args(args):
-    """! @brief Converts a list of lists to a single list."""
-    return [item for sublist in args for item in sublist]
-
-def int_base_0(x):
-    """! @brief Converts a string to an int with support for base prefixes."""
-    return int(x, base=0)
-
-class PyOCDTool(object):
+class PyOCDTool(SubcommandBase):
     """! @brief Main class for the pyocd tool and subcommands.
     """
+    
+    HELP = "PyOCD debug tools for Arm Cortex devices"
+    
+    ## List of subcommand classes.
+    SUBCOMMANDS = [
+        CommanderSubcommand,
+        EraseSubcommand,
+        FlashSubcommand,
+        GdbserverSubcommand,
+        JsonSubcommand,
+        ListSubcommand,
+        PackSubcommand,
+        ResetSubcommand,
+        ServerSubcommand,
+        ]
+    
     def __init__(self):
-        self._args = None
-        self._default_log_level = logging.INFO
-        self._log_level_delta = 0
-        self._parser = None
-        self.echo_msg = None
+        # Start with an empty namespace.
+        super().__init__(argparse.Namespace())
+        self._parser = self.build_parser()
 
-    def build_parser(self):
+    def build_parser(self) -> argparse.ArgumentParser:
         """! @brief Construct the command line parser with all subcommands and options."""
         # Create top level argument parser.
-        parser = argparse.ArgumentParser(
-            description='PyOCD debug tools for Arm Cortex devices')
-        subparsers = parser.add_subparsers(title="subcommands", metavar="", dest='cmd')
-        
+        parser = argparse.ArgumentParser(description=self.HELP)
+        parser.set_defaults(command_class=self, quiet=0, verbose=0)
+
         parser.add_argument('-V', '--version', action='version', version=__version__)
         parser.add_argument('--help-options', action='store_true',
             help="Display available session options.")
-        
-        # Define logging related options.
-        loggingOptions = argparse.ArgumentParser(description='logging', add_help=False)
-        loggingOptions.add_argument('-v', '--verbose', action='count', default=0,
-            help="More logging. Can be specified multiple times.")
-        loggingOptions.add_argument('-q', '--quiet', action='count', default=0,
-            help="Less logging. Can be specified multiple times.")
-        
-        # Define common options for all subcommands, excluding --verbose and --quiet.
-        commonOptionsNoLoggingParser = argparse.ArgumentParser(description='common', add_help=False)
-        commonOptionsNoLogging = commonOptionsNoLoggingParser.add_argument_group("configuration")
-        commonOptionsNoLogging.add_argument('-j', '--project', '--dir', metavar="PATH", dest="project_dir",
-            help="Set the project directory. Defaults to the directory where pyocd was run.")
-        commonOptionsNoLogging.add_argument('--config', metavar="PATH",
-            help="Specify YAML configuration file. Default is pyocd.yaml or pyocd.yml.")
-        commonOptionsNoLogging.add_argument("--no-config", action="store_true", default=None,
-            help="Do not use a configuration file.")
-        commonOptionsNoLogging.add_argument('--script', metavar="PATH",
-            help="Use the specified user script. Defaults to pyocd_user.py.")
-        commonOptionsNoLogging.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
-            help="Set named option.")
-        commonOptionsNoLogging.add_argument("-da", "--daparg", dest="daparg", nargs='+',
-            help="(Deprecated) Send setting to DAPAccess layer.")
-        commonOptionsNoLogging.add_argument("--pack", metavar="PATH", action="append",
-            help="Path to a CMSIS Device Family Pack.")
-        
-        # Define common options for all subcommands with --verbose and --quiet.
-        commonOptions = argparse.ArgumentParser(description='common',
-            parents=[loggingOptions, commonOptionsNoLoggingParser], add_help=False)
-        
-        # Common connection related options.
-        connectParser = argparse.ArgumentParser(description='common', add_help=False)
-        connectOptions = connectParser.add_argument_group("connection")
-        connectOptions.add_argument("-u", "--uid", "--probe", dest="unique_id",
-            help="Choose a probe by its unique ID or a substring thereof. Optionally prefixed with "
-            "'<probe-type>:' where <probe-type> is the name of a probe plugin.")
-        connectOptions.add_argument("-b", "--board", dest="board_override", metavar="BOARD",
-            help="Set the board type (not yet implemented).")
-        connectOptions.add_argument("-t", "--target", dest="target_override", metavar="TARGET",
-            help="Set the target type.")
-        connectOptions.add_argument("-f", "--frequency", dest="frequency", default=None, type=convert_frequency,
-            help="SWD/JTAG clock frequency in Hz. Accepts a float or int with optional case-"
-                "insensitive K/M suffix and optional Hz. Examples: \"1000\", \"2.5khz\", \"10m\".")
-        connectOptions.add_argument("-W", "--no-wait", action="store_true",
-            help="Do not wait for a probe to be connected if none are available.")
-        connectOptions.add_argument("-M", "--connect", dest="connect_mode", metavar="MODE",
-            help="Select connect mode from one of (halt, pre-reset, under-reset, attach).")
+            
+        self.add_subcommands(parser)
 
-        # Create *commander* subcommand parser.
-        commanderParser = argparse.ArgumentParser(description='commander', add_help=False)
-        commanderOptions = commanderParser.add_argument_group("commander options")
-        commanderOptions.add_argument("-H", "--halt", action="store_true", default=None,
-            help="Halt core upon connect. (Deprecated, see --connect.)")
-        commanderOptions.add_argument("-N", "--no-init", action="store_true",
-            help="Do not init debug system.")
-        commanderOptions.add_argument("--elf", metavar="PATH",
-            help="Optionally specify ELF file being debugged.")
-        commanderOptions.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
-            help="Run commands.")
-        subparsers.add_parser('commander', parents=[commonOptions, connectParser, commanderParser],
-            help="Interactive command console.")
-        subparsers.add_parser('cmd', parents=[commonOptions, connectParser, commanderParser],
-            help="Alias for 'commander'.")
-
-        # Create *erase* subcommand parser.
-        eraseParser = argparse.ArgumentParser(description='erase', add_help=False)
-        eraseOptions = eraseParser.add_argument_group("erase options")
-        eraseOptions.add_argument("-c", "--chip", dest="erase_mode", action="store_const", const=FlashEraser.Mode.CHIP,
-            help="Perform a chip erase.")
-        eraseOptions.add_argument("-s", "--sector", dest="erase_mode", action="store_const", const=FlashEraser.Mode.SECTOR,
-            help="Erase the sectors listed as positional arguments.")
-        eraseOptions.add_argument("--mass", dest="erase_mode", action="store_const", const=FlashEraser.Mode.MASS,
-            help="Perform a mass erase. On some devices this is different than a chip erase.")
-        eraseOptions.add_argument("addresses", metavar="<sector-address>", action='append', nargs='*',
-            help="List of sector addresses or ranges to erase.")
-        subparsers.add_parser('erase', parents=[commonOptions, connectParser, eraseParser],
-            help="Erase entire device flash or specified sectors.",
-            epilog="If no position arguments are listed, then no action will be taken unless the --chip or "
-            "--mass-erase options are provided. Otherwise, the positional arguments should be the addresses of flash "
-            "sectors or address ranges. The end address of a range is exclusive, meaning that it will not be "
-            "erased. Thus, you should specify the address of the sector after the last one "
-            "to be erased. If a '+' is used instead of '-' in a range, this indicates that the "
-            "second value is a length rather than end address. "
-            "Examples: 0x1000 (erase single sector starting at 0x1000) "
-            "0x800-0x2000 (erase sectors starting at 0x800 up to but not including 0x2000) "
-            "0+8192 (erase 8 kB starting at address 0)")
-
-        # Create *flash* subcommand parser.
-        flashParser = argparse.ArgumentParser(description='flash', add_help=False)
-        flashOptions = flashParser.add_argument_group("flash options")
-        flashOptions.add_argument("-e", "--erase", choices=ERASE_OPTIONS, default='sector',
-            help="Choose flash erase method. Default is sector.")
-        flashOptions.add_argument("-a", "--base-address", metavar="ADDR", type=int_base_0,
-            help="Base address used for the address where to flash a binary. Defaults to start of flash.")
-        flashOptions.add_argument("--trust-crc", action="store_true",
-            help="Use only the CRC of each page to determine if it already has the same data.")
-        flashOptions.add_argument("--format", choices=("bin", "hex", "elf"),
-            help="File format. Default is to use the file's extension.")
-        flashOptions.add_argument("--skip", metavar="BYTES", default=0, type=int_base_0,
-            help="Skip programming the first N bytes. This can only be used with binary files.")
-        flashOptions.add_argument("file", metavar="PATH",
-            help="File to program into flash.")
-        subparsers.add_parser('flash', parents=[commonOptions, connectParser, flashParser],
-            help="Program an image to device flash.")
-
-        # Create *reset* subcommand parser.
-        resetParser = argparse.ArgumentParser(description='reset', add_help=False)
-        resetOptions = resetParser.add_argument_group("reset options")
-        resetOptions.add_argument("-m", "--method", default='hw', dest='reset_type', metavar="METHOD",
-            help="Reset method to use ('hw', 'sw', and others). Default is 'hw'.")
-        subparsers.add_parser('reset', parents=[commonOptions, connectParser, resetParser],
-            help="Reset a device.")
-        
-        # Create *gdbserver* subcommand parser.
-        gdbserverParser = argparse.ArgumentParser(description='gdbserver', add_help=False)
-        gdbserverOptions = gdbserverParser.add_argument_group("gdbserver options")
-        gdbserverOptions.add_argument("-p", "--port", metavar="PORT", dest="port_number", type=int,
-            default=3333,
-            help="Set starting port number for the GDB server (default 3333). Additional cores "
-                "will have a port number of this parameter plus the core number.")
-        gdbserverOptions.add_argument("-T", "--telnet-port", metavar="PORT", dest="telnet_port",
-            type=int, default=4444,
-            help="Specify starting telnet port for semihosting (default 4444).")
-        gdbserverOptions.add_argument("-R", "--probe-server-port",
-            dest="probe_server_port", metavar="PORT", type=int, default=5555,
-            help="Specify the telnet port for semihosting (default 4444).")
-        gdbserverOptions.add_argument("--allow-remote", dest="serve_local_only", default=True, action="store_false",
-            help="Allow remote TCP/IP connections (default is no).")
-        gdbserverOptions.add_argument("--persist", action="store_true",
-            help="Keep GDB server running even after remote has detached.")
-        gdbserverOptions.add_argument("-r", "--probe-server", action="store_true", dest="enable_probe_server",
-            help="Enable the probe server in addition to the GDB server.")
-        gdbserverOptions.add_argument("--core", metavar="CORE_LIST",
-            help="Comma-separated list of cores for which gdbservers will be created. Default is all cores.")
-        gdbserverOptions.add_argument("--elf", metavar="PATH",
-            help="Optionally specify ELF file being debugged.")
-        gdbserverOptions.add_argument("-e", "--erase", choices=ERASE_OPTIONS, default='sector',
-            help="Choose flash erase method. Default is sector.")
-        gdbserverOptions.add_argument("--trust-crc", action="store_true",
-            help="Use only the CRC of each page to determine if it already has the same data.")
-        gdbserverOptions.add_argument("-C", "--vector-catch", default='h',
-            help="Enable vector catch sources, one letter per enabled source in any order, or 'all' "
-                "or 'none'. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, "
-                "c=check err, p=nocp, r=reset, a=all, n=none). Default is hard fault.")
-        gdbserverOptions.add_argument("-S", "--semihosting", dest="enable_semihosting", action="store_true",
-            help="Enable semihosting.")
-        gdbserverOptions.add_argument("--step-into-interrupts", dest="step_into_interrupt", default=False, action="store_true",
-            help="Allow single stepping to step into interrupts.")
-        gdbserverOptions.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
-            help="Run command (OpenOCD compatibility).")
-        subparsers.add_parser('gdbserver', parents=[commonOptions, connectParser, gdbserverParser],
-            help="Run the gdb remote server(s).")
-        subparsers.add_parser('gdb', parents=[commonOptions, connectParser, gdbserverParser],
-            help="Alias for 'gdbserver'.")
-
-        # Create *json* subcommand parser.
-        #
-        # The json subcommand does not support --verbose or --quiet since all logging is disabled.
-        jsonParser = argparse.ArgumentParser(description='json', add_help=False)
-        jsonOptions = jsonParser.add_argument_group('json output')
-        jsonOptions.add_argument('-p', '--probes', action='store_true',
-            help="List available probes.")
-        jsonOptions.add_argument('-t', '--targets', action='store_true',
-            help="List all known targets.")
-        jsonOptions.add_argument('-b', '--boards', action='store_true',
-            help="List all known boards.")
-        jsonOptions.add_argument('-f', '--features', action='store_true',
-            help="List available features and options.")
-        jsonSubparser = subparsers.add_parser('json', parents=[commonOptionsNoLoggingParser, jsonParser],
-            help="Output information as JSON.")
-        jsonSubparser.set_defaults(verbose=0, quiet=0)
-
-        # Create *list* subcommand parser.
-        listParser = argparse.ArgumentParser(description='list', add_help=False)
-        listOutput = listParser.add_argument_group("list output")
-        listOutput.add_argument('-p', '--probes', action='store_true',
-            help="List available probes.")
-        listOutput.add_argument('-t', '--targets', action='store_true',
-            help="List all known targets.")
-        listOutput.add_argument('-b', '--boards', action='store_true',
-            help="List all known boards.")
-        listOutput.add_argument('--plugins', action='store_true',
-            help="List available plugins.")
-        listOptions = listParser.add_argument_group('list options')
-        listOptions.add_argument('-n', '--name',
-            help="Restrict listing to items matching the given name. Applies to targets and boards.")
-        listOptions.add_argument('-r', '--vendor',
-            help="Restrict listing to items whose vendor matches the given name. Applies to targets.")
-        listOptions.add_argument('-s', '--source', choices=('builtin', 'pack'),
-            help="Restrict listing to targets from the specified source. Applies to targets.")
-        listOptions.add_argument('-H', '--no-header', action='store_true',
-            help="Don't print a table header.")
-        subparsers.add_parser('list', parents=[commonOptions, listParser],
-            help="List information about probes, targets, or boards.")
-
-        # Create *pack* subcommand parser.
-        packParser = argparse.ArgumentParser(description='pack', add_help=False)
-        packOperations = packParser.add_argument_group('pack operations')
-        packOperations.add_argument("-c", "--clean", action='store_true',
-            help="Erase all stored pack information.")
-        packOperations.add_argument("-u", "--update", action='store_true',
-            help="Update the pack index.")
-        packOperations.add_argument("-s", "--show", action='store_true',
-            help="Show the list of installed packs.")
-        packOperations.add_argument("-f", "--find", dest="find_devices", metavar="GLOB", action='append',
-            help="Report pack(s) in the index containing matching device part numbers.")
-        packOperations.add_argument("-i", "--install", dest="install_devices", metavar="GLOB", action='append',
-            help="Download and install pack(s) containing matching device part numbers.")
-        packOptions = packParser.add_argument_group('pack options')
-        packOptions.add_argument("-n", "--no-download", action='store_true',
-            help="Just list the pack(s) that would be downloaded, don't actually download anything.")
-        packOptions.add_argument('-H', '--no-header', action='store_true',
-            help="Don't print a table header.")
-        subparsers.add_parser('pack', parents=[loggingOptions, packParser],
-            help="Manage CMSIS-Packs for target support.")
-
-        # Create *server* subcommand parser.
-        serverParser = subparsers.add_parser('server', parents=[loggingOptions],
-            help="Run debug probe server.")
-        serverParser.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
-            help="Set named option.")
-        serverParser.add_argument("-da", "--daparg", dest="daparg", nargs='+',
-            help="Send setting to DAPAccess layer.")
-        serverParser.add_argument("-p", "--port", dest="port_number", type=int, default=None,
-            help="Set the server's port number (default 5555).")
-        serverParser.add_argument("--allow-remote", dest="serve_local_only", default=None, action="store_false",
-            help="Allow remote TCP/IP connections (default is no).")
-        serverParser.add_argument("--local-only", default=False, action="store_true",
-            help="Ignored and deprecated. Server is local only by default. Use --alow-remote to enable remote "
-                 "connections.")
-        serverParser.add_argument("-u", "--uid", dest="unique_id",
-            help="Serve the specified probe.")
-        serverParser.set_defaults(verbose=0, quiet=0)
-        
-        self._parser = parser
         return parser
 
-    def _setup_logging(self):
+    def _setup_logging(self) -> None:
         """! @brief Configure the logging module.
         
         The quiet and verbose argument counts are used to set the log verbosity level.
         """
-        self._log_level_delta = (self._args.quiet * 10) - (self._args.verbose * 10)
-        level = max(1, self._default_log_level + self._log_level_delta)
+        level = max(1, self._args.command_class.DEFAULT_LOG_LEVEL + self._get_log_level_delta())
         logging.basicConfig(level=level, format=LOG_FORMAT)
-    
-    def _increase_logging(self, loggers):
-        """! @brief Increase logging level for a set of subloggers."""
-        if self._log_level_delta <= 0:
-            level = max(1, self._default_log_level + self._log_level_delta - 10)
-            for logger in loggers:
-                logging.getLogger(logger).setLevel(level)
 
-    def run(self, args=None):
+    def invoke(self) -> int:
+        """! @brief Show help when pyocd is run with no subcommand."""
+        if self._args.help_options:
+            self.show_options_help()
+        else:
+            self._parser.print_help()
+        return 0
+    
+    def __call__(self, *args: Any, **kwds: Any) -> "PyOCDTool":
+        """! @brief Hack to allow the root command object instance to be used as default command class."""
+        return self
+
+    def run(self, args: Optional[Sequence[str]] = None) -> int:
         """! @brief Main entry point for command line processing."""
         try:
-            self._args = self.build_parser().parse_args(args)
+            self._args = self._parser.parse_args(args)
             
-            # Running without a subcommand will print usage.
-            if self._args.cmd is None:
-                if self._args.help_options:
-                    self.show_options_help()
-                else:
-                    self._parser.print_help()
-                return 1
-            
-            # The default log level differs for some subcommands.
-            self._default_log_level = DEFAULT_CMD_LOG_LEVEL[self._args.cmd]
             self._setup_logging()
             
             # Pass any options to DAPAccess.
             if hasattr(self._args, 'daparg'):
                 DAPAccess.set_args(self._args.daparg)
-
-            # Invoke subcommand.
-            self._COMMANDS[self._args.cmd](self)
+            
+            # Create an instance of the subcommand and invoke it.
+            cmd = self._args.command_class(self._args)
+            status = cmd.invoke()
 
             # Successful exit.
-            return 0
+            return status
         except KeyboardInterrupt:
             return 0
         except (exceptions.Error, ValueError, IndexError) as e:
@@ -412,527 +130,18 @@ class PyOCDTool(object):
             LOG.critical("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
             return 1
     
-    def show_options_help(self):
+    def show_options_help(self) -> None:
         """! @brief Display help for session options."""
-        for infoName in sorted(options.OPTIONS_INFO.keys()):
-            info = options.OPTIONS_INFO[infoName]
+        for info_name in sorted(options.OPTIONS_INFO.keys()):
+            info = options.OPTIONS_INFO[info_name]
             if isinstance(info.type, tuple):
                 typename = ", ".join(t.__name__ for t in info.type)
             else:
                 typename = info.type.__name__
-            print((colorama.Fore.BLUE + "{name}"
-                + colorama.Style.RESET_ALL + colorama.Fore.GREEN + " ({typename})"
-                + colorama.Style.RESET_ALL + " {help}").format(
+            print((colorama.Fore.CYAN + colorama.Style.BRIGHT + "{name}" + colorama.Style.RESET_ALL  # type:ignore
+                + colorama.Fore.GREEN + " ({typename})" + colorama.Style.RESET_ALL
+                + " {help}").format(
                 name=info.name, typename=typename, help=info.help))
-    
-    def _get_pretty_table(self, fields):
-        """! @brief Returns a PrettyTable object with formatting options set."""
-        pt = prettytable.PrettyTable(fields)
-        pt.align = 'l'
-        pt.header = not self._args.no_header
-        pt.border = True
-        pt.hrules = prettytable.HEADER
-        pt.vrules = prettytable.NONE
-        return pt
-    
-    def do_list(self):
-        """! @brief Handle 'list' subcommand."""
-        all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.plugins)
-        
-        # Default to listing probes.
-        if not any(all_outputs):
-            self._args.probes = True
-        
-        # Check for more than one output option being selected.
-        if sum(int(x) for x in all_outputs) > 1:
-            LOG.error("Only one of the output options '--probes', '--targets', '--boards', "
-                      "or '--plugins' may be selected at a time.")
-            return
-        
-        # Create a session with no device so we load any config.
-        session = Session(None,
-                            project_dir=self._args.project_dir,
-                            config_file=self._args.config,
-                            no_config=self._args.no_config,
-                            pack=self._args.pack,
-                            **convert_session_options(self._args.options)
-                            )
-        
-        if self._args.probes:
-            ConnectHelper.list_connected_probes()
-        elif self._args.targets:
-            # Create targets from provided CMSIS pack.
-            if session.options['pack'] is not None:
-                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
-
-            obj = ListGenerator.list_targets(name_filter=self._args.name,
-                                            vendor_filter=self._args.vendor,
-                                            source_filter=self._args.source)
-            pt = self._get_pretty_table(["Name", "Vendor", "Part Number", "Families", "Source"])
-            for info in sorted(obj['targets'], key=lambda i: i['name']):
-                pt.add_row([
-                            info['name'],
-                            info['vendor'],
-                            info['part_number'],
-                            ', '.join(info['part_families']),
-                            info['source'],
-                            ])
-            print(pt)
-        elif self._args.boards:
-            obj = ListGenerator.list_boards(name_filter=self._args.name)
-            pt = self._get_pretty_table(["ID", "Name", "Target", "Test Binary"])
-            for info in sorted(obj['boards'], key=lambda i: i['id']):
-                pt.add_row([
-                            info['id'],
-                            info['name'],
-                            info['target'],
-                            info['binary']
-                            ])
-            print(pt)
-        elif self._args.plugins:
-            obj = ListGenerator.list_plugins()
-            pt = self._get_pretty_table(["Type", "Plugin Name", "Version", "Description"])
-            for group_info in sorted(obj['plugins'], key=lambda i: i['plugin_type']):
-                for plugin_info in sorted(group_info['plugins'], key=lambda i: i['name']):
-                    pt.add_row([
-                                PLUGIN_GROUP_NAMES[group_info['plugin_type']],
-                                plugin_info['name'],
-                                plugin_info['version'],
-                                plugin_info['description'],
-                                ])
-            print(pt)
-    
-    def do_json(self):
-        """! @brief Handle 'json' subcommand."""
-        all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.features)
-        
-        # Default to listing probes.
-        if not any(all_outputs):
-            self._args.probes = True
-        
-        # Check for more than one output option being selected.
-        if sum(int(x) for x in all_outputs) > 1:
-            # Because we're outputting JSON we can't just log the error, but must report the error
-            # via the JSON format.
-            obj = {
-                'pyocd_version' : __version__,
-                'version' : { 'major' : 1, 'minor' : 0 },
-                'status' : 1,
-                'error' : "More than one output data selected.",
-                }
-
-            print(json.dumps(obj, indent=4))
-            return
-        
-        # Create a session with no device so we load any config.
-        session = Session(None,
-                            project_dir=self._args.project_dir,
-                            config_file=self._args.config,
-                            no_config=self._args.no_config,
-                            pack=self._args.pack,
-                            **convert_session_options(self._args.options)
-                            )
-        
-        if self._args.targets or self._args.boards:
-            # Create targets from provided CMSIS pack.
-            if session.options['pack'] is not None:
-                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
-
-        if self._args.probes:
-            obj = ListGenerator.list_probes()
-        elif self._args.targets:
-            obj = ListGenerator.list_targets()
-        elif self._args.boards:
-            obj = ListGenerator.list_boards()
-        elif self._args.features:
-            obj = ListGenerator.list_features()
-        else:
-            assert False
-        print(json.dumps(obj, indent=4))
-    
-    def do_flash(self):
-        """! @brief Handle 'flash' subcommand."""
-        self._increase_logging(["pyocd.flash.loader"])
-        
-        session = ConnectHelper.session_with_chosen_probe(
-                            project_dir=self._args.project_dir,
-                            config_file=self._args.config,
-                            user_script=self._args.script,
-                            no_config=self._args.no_config,
-                            pack=self._args.pack,
-                            unique_id=self._args.unique_id,
-                            target_override=self._args.target_override,
-                            frequency=self._args.frequency,
-                            blocking=(not self._args.no_wait),
-                            connect_mode=self._args.connect_mode,
-                            options=convert_session_options(self._args.options))
-        if session is None:
-            LOG.error("No device available to flash")
-            sys.exit(1)
-        with session:
-            programmer = FileProgrammer(session,
-                            chip_erase=self._args.erase,
-                            trust_crc=self._args.trust_crc)
-            programmer.program(self._args.file,
-                            base_address=self._args.base_address,
-                            skip=self._args.skip,
-                            file_format=self._args.format)
-    
-    def do_erase(self):
-        """! @brief Handle 'erase' subcommand."""
-        self._increase_logging(["pyocd.flash.eraser"])
-        
-        # Display a nice, helpful error describing why nothing was done and how to correct it.
-        if (self._args.erase_mode is None) or not self._args.addresses:
-            LOG.error("No erase operation specified. Please specify one of '--chip', '--sector', "
-                        "or '--mass' to indicate the desired erase mode. For sector erases, a list "
-                        "of sector addresses to erase must be provided. "
-                        "See 'pyocd erase --help' for more.")
-            return
-        
-        session = ConnectHelper.session_with_chosen_probe(
-                            project_dir=self._args.project_dir,
-                            config_file=self._args.config,
-                            user_script=self._args.script,
-                            no_config=self._args.no_config,
-                            pack=self._args.pack,
-                            unique_id=self._args.unique_id,
-                            target_override=self._args.target_override,
-                            frequency=self._args.frequency,
-                            blocking=(not self._args.no_wait),
-                            connect_mode=self._args.connect_mode,
-                            options=convert_session_options(self._args.options))
-        if session is None:
-            LOG.error("No device available to erase")
-            sys.exit(1)
-        with session:
-            mode = self._args.erase_mode or FlashEraser.Mode.SECTOR
-            eraser = FlashEraser(session, mode)
-            
-            addresses = flatten_args(self._args.addresses)
-            eraser.erase(addresses)
-    
-    def do_reset(self):
-        """! @brief Handle 'reset' subcommand."""
-        # Verify selected reset type.
-        try:
-            the_reset_type = convert_reset_type(self._args.reset_type)
-        except ValueError:
-            LOG.error("Invalid reset method: %s", self._args.reset_type)
-            return
-        
-        session = ConnectHelper.session_with_chosen_probe(
-                            project_dir=self._args.project_dir,
-                            config_file=self._args.config,
-                            user_script=self._args.script,
-                            no_config=self._args.no_config,
-                            pack=self._args.pack,
-                            unique_id=self._args.unique_id,
-                            target_override=self._args.target_override,
-                            frequency=self._args.frequency,
-                            blocking=(not self._args.no_wait),
-                            connect_mode=self._args.connect_mode,
-                            options=convert_session_options(self._args.options))
-        if session is None:
-            LOG.error("No device available to reset")
-            sys.exit(1)
-        try:
-            # Handle hw reset specially using the probe, so we don't need a valid connection
-            # and can skip discovery.
-            is_hw_reset = the_reset_type == Target.ResetType.HW
-            
-            # Only init the board if performing a sw reset.
-            session.open(init_board=(not is_hw_reset))
-            
-            LOG.info("Performing '%s' reset...", self._args.reset_type)
-            if is_hw_reset:
-                session.probe.reset()
-            else:
-                session.target.reset(reset_type=the_reset_type)
-            LOG.info("Done.")
-        finally:
-            session.close()
-
-    def _process_commands(self, commands):
-        """! @brief Handle OpenOCD commands for compatibility."""
-        if commands is None:
-            return
-        for cmd_list in commands:
-            try:
-                cmd_list = split_command_line(cmd_list)
-                cmd = cmd_list[0]
-                if cmd == 'gdb_port':
-                    if len(cmd_list) < 2:
-                        LOG.error("Missing port argument")
-                    else:
-                        self._args.port_number = int(cmd_list[1], base=0)
-                elif cmd == 'telnet_port':
-                    if len(cmd_list) < 2:
-                        LOG.error("Missing port argument")
-                    else:
-                        self._args.telnet_port = int(cmd_list[1], base=0)
-                elif cmd == 'echo':
-                    self.echo_msg = ' '.join(cmd_list[1:])
-                else:
-                    LOG.error("Unsupported command: %s" % ' '.join(cmd_list))
-            except IndexError:
-                pass
-
-    def _gdbserver_listening_cb(self, note):
-        """! @brief Callback invoked when the gdbserver starts listening on its port."""
-        if self.echo_msg is not None:
-            print(self.echo_msg, file=sys.stderr)
-            sys.stderr.flush()
-    
-    def do_gdbserver(self):
-        """! @brief Handle 'gdbserver' subcommand."""
-        self._process_commands(self._args.commands)
-
-        probe_server = None
-        gdbs = []
-        try:
-            # Build dict of session options.
-            sessionOptions = convert_session_options(self._args.options)
-            sessionOptions.update({
-                'gdbserver_port' : self._args.port_number,
-                'telnet_port' : self._args.telnet_port,
-                'persist' : self._args.persist,
-                'step_into_interrupt' : self._args.step_into_interrupt,
-                'chip_erase': self._args.erase,
-                'fast_program' : self._args.trust_crc,
-                'enable_semihosting' : self._args.enable_semihosting,
-                'serve_local_only' : self._args.serve_local_only,
-                'vector_catch' : self._args.vector_catch,
-                })
-            
-            # Split list of cores to serve.
-            if self._args.core is not None:
-                try:
-                    core_list = {int(x) for x in self._args.core.split(',')}
-                except ValueError as err:
-                    LOG.error("Invalid value passed to --core")
-                    return
-            else:
-                core_list = None
-            
-            # Get the probe.
-            probe = ConnectHelper.choose_probe(
-                        blocking=(not self._args.no_wait),
-                        return_first=False,
-                        unique_id=self._args.unique_id,
-                        )
-            if probe is None:
-                LOG.error("No probe selected.")
-                return
-            
-            # Create a proxy so the probe can be shared between the session and probe server.
-            probe_proxy = SharedDebugProbeProxy(probe)
-            
-            # Create the session.
-            session = Session(probe_proxy,
-                project_dir=self._args.project_dir,
-                user_script=self._args.script,
-                config_file=self._args.config,
-                no_config=self._args.no_config,
-                pack=self._args.pack,
-                unique_id=self._args.unique_id,
-                target_override=self._args.target_override,
-                frequency=self._args.frequency,
-                connect_mode=self._args.connect_mode,
-                options=sessionOptions)
-            if session is None:
-                LOG.error("No probe selected.")
-                return
-            with session:
-                # Validate the core selection.
-                all_cores = set(session.target.cores.keys())
-                if core_list is None:
-                    core_list = all_cores
-                bad_cores = core_list.difference(all_cores)
-                if len(bad_cores):
-                    LOG.error("Invalid core number%s: %s",
-                        "s" if len(bad_cores) > 1 else "",
-                        ", ".join(str(x) for x in bad_cores))
-                    return
-                
-                # Set ELF if provided.
-                if self._args.elf:
-                    session.board.target.elf = os.path.expanduser(self._args.elf)
-                    
-                # Run the probe server is requested.
-                if self._args.enable_probe_server:
-                    probe_server = DebugProbeServer(session, session.probe,
-                            self._args.probe_server_port, self._args.serve_local_only)
-                    session.probeserver = probe_server
-                    probe_server.start()
-                    
-                # Start up the gdbservers.
-                for core_number, core in session.board.target.cores.items():
-                    # Don't create a server for CPU-less memory Access Port. 
-                    if isinstance(session.board.target.cores[core_number], GenericMemAPTarget):
-                        continue
-                    # Don't create a server if this core is not listed by the user.
-                    if core_number not in core_list:
-                        continue
-                    gdb = GDBServer(session, core=core_number)
-                    # Only subscribe to the server for the first core, so echo messages aren't printed
-                    # multiple times.
-                    if not gdbs:
-                        session.subscribe(self._gdbserver_listening_cb, GDBServer.GDBSERVER_START_LISTENING_EVENT, gdb)
-                    session.gdbservers[core_number] = gdb
-                    gdbs.append(gdb)
-                    gdb.start()
-                gdb = gdbs[0]
-                while any(g.is_alive() for g in gdbs):
-                    sleep(0.1)
-                if probe_server:
-                    probe_server.stop()
-        except (KeyboardInterrupt, Exception):
-            for server in gdbs:
-                server.stop()
-            if probe_server:
-                probe_server.stop()
-            raise
-    
-    def do_commander(self):
-        """! @brief Handle 'commander' subcommand."""
-        # Flatten commands list then extract primary command and its arguments.
-        if self._args.commands is not None:
-            cmds = []
-            for cmd in self._args.commands:
-                cmds.append(flatten_args(split_command_line(arg) for arg in cmd))
-        else:
-            cmds = None
-
-        # Enter REPL.
-        PyOCDCommander(self._args, cmds).run()
-    
-    def do_pack(self):
-        """! @brief Handle 'pack' subcommand."""
-        if not CPM_AVAILABLE:
-            LOG.error("'pack' command is not available because cmsis-pack-manager is not installed")
-            return
-        
-        verbosity = self._args.verbose - self._args.quiet
-        cache = cmsis_pack_manager.Cache(verbosity < 0, False)
-        
-        if self._args.clean:
-            LOG.info("Removing all pack data...")
-            cache.cache_clean()
-        
-        if self._args.update:
-            LOG.info("Updating pack index...")
-            cache.cache_descriptors()
-            print()
-        
-        if self._args.show:
-            packs = pack_target.ManagedPacks.get_installed_packs(cache)
-            pt = self._get_pretty_table(["Vendor", "Pack", "Version"])
-            for ref in packs:
-                pt.add_row([
-                            ref.vendor,
-                            ref.pack,
-                            ref.version,
-                            ])
-            print(pt)
-
-        if self._args.find_devices or self._args.install_devices:
-            if not cache.index:
-                LOG.info("No pack index present, downloading now...")
-                cache.cache_descriptors()
-            
-            patterns = self._args.find_devices or self._args.install_devices
-            
-            # Find matching part numbers.
-            matches = set()
-            for pattern in patterns:
-                # Using fnmatch.fnmatch() was failing to match correctly.
-                pat = re.compile(fnmatch.translate(pattern).rsplit('\\Z')[0], re.IGNORECASE)
-                results = {name for name in cache.index.keys() if pat.search(name)}
-                matches.update(results)
-            
-            if not matches:
-                LOG.warning("No matching devices. Please make sure the pack index is up to date.")
-                return
-            
-            if self._args.find_devices:
-                # Get the list of installed pack targets.
-                installed_targets = pack_target.ManagedPacks.get_installed_targets(cache=cache)
-                installed_target_names = [target.part_number.lower() for target in installed_targets]
-                
-                pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version", "Installed"])
-                for name in sorted(matches):
-                    info = cache.index[name]
-                    ref, = cache.packs_for_devices([info])
-                    pt.add_row([
-                                info['name'],
-                                ref.vendor,
-                                ref.pack,
-                                ref.version,
-                                info['name'].lower() in installed_target_names,
-                                ])
-                print(pt)
-            elif self._args.install_devices:
-                devices = [cache.index[dev] for dev in matches]
-                packs = cache.packs_for_devices(devices)
-                if not self._args.no_download:
-                    print("Downloading packs (press Control-C to cancel):")
-                else:
-                    print("Would download packs:")
-                for pack in packs:
-                    print("    " + str(pack))
-                if not self._args.no_download:
-                    cache.download_pack_list(packs)
-                print()
-
-    def do_server(self):
-        """! @brief Handle 'server' subcommand."""
-        # Create a session to load config, particularly logging config. Even though we do have a
-        # probe, we don't set it in the session because we don't want the board, target, etc objects
-        # to be created.
-        session_options = convert_session_options(self._args.options)
-        session = Session(probe=None,
-                serve_local_only=self._args.serve_local_only,
-                options=session_options)
-        
-        # The ultimate intent is to serve all available probes by default. For now we just serve
-        # a single probe.
-        probe = ConnectHelper.choose_probe(unique_id=self._args.unique_id)
-        if probe is None:
-            return
-        
-        # Assign the session to the probe.
-        probe.session = session
-        
-        # Create the server instance.
-        server = DebugProbeServer(session, probe, self._args.port_number, self._args.serve_local_only)
-        session.probeserver = server
-        LOG.debug("Starting debug probe server")
-        server.start()
-        
-        # Loop as long as the probe is running. The server thread is a daemon, so the main thread
-        # must continue to exist.
-        try:
-            while server.is_running:
-                sleep(0.1)
-        except (KeyboardInterrupt, Exception):
-            server.stop()
-            raise
-
-    ## @brief Table of handler methods for subcommands.
-    _COMMANDS = {
-        'list':         do_list,
-        'json':         do_json,
-        'flash':        do_flash,
-        'erase':        do_erase,
-        'reset':        do_reset,
-        'gdbserver':    do_gdbserver,
-        'gdb':          do_gdbserver,
-        'commander':    do_commander,
-        'cmd':          do_commander,
-        'pack':         do_pack,
-        'server':       do_server,
-        }
 
 def main():
     sys.exit(PyOCDTool().run())

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -194,7 +194,11 @@ class Session(Notifier):
                     with open(configPath, 'r') as configFile:
                         LOG.debug("Loading config from: %s", configPath)
                         config = yaml.safe_load(configFile)
-                        if not isinstance(config, dict):
+                        # Allow an empty config file.
+                        if config is None:
+                            return {}
+                        # But fail if someone tries to put something other than a dict at the top.
+                        elif not isinstance(config, dict):
                             raise exceptions.Error("configuration file %s does not contain a top-level dictionary"
                                     % configPath)
                         return config

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -687,7 +687,7 @@ class PicoprobePlugin(Plugin):
 
     @ property
     def name(self):
-        return "Picoprobe"
+        return "picoprobe"
 
     @ property
     def description(self):

--- a/pyocd/subcommands/__init__.py
+++ b/pyocd/subcommands/__init__.py
@@ -1,0 +1,15 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -39,10 +39,15 @@ class SubcommandBase:
         
         # Define logging related options.
         LOGGING = argparse.ArgumentParser(description='logging', add_help=False)
-        LOGGING.add_argument('-v', '--verbose', action='count', default=0,
-            help="More logging. Can be specified multiple times.")
-        LOGGING.add_argument('-q', '--quiet', action='count', default=0,
-            help="Less logging. Can be specified multiple times.")
+        LOGGING_GROUP = LOGGING.add_argument_group("logging")
+        LOGGING_GROUP.add_argument('-v', '--verbose', action='count', default=0,
+            help="Increase logging level. Can be specified multiple times.")
+        LOGGING_GROUP.add_argument('-q', '--quiet', action='count', default=0,
+            help="Decrease logging level. Can be specified multiple times.")
+        LOGGING_GROUP.add_argument('-L', '--log-level', action='append', metavar="LOGGERS=LEVEL", default=[],
+            help="Set log level of loggers matching any of the comma-separated list of logger name glob-style "
+            "patterns. Log level must be one of 'critical', 'error', 'warning', 'info', or 'debug'. Can be "
+            "specified multiple times. Example: -L*.trace,pyocd.core.*=debug")
     
         # Define config related options for all subcommands.
         CONFIG = argparse.ArgumentParser(description='common', add_help=False)

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -1,0 +1,169 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import prettytable
+from typing import (Iterable, List, Any, Optional)
+
+from ..utility.cmdline import convert_frequency
+
+class SubcommandBase:
+    """! @brief Base class for pyocd command line subcommand."""
+
+    # Subcommand descriptors.
+    NAMES: List[str] = []
+    HELP: str = ""
+    EPILOG: Optional[str] = None
+    DEFAULT_LOG_LEVEL = logging.INFO
+    SUBCOMMANDS: List["SubcommandBase"] = []
+
+    ## Class attribute to store the built subcommand argument parser.
+    parser: Optional[argparse.ArgumentParser] = None
+
+    class CommonOptions:
+        """! @brief Namespace with parsers for repeated option groups."""
+        
+        # Define logging related options.
+        LOGGING = argparse.ArgumentParser(description='logging', add_help=False)
+        LOGGING.add_argument('-v', '--verbose', action='count', default=0,
+            help="More logging. Can be specified multiple times.")
+        LOGGING.add_argument('-q', '--quiet', action='count', default=0,
+            help="Less logging. Can be specified multiple times.")
+    
+        # Define config related options for all subcommands.
+        CONFIG = argparse.ArgumentParser(description='common', add_help=False)
+        CONFIG_GROUP = CONFIG.add_argument_group("configuration")
+        CONFIG_GROUP.add_argument('-j', '--project', '--dir', metavar="PATH", dest="project_dir",
+            help="Set the project directory. Defaults to the directory where pyocd was run.")
+        CONFIG_GROUP.add_argument('--config', metavar="PATH",
+            help="Specify YAML configuration file. Default is pyocd.yaml or pyocd.yml.")
+        CONFIG_GROUP.add_argument("--no-config", action="store_true", default=None,
+            help="Do not use a configuration file.")
+        CONFIG_GROUP.add_argument('--script', metavar="PATH",
+            help="Use the specified user script. Defaults to pyocd_user.py.")
+        CONFIG_GROUP.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
+            help="Set named option.")
+        CONFIG_GROUP.add_argument("-da", "--daparg", dest="daparg", nargs='+',
+            help="(Deprecated) Send setting to DAPAccess layer.")
+        CONFIG_GROUP.add_argument("--pack", metavar="PATH", action="append",
+            help="Path to a CMSIS Device Family Pack.")
+    
+        # Define common options for all subcommands, including logging options.
+        COMMON = argparse.ArgumentParser(description='common',
+            parents=[LOGGING, CONFIG], add_help=False)
+    
+        # Common connection related options.
+        CONNECT = argparse.ArgumentParser(description='common', add_help=False)
+        CONNECT_GROUP = CONNECT.add_argument_group("connection")
+        CONNECT_GROUP.add_argument("-u", "--uid", "--probe", dest="unique_id",
+            help="Choose a probe by its unique ID or a substring thereof. Optionally prefixed with "
+            "'<probe-type>:' where <probe-type> is the name of a probe plugin.")
+        CONNECT_GROUP.add_argument("-b", "--board", dest="board_override", metavar="BOARD",
+            help="Set the board type (not yet implemented).")
+        CONNECT_GROUP.add_argument("-t", "--target", dest="target_override", metavar="TARGET",
+            help="Set the target type.")
+        CONNECT_GROUP.add_argument("-f", "--frequency", dest="frequency", default=None, type=convert_frequency,
+            help="SWD/JTAG clock frequency in Hz. Accepts a float or int with optional case-"
+                "insensitive K/M suffix and optional Hz. Examples: \"1000\", \"2.5khz\", \"10m\".")
+        CONNECT_GROUP.add_argument("-W", "--no-wait", action="store_true",
+            help="Do not wait for a probe to be connected if none are available.")
+        CONNECT_GROUP.add_argument("-M", "--connect", dest="connect_mode", metavar="MODE",
+            help="Select connect mode from one of (halt, pre-reset, under-reset, attach).")
+    
+    @classmethod
+    def add_subcommands(cls, parser: argparse.ArgumentParser) -> None:
+        """! @brief Add declared subcommands to the given parser."""
+        if cls.SUBCOMMANDS:
+            subparsers = parser.add_subparsers(title="subcommands", metavar="", dest='cmd')
+            for subcmd_class in cls.SUBCOMMANDS:
+                parsers = subcmd_class.get_args()
+                subcmd_class.parser = parsers[-1]
+                
+                subparser = subparsers.add_parser(
+                                subcmd_class.NAMES[0],
+                                aliases=subcmd_class.NAMES[1:],
+                                parents=parsers,
+                                help=subcmd_class.HELP,
+                                epilog=subcmd_class.EPILOG)
+                subparser.set_defaults(command_class=subcmd_class)
+                subcmd_class.customize_subparser(subparser)
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object.
+        @return List of argument parsers. The last element in the list _must_ be the parser for the subcommand
+            class itself, as it is saved by the caller in cls.parser.
+        """
+        raise NotImplementedError()
+
+    @classmethod
+    def customize_subparser(cls, subparser: argparse.ArgumentParser) -> None:
+        """! @brief Optionally modify a subparser after it is created."""
+        pass
+    
+    def __init__(self, args: argparse.Namespace):
+        """! @brief Constructor.
+        
+        @param self This object.
+        @param args Namespace of parsed argument values.
+        """
+        self._args = args
+    
+    def invoke(self) -> int:
+        """! @brief Run the subcommand.
+        @return Process status code for the command.
+        """
+        if self.parser is not None:
+            self.parser.print_help()
+        return 0
+
+    def _get_log_level_delta(self) -> int:
+        """! @brief Compute the logging level delta sum from quiet and verbose counts."""
+        return (self._args.quiet * 10) - (self._args.verbose * 10)
+
+    def _increase_logging(self, loggers: List[str]) -> None:
+        """! @brief Increase logging level for a set of subloggers.
+        @param self This object.
+        @param loggers
+        """
+        delta = self._get_log_level_delta()
+        if delta <= 0:
+            level = max(1, self.DEFAULT_LOG_LEVEL + delta - 10)
+            for logger in loggers:
+                logging.getLogger(logger).setLevel(level)
+
+    def _get_pretty_table(self, fields: List[str], header: bool = None) -> prettytable.PrettyTable:
+        """! @brief Returns a PrettyTable object with formatting options set."""
+        pt = prettytable.PrettyTable(fields)
+        pt.align = 'l'
+        if header is not None:
+            pt.header = header
+        elif hasattr(self._args, 'no_header'):
+            pt.header = not self._args.no_header
+        else:
+            pt.header = True
+        pt.border = True
+        pt.hrules = prettytable.HEADER
+        pt.vrules = prettytable.NONE
+        return pt
+
+    @staticmethod
+    def flatten_args(args: Iterable[Iterable[Any]]) -> List[Any]:
+        """! @brief Converts a list of lists to a single list."""
+        return [item for sublist in args for item in sublist]
+    
+

--- a/pyocd/subcommands/commander_cmd.py
+++ b/pyocd/subcommands/commander_cmd.py
@@ -1,0 +1,64 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+from typing import List
+
+from .base import SubcommandBase
+from ..commands.commander import PyOCDCommander
+from ..utility.cmdline import split_command_line
+
+class CommanderSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['commander', 'cmd']
+    HELP = "Interactive command console."
+    DEFAULT_LOG_LEVEL = logging.WARNING
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        commander_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        commander_options = commander_parser.add_argument_group("commander options")
+        commander_options.add_argument("-H", "--halt", action="store_true", default=None,
+            help="Halt core upon connect. (Deprecated, see --connect.)")
+        commander_options.add_argument("-N", "--no-init", action="store_true",
+            help="Do not init debug system.")
+        commander_options.add_argument("--elf", metavar="PATH",
+            help="Optionally specify ELF file being debugged.")
+        commander_options.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
+            help="Run commands.")
+        
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, commander_parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'commander' subcommand."""
+        # Flatten commands list then extract primary command and its arguments.
+        if self._args.commands is not None:
+            cmds = []
+            for cmd in self._args.commands:
+                cmds.append(self.flatten_args(split_command_line(arg) for arg in cmd))
+        else:
+            cmds = None
+
+        # Enter REPL.
+        PyOCDCommander(self._args, cmds).run()
+
+        return 0
+
+

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -1,0 +1,97 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..flash.eraser import FlashEraser
+from ..utility.cmdline import convert_session_options
+
+LOG = logging.getLogger(__name__)
+
+class EraseSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['erase']
+    HELP = "Erase entire device flash or specified sectors."
+    EPILOG = ("If no position arguments are listed, then no action will be taken unless the --chip or "
+            "--mass-erase options are provided. Otherwise, the positional arguments should be the addresses of flash "
+            "sectors or address ranges. The end address of a range is exclusive, meaning that it will not be "
+            "erased. Thus, you should specify the address of the sector after the last one "
+            "to be erased. If a '+' is used instead of '-' in a range, this indicates that the "
+            "second value is a length rather than end address. "
+            "Examples: 0x1000 (erase single sector starting at 0x1000) "
+            "0x800-0x2000 (erase sectors starting at 0x800 up to but not including 0x2000) "
+            "0+8192 (erase 8 kB starting at address 0)")
+    DEFAULT_LOG_LEVEL = logging.WARNING
+    
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        erase_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        erase_options = erase_parser.add_argument_group("erase options")
+        erase_options.add_argument("-c", "--chip", dest="erase_mode", action="store_const", const=FlashEraser.Mode.CHIP,
+            help="Perform a chip erase.")
+        erase_options.add_argument("-s", "--sector", dest="erase_mode", action="store_const", const=FlashEraser.Mode.SECTOR,
+            help="Erase the sectors listed as positional arguments.")
+        erase_options.add_argument("--mass", dest="erase_mode", action="store_const", const=FlashEraser.Mode.MASS,
+            help="Perform a mass erase. On some devices this is different than a chip erase.")
+        erase_options.add_argument("addresses", metavar="<sector-address>", action='append', nargs='*',
+            help="List of sector addresses or ranges to erase.")
+        
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, erase_parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'erase' subcommand."""
+        self._increase_logging(["pyocd.flash.eraser"])
+        
+        # Display a nice, helpful error describing why nothing was done and how to correct it.
+        if (self._args.erase_mode is None) or not self._args.addresses:
+            LOG.error("No erase operation specified. Please specify one of '--chip', '--sector', "
+                        "or '--mass' to indicate the desired erase mode. For sector erases, a list "
+                        "of sector addresses to erase must be provided. "
+                        "See 'pyocd erase --help' for more.")
+            return 1
+        
+        session = ConnectHelper.session_with_chosen_probe(
+                            project_dir=self._args.project_dir,
+                            config_file=self._args.config,
+                            user_script=self._args.script,
+                            no_config=self._args.no_config,
+                            pack=self._args.pack,
+                            unique_id=self._args.unique_id,
+                            target_override=self._args.target_override,
+                            frequency=self._args.frequency,
+                            blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
+                            options=convert_session_options(self._args.options))
+        if session is None:
+            LOG.error("No device available to erase")
+            return 1
+        with session:
+            mode = self._args.erase_mode or FlashEraser.Mode.SECTOR
+            eraser = FlashEraser(session, mode)
+            
+            addresses = self.flatten_args(self._args.addresses)
+            eraser.erase(addresses)
+
+        return 0
+
+

--- a/pyocd/subcommands/flash_cmd.py
+++ b/pyocd/subcommands/flash_cmd.py
@@ -1,0 +1,97 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..flash.file_programmer import FileProgrammer
+from ..utility.cmdline import convert_session_options
+
+LOG = logging.getLogger(__name__)
+
+def int_base_0(x):
+    """! @brief Converts a string to an int with support for base prefixes."""
+    return int(x, base=0)
+
+class FlashSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['flash']
+    HELP = "Program an image to device flash."
+    DEFAULT_LOG_LEVEL = logging.WARNING
+    
+    ## @brief Valid erase mode options.
+    ERASE_OPTIONS = [
+        'auto',
+        'chip',
+        'sector',
+        ]
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        flash_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        flash_options = flash_parser.add_argument_group("flash options")
+        flash_options.add_argument("-e", "--erase", choices=cls.ERASE_OPTIONS, default='sector',
+            help="Choose flash erase method. Default is sector.")
+        flash_options.add_argument("-a", "--base-address", metavar="ADDR", type=int_base_0,
+            help="Base address used for the address where to flash a binary. Defaults to start of flash.")
+        flash_options.add_argument("--trust-crc", action="store_true",
+            help="Use only the CRC of each page to determine if it already has the same data.")
+        flash_options.add_argument("--format", choices=("bin", "hex", "elf"),
+            help="File format. Default is to use the file's extension.")
+        flash_options.add_argument("--skip", metavar="BYTES", default=0, type=int_base_0,
+            help="Skip programming the first N bytes. This can only be used with binary files.")
+        flash_options.add_argument("file", metavar="PATH",
+            help="File to program into flash.")
+        
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, flash_parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'flash' subcommand."""
+        self._increase_logging(["pyocd.flash.loader"])
+        
+        session = ConnectHelper.session_with_chosen_probe(
+                            project_dir=self._args.project_dir,
+                            config_file=self._args.config,
+                            user_script=self._args.script,
+                            no_config=self._args.no_config,
+                            pack=self._args.pack,
+                            unique_id=self._args.unique_id,
+                            target_override=self._args.target_override,
+                            frequency=self._args.frequency,
+                            blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
+                            options=convert_session_options(self._args.options))
+        if session is None:
+            LOG.error("No device available to flash")
+            return 1
+        with session:
+            programmer = FileProgrammer(session,
+                            chip_erase=self._args.erase,
+                            trust_crc=self._args.trust_crc)
+            programmer.program(self._args.file,
+                            base_address=self._args.base_address,
+                            skip=self._args.skip,
+                            file_format=self._args.format)
+
+        return 0
+
+

--- a/pyocd/subcommands/gdbserver_cmd.py
+++ b/pyocd/subcommands/gdbserver_cmd.py
@@ -1,0 +1,242 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import (Optional, List)
+import logging
+import sys
+import os
+from time import sleep
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..core.session import Session
+from ..utility.cmdline import (
+    convert_session_options,
+    split_command_line,
+    )
+from ..probe.shared_probe_proxy import SharedDebugProbeProxy
+from ..gdbserver import GDBServer
+from ..probe.tcp_probe_server import DebugProbeServer
+from ..coresight.generic_mem_ap import GenericMemAPTarget
+from ..utility.notification import Notification
+
+LOG = logging.getLogger(__name__)
+
+class GdbserverSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['gdbserver', 'gdb']
+    HELP = "Run the gdb remote server(s)."
+    
+    ## @brief Valid erase mode options.
+    ERASE_OPTIONS = [
+        'auto',
+        'chip',
+        'sector',
+        ]
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        gdbserver_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        gdbserver_options = gdbserver_parser.add_argument_group("gdbserver options")
+        gdbserver_options.add_argument("-p", "--port", metavar="PORT", dest="port_number", type=int,
+            default=3333,
+            help="Set starting port number for the GDB server (default 3333). Additional cores "
+                "will have a port number of this parameter plus the core number.")
+        gdbserver_options.add_argument("-T", "--telnet-port", metavar="PORT", dest="telnet_port",
+            type=int, default=4444,
+            help="Specify starting telnet port for semihosting (default 4444).")
+        gdbserver_options.add_argument("-R", "--probe-server-port",
+            dest="probe_server_port", metavar="PORT", type=int, default=5555,
+            help="Specify the telnet port for semihosting (default 4444).")
+        gdbserver_options.add_argument("--allow-remote", dest="serve_local_only", default=True, action="store_false",
+            help="Allow remote TCP/IP connections (default is no).")
+        gdbserver_options.add_argument("--persist", action="store_true",
+            help="Keep GDB server running even after remote has detached.")
+        gdbserver_options.add_argument("-r", "--probe-server", action="store_true", dest="enable_probe_server",
+            help="Enable the probe server in addition to the GDB server.")
+        gdbserver_options.add_argument("--core", metavar="CORE_LIST",
+            help="Comma-separated list of cores for which gdbservers will be created. Default is all cores.")
+        gdbserver_options.add_argument("--elf", metavar="PATH",
+            help="Optionally specify ELF file being debugged.")
+        gdbserver_options.add_argument("-e", "--erase", choices=cls.ERASE_OPTIONS, default='sector',
+            help="Choose flash erase method. Default is sector.")
+        gdbserver_options.add_argument("--trust-crc", action="store_true",
+            help="Use only the CRC of each page to determine if it already has the same data.")
+        gdbserver_options.add_argument("-C", "--vector-catch", default='h',
+            help="Enable vector catch sources, one letter per enabled source in any order, or 'all' "
+                "or 'none'. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, "
+                "c=check err, p=nocp, r=reset, a=all, n=none). Default is hard fault.")
+        gdbserver_options.add_argument("-S", "--semihosting", dest="enable_semihosting", action="store_true",
+            help="Enable semihosting.")
+        gdbserver_options.add_argument("--step-into-interrupts", dest="step_into_interrupt", default=False, action="store_true",
+            help="Allow single stepping to step into interrupts.")
+        gdbserver_options.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
+            help="Run command (OpenOCD compatibility).")
+        
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, gdbserver_parser]
+    
+    def __init__(self, args: argparse.Namespace):
+        """! @brief Constructor."""
+        super().__init__(args)
+        self._echo_msg = None
+        
+    def _process_commands(self, commands: Optional[List[str]]):
+        """! @brief Handle OpenOCD commands for compatibility."""
+        if commands is None:
+            return
+        for cmd_list in commands:
+            try:
+                cmd_list = split_command_line(cmd_list)
+                cmd = cmd_list[0]
+                if cmd == 'gdb_port':
+                    if len(cmd_list) < 2:
+                        LOG.error("Missing port argument")
+                    else:
+                        self._args.port_number = int(cmd_list[1], base=0)
+                elif cmd == 'telnet_port':
+                    if len(cmd_list) < 2:
+                        LOG.error("Missing port argument")
+                    else:
+                        self._args.telnet_port = int(cmd_list[1], base=0)
+                elif cmd == 'echo':
+                    self._echo_msg = ' '.join(cmd_list[1:])
+                else:
+                    LOG.error("Unsupported command: %s" % ' '.join(cmd_list))
+            except IndexError:
+                pass
+
+    def _gdbserver_listening_cb(self, note: Notification):
+        """! @brief Callback invoked when the gdbserver starts listening on its port."""
+        if self._echo_msg is not None:
+            print(self._echo_msg, file=sys.stderr)
+            sys.stderr.flush()
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'gdbserver' subcommand."""
+        self._process_commands(self._args.commands)
+
+        probe_server = None
+        gdbs = []
+        try:
+            # Build dict of session options.
+            sessionOptions = convert_session_options(self._args.options)
+            sessionOptions.update({
+                'gdbserver_port' : self._args.port_number,
+                'telnet_port' : self._args.telnet_port,
+                'persist' : self._args.persist,
+                'step_into_interrupt' : self._args.step_into_interrupt,
+                'chip_erase': self._args.erase,
+                'fast_program' : self._args.trust_crc,
+                'enable_semihosting' : self._args.enable_semihosting,
+                'serve_local_only' : self._args.serve_local_only,
+                'vector_catch' : self._args.vector_catch,
+                })
+            
+            # Split list of cores to serve.
+            if self._args.core is not None:
+                try:
+                    core_list = {int(x) for x in self._args.core.split(',')}
+                except ValueError as err:
+                    LOG.error("Invalid value passed to --core")
+                    return 1
+            else:
+                core_list = None
+            
+            # Get the probe.
+            probe = ConnectHelper.choose_probe(
+                        blocking=(not self._args.no_wait),
+                        return_first=False,
+                        unique_id=self._args.unique_id,
+                        )
+            if probe is None:
+                LOG.error("No probe selected.")
+                return 1
+            
+            # Create a proxy so the probe can be shared between the session and probe server.
+            probe_proxy = SharedDebugProbeProxy(probe)
+            
+            # Create the session.
+            session = Session(probe_proxy,
+                project_dir=self._args.project_dir,
+                user_script=self._args.script,
+                config_file=self._args.config,
+                no_config=self._args.no_config,
+                pack=self._args.pack,
+                unique_id=self._args.unique_id,
+                target_override=self._args.target_override,
+                frequency=self._args.frequency,
+                connect_mode=self._args.connect_mode,
+                options=sessionOptions)
+            if session is None:
+                LOG.error("No probe selected.")
+                return 1
+            with session:
+                # Validate the core selection.
+                all_cores = set(session.target.cores.keys())
+                if core_list is None:
+                    core_list = all_cores
+                bad_cores = core_list.difference(all_cores)
+                if len(bad_cores):
+                    LOG.error("Invalid core number%s: %s",
+                        "s" if len(bad_cores) > 1 else "",
+                        ", ".join(str(x) for x in bad_cores))
+                    return 1
+                
+                # Set ELF if provided.
+                if self._args.elf:
+                    session.board.target.elf = os.path.expanduser(self._args.elf)
+                    
+                # Run the probe server is requested.
+                if self._args.enable_probe_server:
+                    probe_server = DebugProbeServer(session, session.probe,
+                            self._args.probe_server_port, self._args.serve_local_only)
+                    session.probeserver = probe_server
+                    probe_server.start()
+                    
+                # Start up the gdbservers.
+                for core_number, core in session.board.target.cores.items():
+                    # Don't create a server for CPU-less memory Access Port. 
+                    if isinstance(session.board.target.cores[core_number], GenericMemAPTarget):
+                        continue
+                    # Don't create a server if this core is not listed by the user.
+                    if core_number not in core_list:
+                        continue
+                    gdb = GDBServer(session, core=core_number)
+                    # Only subscribe to the server for the first core, so echo messages aren't printed
+                    # multiple times.
+                    if not gdbs:
+                        session.subscribe(self._gdbserver_listening_cb, GDBServer.GDBSERVER_START_LISTENING_EVENT, gdb)
+                    session.gdbservers[core_number] = gdb
+                    gdbs.append(gdb)
+                    gdb.start()
+                gdb = gdbs[0]
+                while any(g.is_alive() for g in gdbs):
+                    sleep(0.1)
+                if probe_server:
+                    probe_server.stop()
+        except (KeyboardInterrupt, Exception):
+            for server in gdbs:
+                server.stop()
+            if probe_server:
+                probe_server.stop()
+            raise
+
+        return 0
+

--- a/pyocd/subcommands/json_cmd.py
+++ b/pyocd/subcommands/json_cmd.py
@@ -1,0 +1,114 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+import json
+
+from .base import SubcommandBase
+from ..core.session import Session
+from ..tools.lists import ListGenerator
+from ..target.pack import pack_target
+from ..utility.cmdline import convert_session_options
+from .. import __version__
+
+LOG = logging.getLogger(__name__)
+
+class JsonSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['json']
+    HELP = "Output information as JSON."
+    DEFAULT_LOG_LEVEL = logging.FATAL + 1
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        json_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        json_options = json_parser.add_argument_group('json output')
+        json_options.add_argument('-p', '--probes', action='store_true',
+            help="List available probes.")
+        json_options.add_argument('-t', '--targets', action='store_true',
+            help="List all known targets.")
+        json_options.add_argument('-b', '--boards', action='store_true',
+            help="List all known boards.")
+        json_options.add_argument('-f', '--features', action='store_true',
+            help="List available features and options.")
+
+        return [cls.CommonOptions.CONFIG, json_parser]
+    
+    @classmethod
+    def customize_subparser(cls, subparser: argparse.ArgumentParser) -> None:
+        """! @brief Optionally modify a subparser after it is created."""
+        subparser.set_defaults(verbose=0, quiet=0)
+    
+    def __init__(self, args: argparse.Namespace):
+        super().__init__(args)
+        
+        # Disable all logging.
+        logging.disable(logging.CRITICAL)
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'json' subcommand."""
+        all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.features)
+        
+        # Default to listing probes.
+        if not any(all_outputs):
+            self._args.probes = True
+        
+        # Check for more than one output option being selected.
+        if sum(int(x) for x in all_outputs) > 1:
+            # Because we're outputting JSON we can't just log the error, but must report the error
+            # via the JSON format.
+            obj = {
+                'pyocd_version' : __version__,
+                'version' : { 'major' : 1, 'minor' : 0 },
+                'status' : 1,
+                'error' : "More than one output data selected.",
+                }
+
+            print(json.dumps(obj, indent=4))
+            return 0
+        
+        # Create a session with no device so we load any config.
+        session = Session(None,
+                            project_dir=self._args.project_dir,
+                            config_file=self._args.config,
+                            no_config=self._args.no_config,
+                            pack=self._args.pack,
+                            **convert_session_options(self._args.options)
+                            )
+        
+        if self._args.targets or self._args.boards:
+            # Create targets from provided CMSIS pack.
+            if session.options['pack'] is not None:
+                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
+
+        if self._args.probes:
+            obj = ListGenerator.list_probes()
+        elif self._args.targets:
+            obj = ListGenerator.list_targets()
+        elif self._args.boards:
+            obj = ListGenerator.list_boards()
+        elif self._args.features:
+            obj = ListGenerator.list_features()
+        else:
+            assert False
+        print(json.dumps(obj, indent=4))
+        return 0
+

--- a/pyocd/subcommands/list_cmd.py
+++ b/pyocd/subcommands/list_cmd.py
@@ -1,0 +1,137 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..core.session import Session
+from ..tools.lists import ListGenerator
+from ..target.pack import pack_target
+from ..utility.cmdline import convert_session_options
+
+LOG = logging.getLogger(__name__)
+
+class ListSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['list']
+    HELP = "List information about probes, targets, or boards."
+    
+    ## @brief Map to convert plugin groups to user friendly names.
+    PLUGIN_GROUP_NAMES = {
+        'pyocd.probe': "Debug Probe",
+        'pyocd.rtos': "RTOS",
+        }
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        list_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+        
+        list_output = list_parser.add_argument_group("list output")
+        list_output.add_argument('-p', '--probes', action='store_true',
+            help="List available probes.")
+        list_output.add_argument('-t', '--targets', action='store_true',
+            help="List all known targets.")
+        list_output.add_argument('-b', '--boards', action='store_true',
+            help="List all known boards.")
+        list_output.add_argument('--plugins', action='store_true',
+            help="List available plugins.")
+            
+        list_options = list_parser.add_argument_group('list options')
+        list_options.add_argument('-n', '--name',
+            help="Restrict listing to items matching the given name. Applies to targets and boards.")
+        list_options.add_argument('-r', '--vendor',
+            help="Restrict listing to items whose vendor matches the given name. Applies to targets.")
+        list_options.add_argument('-s', '--source', choices=('builtin', 'pack'),
+            help="Restrict listing to targets from the specified source. Applies to targets.")
+        list_options.add_argument('-H', '--no-header', action='store_true',
+            help="Don't print a table header.")
+        
+        return [cls.CommonOptions.COMMON, list_parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'list' subcommand."""
+        all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.plugins)
+        
+        # Default to listing probes.
+        if not any(all_outputs):
+            self._args.probes = True
+        
+        # Check for more than one output option being selected.
+        if sum(int(x) for x in all_outputs) > 1:
+            LOG.error("Only one of the output options '--probes', '--targets', '--boards', "
+                      "or '--plugins' may be selected at a time.")
+            return 1
+        
+        # Create a session with no device so we load any config.
+        session = Session(None,
+                            project_dir=self._args.project_dir,
+                            config_file=self._args.config,
+                            no_config=self._args.no_config,
+                            pack=self._args.pack,
+                            **convert_session_options(self._args.options)
+                            )
+        
+        if self._args.probes:
+            ConnectHelper.list_connected_probes()
+        elif self._args.targets:
+            # Create targets from provided CMSIS pack.
+            if session.options['pack'] is not None:
+                pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
+
+            obj = ListGenerator.list_targets(name_filter=self._args.name,
+                                            vendor_filter=self._args.vendor,
+                                            source_filter=self._args.source)
+            pt = self._get_pretty_table(["Name", "Vendor", "Part Number", "Families", "Source"])
+            for info in sorted(obj['targets'], key=lambda i: i['name']):
+                pt.add_row([
+                            info['name'],
+                            info['vendor'],
+                            info['part_number'],
+                            ', '.join(info['part_families']),
+                            info['source'],
+                            ])
+            print(pt)
+        elif self._args.boards:
+            obj = ListGenerator.list_boards(name_filter=self._args.name)
+            pt = self._get_pretty_table(["ID", "Name", "Target", "Test Binary"])
+            for info in sorted(obj['boards'], key=lambda i: i['id']):
+                pt.add_row([
+                            info['id'],
+                            info['name'],
+                            info['target'],
+                            info['binary']
+                            ])
+            print(pt)
+        elif self._args.plugins:
+            obj = ListGenerator.list_plugins()
+            pt = self._get_pretty_table(["Type", "Plugin Name", "Version", "Description"])
+            for group_info in sorted(obj['plugins'], key=lambda i: i['plugin_type']):
+                for plugin_info in sorted(group_info['plugins'], key=lambda i: i['name']):
+                    pt.add_row([
+                                self.PLUGIN_GROUP_NAMES[group_info['plugin_type']],
+                                plugin_info['name'],
+                                plugin_info['version'],
+                                plugin_info['description'],
+                                ])
+            print(pt)
+
+        return 0
+

--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -63,28 +63,237 @@ class PackSubcommandBase(SubcommandBase):
         
         return matches
 
+class PackCleanSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack clean` subcommand."""
+    
+    NAMES = ['clean']
+    HELP = "Delete the pack index and all installed packs."
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+        return [cls.CommonOptions.LOGGING, parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'clean' subcommand."""
+        cache = self._get_cache()
+        
+        LOG.info("Removing all pack data...")
+        cache.cache_clean()
+        print()
+        return 0
+
+class PackUpdateSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack update` subcommand."""
+    
+    NAMES = ['update']
+    HELP = "Update the pack index."
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        parser.add_argument("-c", "--clean", action='store_true',
+            help="Erase existing pack information before updating.")
+        
+        return [cls.CommonOptions.LOGGING, parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'update' subcommand."""
+        cache = self._get_cache()
+        
+        if self._args.clean:
+            LOG.info("Removing all pack data...")
+            cache.cache_clean()
+        
+        LOG.info("Updating pack index...")
+        cache.cache_descriptors()
+        print()
+        return 0
+
+class PackShowSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack show` subcommand."""
+    
+    NAMES = ['show']
+    HELP = "Show the list of installed packs."
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+        
+        display_options = parser.add_argument_group('display options')
+        display_options.add_argument('-H', '--no-header', action='store_true',
+            help="Don't print a table header.")
+        
+        return [cls.CommonOptions.LOGGING, parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'show' subcommand."""
+        cache = self._get_cache()
+        
+        packs = pack_target.ManagedPacks.get_installed_packs(cache)
+        pt = self._get_pretty_table(["Vendor", "Pack", "Version"])
+        for ref in packs:
+            pt.add_row([
+                        ref.vendor,
+                        ref.pack,
+                        ref.version,
+                        ])
+        print(pt)
+        return 0
+
+class PackFindSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack find` subcommand."""
+    
+    NAMES = ['find']
+    HELP = "Report pack(s) in the index containing matching device part numbers."
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        index_options = parser.add_argument_group("index operations")
+        index_options.add_argument("-c", "--clean", action='store_true',
+            help="Erase existing pack information before updating. Ignored if --update is not specified.")
+        index_options.add_argument("-u", "--update", action='store_true',
+            help="Update the pack index before searching.")
+        
+        display_options = parser.add_argument_group('display options')
+        display_options.add_argument('-H', '--no-header', action='store_true',
+            help="Don't print a table header.")
+        
+        parser.add_argument("patterns", metavar="PATTERN", nargs='+',
+            help="Glob-style pattern for matching a target part number.")
+        
+        return [cls.CommonOptions.LOGGING, parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'find' subcommand."""
+        cache = self._get_cache()
+
+        if self._args.update:
+            if self._args.clean:
+                LOG.info("Removing all pack data...")
+                cache.cache_clean()
+            
+            LOG.info("Updating pack index...")
+            cache.cache_descriptors()
+            print()
+
+        # Look for matching part numbers.
+        matches = self._get_matches(cache)
+        
+        if matches:
+            # Get the list of installed pack targets.
+            installed_targets = pack_target.ManagedPacks.get_installed_targets(cache=cache)
+            installed_target_names = [target.part_number.lower() for target in installed_targets]
+            
+            pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version", "Installed"])
+            for name in sorted(matches):
+                info = cache.index[name]
+                ref, = cache.packs_for_devices([info])
+                pt.add_row([
+                            info['name'],
+                            ref.vendor,
+                            ref.pack,
+                            ref.version,
+                            info['name'].lower() in installed_target_names,
+                            ])
+            print(pt)
+        
+        return 0
+
+class PackInstallSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack install` subcommand."""
+    
+    NAMES = ['install']
+    HELP = "Download and install pack(s) containing matching device part numbers."
+
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        index_options = parser.add_argument_group("index operations")
+        index_options.add_argument("-c", "--clean", action='store_true',
+            help="Erase existing pack information before updating. Ignored if --update is not specified.")
+        index_options.add_argument("-u", "--update", action='store_true',
+            help="Update the pack index before searching.")
+
+        download_options = parser.add_argument_group('download options')
+        download_options.add_argument("-n", "--no-download", action='store_true',
+            help="Just list the pack(s) that would be downloaded, don't actually download anything.")
+        
+        parser.add_argument("patterns", metavar="PATTERN", nargs="+",
+            help="Glob-style pattern for matching a target part number.")
+        
+        return [cls.CommonOptions.LOGGING, parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'find' subcommand."""
+        cache = self._get_cache()
+
+        if self._args.update:
+            if self._args.clean:
+                LOG.info("Removing all pack data...")
+                cache.cache_clean()
+            
+            LOG.info("Updating pack index...")
+            cache.cache_descriptors()
+            print()
+
+        # Look for matching part numbers.
+        matches = self._get_matches(cache)
+        
+        if matches:
+            devices = [cache.index[dev] for dev in matches]
+            packs = cache.packs_for_devices(devices)
+            if not self._args.no_download:
+                print("Downloading packs (press Control-C to cancel):")
+            else:
+                print("Would download packs:")
+            for pack in packs:
+                print("    " + str(pack))
+            if not self._args.no_download:
+                cache.download_pack_list(packs)
+            print()
+
+        return 0
+
 class PackSubcommand(PackSubcommandBase):
     """! @brief `pyocd pack` subcommand."""
     
     NAMES = ['pack']
     HELP = "Manage CMSIS-Packs for target support."
+    SUBCOMMANDS = [
+        PackCleanSubcommand,
+        PackFindSubcommand,
+        PackInstallSubcommand,
+        PackShowSubcommand,
+        PackUpdateSubcommand,
+        ]
     
     @classmethod
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
         pack_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+        cls.add_subcommands(pack_parser)
 
         pack_operations = pack_parser.add_argument_group('pack operations')
         pack_operations.add_argument("-c", "--clean", action='store_true',
-            help="Erase all stored pack information.")
+            help="(Deprecated; use clean subcommand.) Erase all stored pack information.")
         pack_operations.add_argument("-u", "--update", action='store_true',
-            help="Update the pack index.")
+            help="(Deprecated; use update subcommand.) Update the pack index.")
         pack_operations.add_argument("-s", "--show", action='store_true',
-            help="Show the list of installed packs.")
+            help="(Deprecated; use show subcommand.) Show the list of installed packs.")
         pack_operations.add_argument("-f", "--find", dest="find_devices", metavar="GLOB", action='append',
-            help="Report pack(s) in the index containing matching device part numbers.")
+            help="(Deprecated; use find subcommand.) Report pack(s) in the index containing matching device part numbers.")
         pack_operations.add_argument("-i", "--install", dest="install_devices", metavar="GLOB", action='append',
-            help="Download and install pack(s) containing matching device part numbers.")
+            help="(Deprecated; use install subcommand.) Download and install pack(s) containing matching device part numbers.")
 
         pack_options = pack_parser.add_argument_group('pack options')
         pack_options.add_argument("-n", "--no-download", action='store_true',
@@ -96,6 +305,10 @@ class PackSubcommand(PackSubcommandBase):
     
     def invoke(self) -> int:
         """! @brief Handle 'pack' subcommand."""
+
+        if not any([self._args.clean, self._args.update, self._args.show, bool(self._args.find_devices), bool(self._args.install_devices)]):
+            self.parser.print_help()
+            return 0
 
         cache = self._get_cache()
         

--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -1,0 +1,158 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+import re
+import fnmatch
+
+from .base import SubcommandBase
+from ..core import exceptions
+from ..target.pack import pack_target
+
+try:
+    import cmsis_pack_manager
+    CPM_AVAILABLE = True
+except ImportError:
+    CPM_AVAILABLE = False
+
+LOG = logging.getLogger(__name__)
+
+class PackSubcommandBase(SubcommandBase):
+    """! @brief Base class for `pyocd pack` subcommands."""
+    
+    # cmsis_pack_manager.Cache is used in quotes in the return type annotation because it may have
+    # not been imported successfully.
+    def _get_cache(self) -> "cmsis_pack_manager.Cache":
+        """! @brief Handle 'clean' subcommand."""
+        if not CPM_AVAILABLE:
+            raise exceptions.CommandError("'pack' subcommand is not available because cmsis-pack-manager is not installed")
+        
+        verbosity = self._args.verbose - self._args.quiet
+        return cmsis_pack_manager.Cache(verbosity < 0, False)
+
+    def _get_matches(self, cache: "cmsis_pack_manager.Cache") -> set[str]:
+        if not cache.index:
+            LOG.info("No pack index present, downloading now...")
+            cache.cache_descriptors()
+        
+        # Find matching part numbers.
+        matches = set()
+        for pattern in self._args.patterns:
+            # Using fnmatch.fnmatch() was failing to match correctly.
+            pat = re.compile(fnmatch.translate(pattern).rsplit('\\Z')[0], re.IGNORECASE)
+            results = {name for name in cache.index.keys() if pat.search(name)}
+            matches.update(results)
+        
+        if not matches:
+            LOG.warning("No matching devices. Please make sure the pack index is up to date."),
+        
+        return matches
+
+class PackSubcommand(PackSubcommandBase):
+    """! @brief `pyocd pack` subcommand."""
+    
+    NAMES = ['pack']
+    HELP = "Manage CMSIS-Packs for target support."
+    
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        pack_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+
+        pack_operations = pack_parser.add_argument_group('pack operations')
+        pack_operations.add_argument("-c", "--clean", action='store_true',
+            help="Erase all stored pack information.")
+        pack_operations.add_argument("-u", "--update", action='store_true',
+            help="Update the pack index.")
+        pack_operations.add_argument("-s", "--show", action='store_true',
+            help="Show the list of installed packs.")
+        pack_operations.add_argument("-f", "--find", dest="find_devices", metavar="GLOB", action='append',
+            help="Report pack(s) in the index containing matching device part numbers.")
+        pack_operations.add_argument("-i", "--install", dest="install_devices", metavar="GLOB", action='append',
+            help="Download and install pack(s) containing matching device part numbers.")
+
+        pack_options = pack_parser.add_argument_group('pack options')
+        pack_options.add_argument("-n", "--no-download", action='store_true',
+            help="Just list the pack(s) that would be downloaded, don't actually download anything.")
+        pack_options.add_argument('-H', '--no-header', action='store_true',
+            help="Don't print a table header.")
+        
+        return [cls.CommonOptions.LOGGING, pack_parser]
+    
+    def invoke(self) -> int:
+        """! @brief Handle 'pack' subcommand."""
+
+        cache = self._get_cache()
+        
+        if self._args.clean:
+            LOG.info("Removing all pack data...")
+            cache.cache_clean()
+        
+        if self._args.update:
+            LOG.info("Updating pack index...")
+            cache.cache_descriptors()
+            print()
+        
+        if self._args.show:
+            packs = pack_target.ManagedPacks.get_installed_packs(cache)
+            pt = self._get_pretty_table(["Vendor", "Pack", "Version"])
+            for ref in packs:
+                pt.add_row([
+                            ref.vendor,
+                            ref.pack,
+                            ref.version,
+                            ])
+            print(pt)
+
+        if self._args.find_devices or self._args.install_devices:
+            self._args.patterns = self._args.find_devices or self._args.install_devices
+            
+            matches = self._get_matches(cache)
+            
+            if self._args.find_devices:
+                # Get the list of installed pack targets.
+                installed_targets = pack_target.ManagedPacks.get_installed_targets(cache=cache)
+                installed_target_names = [target.part_number.lower() for target in installed_targets]
+                
+                pt = self._get_pretty_table(["Part", "Vendor", "Pack", "Version", "Installed"])
+                for name in sorted(matches):
+                    info = cache.index[name]
+                    ref, = cache.packs_for_devices([info])
+                    pt.add_row([
+                                info['name'],
+                                ref.vendor,
+                                ref.pack,
+                                ref.version,
+                                info['name'].lower() in installed_target_names,
+                                ])
+                print(pt)
+            elif self._args.install_devices:
+                devices = [cache.index[dev] for dev in matches]
+                packs = cache.packs_for_devices(devices)
+                if not self._args.no_download:
+                    print("Downloading packs (press Control-C to cancel):")
+                else:
+                    print("Would download packs:")
+                for pack in packs:
+                    print("    " + str(pack))
+                if not self._args.no_download:
+                    cache.download_pack_list(packs)
+                print()
+
+        return 0
+

--- a/pyocd/subcommands/reset_cmd.py
+++ b/pyocd/subcommands/reset_cmd.py
@@ -1,0 +1,90 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+import sys
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..core.target import Target
+from ..utility.cmdline import (
+    convert_session_options,
+    convert_reset_type,
+    )
+
+LOG = logging.getLogger(__name__)
+
+class ResetSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['reset']
+    HELP = "Reset a device."
+    DEFAULT_LOG_LEVEL = logging.WARNING
+    
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        reset_parser = argparse.ArgumentParser(description='reset', add_help=False)
+
+        reset_options = reset_parser.add_argument_group("reset options")
+        reset_options.add_argument("-m", "--method", default='hw', dest='reset_type', metavar="METHOD",
+            help="Reset method to use ('hw', 'sw', and others). Default is 'hw'.")
+        
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, reset_parser]
+    
+    def invoke(self) -> None:
+        """! @brief Handle 'reset' subcommand."""
+        # Verify selected reset type.
+        try:
+            the_reset_type = convert_reset_type(self._args.reset_type)
+        except ValueError:
+            LOG.error("Invalid reset method: %s", self._args.reset_type)
+            return
+        
+        session = ConnectHelper.session_with_chosen_probe(
+                            project_dir=self._args.project_dir,
+                            config_file=self._args.config,
+                            user_script=self._args.script,
+                            no_config=self._args.no_config,
+                            pack=self._args.pack,
+                            unique_id=self._args.unique_id,
+                            target_override=self._args.target_override,
+                            frequency=self._args.frequency,
+                            blocking=(not self._args.no_wait),
+                            connect_mode=self._args.connect_mode,
+                            options=convert_session_options(self._args.options))
+        if session is None:
+            LOG.error("No device available to reset")
+            sys.exit(1)
+        try:
+            # Handle hw reset specially using the probe, so we don't need a valid connection
+            # and can skip discovery.
+            is_hw_reset = the_reset_type == Target.ResetType.HW
+            
+            # Only init the board if performing a sw reset.
+            session.open(init_board=(not is_hw_reset))
+            
+            LOG.info("Performing '%s' reset...", self._args.reset_type)
+            if is_hw_reset:
+                session.probe.reset()
+            else:
+                session.target.reset(reset_type=the_reset_type)
+            LOG.info("Done.")
+        finally:
+            session.close()
+

--- a/pyocd/subcommands/server_cmd.py
+++ b/pyocd/subcommands/server_cmd.py
@@ -1,0 +1,102 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from typing import List
+import logging
+from time import sleep
+
+from .base import SubcommandBase
+from ..core.helpers import ConnectHelper
+from ..core.session import Session
+from ..utility.cmdline import convert_session_options
+from ..probe.tcp_probe_server import DebugProbeServer
+
+LOG = logging.getLogger(__name__)
+
+class ServerSubcommand(SubcommandBase):
+    """! @brief Base class for pyocd command line subcommand."""
+    
+    NAMES = ['server']
+    HELP = "Run debug probe server."
+    
+    @classmethod
+    def get_args(cls) -> List[argparse.ArgumentParser]:
+        """! @brief Add this subcommand to the subparsers object."""
+        server_parser = argparse.ArgumentParser(description='server', add_help=False)
+
+        server_config_options = server_parser.add_argument_group('configuration')
+        server_config_options.add_argument('-j', '--project', '--dir', metavar="PATH", dest="project_dir",
+            help="Set the project directory. Defaults to the directory where pyocd was run.")
+        server_config_options.add_argument('--config', metavar="PATH",
+            help="Specify YAML configuration file. Default is pyocd.yaml or pyocd.yml.")
+        server_config_options.add_argument("--no-config", action="store_true", default=None,
+            help="Do not use a configuration file.")
+        server_config_options.add_argument('-O', action='append', dest='options', metavar="OPTION=VALUE",
+            help="Set named option.")
+        server_config_options.add_argument("-da", "--daparg", dest="daparg", nargs='+',
+            help="Send setting to DAPAccess layer.")
+
+        server_options = server_parser.add_argument_group('probe server')
+        server_options.add_argument("-p", "--port", dest="port_number", type=int, default=None,
+            help="Set the server's port number (default 5555).")
+        server_options.add_argument("--allow-remote", dest="serve_local_only", default=None, action="store_false",
+            help="Allow remote TCP/IP connections (default is no).")
+        server_options.add_argument("--local-only", default=False, action="store_true",
+            help="Ignored and deprecated. Server is local only by default. Use --alow-remote to enable remote "
+                 "connections.")
+        server_options.add_argument("-u", "--uid", "--probe", dest="unique_id",
+            help="Serve the specified probe. Optionally prefixed with '<probe-type>:' where <probe-type> is the "
+                 "name of a probe plugin.")
+        server_options.add_argument("-W", "--no-wait", action="store_true",
+            help="Do not wait for a probe to be connected if none are available.")
+        
+        return [cls.CommonOptions.LOGGING, server_parser]
+    
+    def invoke(self) -> None:
+        """! @brief Handle 'server' subcommand."""
+        # Create a session to load config, particularly logging config. Even though we do have a
+        # probe, we don't set it in the session because we don't want the board, target, etc objects
+        # to be created.
+        session_options = convert_session_options(self._args.options)
+        session = Session(probe=None,
+                serve_local_only=self._args.serve_local_only,
+                options=session_options)
+        
+        # The ultimate intent is to serve all available probes by default. For now we just serve
+        # a single probe.
+        probe = ConnectHelper.choose_probe(unique_id=self._args.unique_id)
+        if probe is None:
+            return
+        
+        # Assign the session to the probe.
+        probe.session = session
+        
+        # Create the server instance.
+        server = DebugProbeServer(session, probe, self._args.port_number, self._args.serve_local_only)
+        session.probeserver = server
+        LOG.debug("Starting debug probe server")
+        server.start()
+        
+        # Loop as long as the probe is running. The server thread is a daemon, so the main thread
+        # must continue to exist.
+        try:
+            while server.is_running:
+                sleep(0.1)
+        except (KeyboardInterrupt, Exception):
+            server.stop()
+            raise
+

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +18,7 @@
 import logging
 import shlex
 import six
+from typing import (Any, Dict, Iterable, List, Sequence, Union, Optional, Tuple)
 
 from ..core.target import Target
 from ..core.options import OPTIONS_INFO
@@ -24,7 +26,7 @@ from ..utility.compatibility import to_str_safe
 
 LOG = logging.getLogger(__name__)
 
-def split_command_line(cmd_line):
+def split_command_line(cmd_line: Union[str, List[str]]) -> List[str]:
     """! @brief Split command line by whitespace, supporting quoted strings."""
     result = []
     if isinstance(cmd_line, six.string_types):
@@ -50,7 +52,7 @@ VECTOR_CATCH_CHAR_MAP = {
         'n': Target.VectorCatch.NONE,
     }
 
-def convert_vector_catch(value):
+def convert_vector_catch(value: str) -> int:
     """! @brief Convert a vector catch string to a mask.
     
     @exception ValueError Raised if an invalid vector catch character is encountered.
@@ -71,7 +73,7 @@ def convert_vector_catch(value):
         # Reraise an error with a more helpful message.
         raise ValueError("invalid vector catch option '{}'".format(e.args[0]))
 
-def convert_session_options(option_list):
+def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
     """! @brief Convert a list of session option settings to a dictionary."""
     options = {}
     if option_list is not None:
@@ -133,7 +135,7 @@ RESET_TYPE_MAP = {
         'emulated': Target.ResetType.SW_EMULATED,
     }
 
-def convert_reset_type(value):
+def convert_reset_type(value: str) -> Target.ResetType:
     """! @brief Convert a reset_type session option value to the Target.ResetType enum.
     @param value The value of the reset_type session option.
     @exception ValueError Raised if an unknown reset_type value is passed.
@@ -143,7 +145,7 @@ def convert_reset_type(value):
         raise ValueError("unexpected value for reset_type option ('%s')" % value)
     return RESET_TYPE_MAP[value]
 
-def convert_frequency(value):
+def convert_frequency(value: str) -> int:
     """! @brief Applies scale suffix to frequency value string.
     @param value String with a float and possible 'k' or 'm' suffix (case-insensitive). "Hz" may
         also follow. No space is allowed between the float and suffix. Leading and trailing
@@ -155,33 +157,33 @@ def convert_frequency(value):
         value = value[:-2]
     suffix = value[-1]
     if suffix in ('k', 'm'):
-        value = float(value[:-1])
+        fvalue = float(value[:-1])
         if suffix == 'k':
-            value *= 1000
+            fvalue *= 1000
         elif suffix == 'm':
-            value *= 1000000
-        return int(value)
+            fvalue *= 1000000
+        return int(fvalue)
     else:
         return int(float(value))
 
-class UniquePrefixMatcher(object):
+class UniquePrefixMatcher():
     """! @brief Manages detection of shortest unique prefix match of a set of strings."""
     
-    def __init__(self, items=None):
+    def __init__(self, items: Optional[Sequence[str]] = None):
         """! @brief Constructor.
         @param self This object.
         @param items Optional sequence of strings.
         """
         self._items = set(items) if (items is not None) else set()
     
-    def add_items(self, items):
+    def add_items(self, items: Sequence[str]) -> None:
         """! @brief Add some items to be matched.
         @param self This object.
         @param items Sequence of strings.
         """
         self._items.update(items)
     
-    def find_all(self, prefix):
+    def find_all(self, prefix: str) -> Tuple[str, ...]:
         """! @brief Return all items matching the given prefix.
         @param self This object.
         @param prefix String that is compared as a prefix against the items passed to the constructor.
@@ -196,7 +198,7 @@ class UniquePrefixMatcher(object):
             return (prefix,)
         return tuple(i for i in self._items if i.startswith(prefix))
     
-    def find_one(self, prefix):
+    def find_one(self, prefix: str) -> Optional[str]:
         """! @brief Return the item matching the given prefix, or None.
         @param self This object.
         @param prefix String that is compared as a prefix against the items passed to the constructor.


### PR DESCRIPTION
The bulk of the PR refactors all pyocd command-line subcommands into independent classes in modules under `pyocd.subcommands`.

In addition to simple refactoring, this work opens up some new possibilities. Subcommands can now themselves have subcommands (similar to many modern tools such as docker). As an exploration of this feature, the `pyocd pack` subcommand has been reworked to have subcommands for the various operations, e.g. `pyocd pack update` or `pyocd pack install nrf5340`. The old arguments still work, but have been marked as deprecated.