### PR TITLE
Fix type annotation in pack subcommand.

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -55,6 +55,10 @@ jobs:
       run: |
         pytest --junitxml=test-results-${{ matrix.python-version }}.xml --cov=pyocd --cov-report=xml
 
+    - name: Test importing all modules
+      run: |
+        python test/import_all.py
+
     - name: Test build
       run: |
         python setup.py sdist bdist_wheel

--- a/pyocd/probe/stlink/detect/windows.py
+++ b/pyocd/probe/stlink/detect/windows.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2019, Arm Limited and affiliates.
+# Copyright (c) 2021 Chris Reed.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,11 +24,17 @@ from .base import StlinkDetectBase
 
 LOG = logging.getLogger(__name__)
 
-if sys.version_info[0] < 3:
-    import _winreg as winreg
-else:
-    import winreg
-
+try:
+    if sys.version_info[0] < 3:
+        import _winreg as winreg
+    else:
+        import winreg
+except ImportError:
+    # Only allow the exception to propagate on Windows. This module should never be imported
+    # in the first place on other OSes, allowing imports is simply for easier testing.
+    import platform
+    if platform.system() == "Windows":
+        raise
 
 MAX_COMPOSITE_DEVICE_SUBDEVICES = 5
 MBED_STORAGE_DEVICE_VENDOR_STRINGS = [

--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 import argparse
-from typing import List
+from typing import (List, Set)
 import logging
 import re
 import fnmatch
@@ -45,7 +45,7 @@ class PackSubcommandBase(SubcommandBase):
         verbosity = self._args.verbose - self._args.quiet
         return cmsis_pack_manager.Cache(verbosity < 0, False)
 
-    def _get_matches(self, cache: "cmsis_pack_manager.Cache") -> set[str]:
+    def _get_matches(self, cache: "cmsis_pack_manager.Cache") -> Set[str]:
         if not cache.index:
             LOG.info("No pack index present, downloading now...")
             cache.cache_descriptors()

--- a/test/import_all.py
+++ b/test/import_all.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from importlib import import_module
+
+# Import pyocd to get its filesystem path.
+import pyocd
+
+# Total count of modules imported.
+import_count = 0
+
+def process_dir(dotted_path: str, dir_path: Path) -> None:
+    global import_count
+    for entry in sorted(dir_path.iterdir(), key=lambda v: v.name):
+        is_subpackage = (entry.is_dir() and (entry / "__init__.py").exists())
+        is_module = entry.suffix == ".py"
+        
+        if not (is_subpackage or is_module):
+            continue
+        
+        module_path = dotted_path + '.' + entry.stem
+        print(f"Importing: {module_path}")
+        import_module(module_path)
+        import_count += 1
+        
+        # Recursive into valid sub-packages.
+        if is_subpackage:
+            process_dir(module_path, entry)
+
+def main() -> None:
+    pyocd_path = Path(pyocd.__file__).parent.resolve()
+    print(f"pyocd package path: {pyocd_path}")
+    process_dir("pyocd", pyocd_path)
+    print(f"Imported {import_count} modules successfully")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The new pack subcommand implementation used `set[str]` as a return type annotation, but this usage of the builtin `set` class is only supported in Python 3.9. Updated to use `typing.Set` instead. Fixes #1138.

Also added `test/import_all.py` that walks over the entire pyocd source tree and imports each module and package. This script is run in the GitHub Actions workflow, to detect any issues such as this in the future.

One additional change was made to `pyocd/probe/stlink/detect/windows.py`. Because `import_all.py` unconditionally imports all modules regardless of the OS, this modules had to be modified to only raise `ImportError` if on Windows.