### PR TITLE
Added pyusb as USB backend to BSD platforms.

### DIFF
--- a/pyocd/probe/pydapaccess/interface/__init__.py
+++ b/pyocd/probe/pydapaccess/interface/__init__.py
@@ -58,6 +58,8 @@ if not USB_BACKEND:
     # Default to pyUSB for Linux.
     elif system == "Linux":
         USB_BACKEND = "pyusb"
+    elif "BSD" in system:
+        USB_BACKEND = "pyusb"
     else:
         raise DAPAccessIntf.DeviceError("No USB backend found")
 


### PR DESCRIPTION
This fixes "No USB backend found" on BSD platforms supporting LibUSB+PyUSB.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>