### PR TITLE
Fallback to pyusb as the default backend.

### DIFF
--- a/pyocd/probe/pydapaccess/interface/__init__.py
+++ b/pyocd/probe/pydapaccess/interface/__init__.py
@@ -59,6 +59,7 @@ if not USB_BACKEND:
     elif system == "Linux":
         USB_BACKEND = "pyusb"
     else:
-        raise DAPAccessIntf.DeviceError("No USB backend found")
+        #raise DAPAccessIntf.DeviceError("No USB backend found")
+        USB_BACKEND = "pyusb"
 
 USB_BACKEND_V2 = "pyusb_v2"


### PR DESCRIPTION
This will try to use `pyusb` as the default USB Interface backend.
So far only selected list of OS has this parameter set.
This prevents pyOCD working on a platforms that are not on the list.
`pyusb` may be used as "fallback" in this case as most versatile solution.
If `pyusb` is not available or fails to work we will know that explicitly.

Signed-off-by: Tomasz 'CeDeROM' CEDRO <tomek@cedro.info>