### PR TITLE
Cleanup more LGTM warnings

### DIFF
--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -98,7 +98,7 @@ class Board(GraphNode):
                 resume = self.session.options.get('resume_on_disconnect')
                 self.target.disconnect(resume)
                 self._inited = False
-            except:
+            except exceptions.Error:
                 LOG.error("link exception during target disconnect:", exc_info=self._session.log_tracebacks)
 
     @property

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from ..core import exceptions
 from ..target import TARGET
 from ..target.pack import pack_target
 from ..utility.graph import GraphNode
-import logging
-import six
 
 LOG = logging.getLogger(__name__)
 
@@ -60,11 +61,11 @@ class Board(GraphNode):
         try:
             self.target = TARGET[self._target_type](session)
         except KeyError as exc:
-            six.raise_from(exceptions.TargetSupportError(
-                "Target type '%s' not recognized. Use 'pyocd list --targets' to see currently "
+            raise exceptions.TargetSupportError(
+                f"Target type {self._target_type} not recognized. Use 'pyocd list --targets' to see currently "
                 "available target types. "
                 "See <https://github.com/pyocd/pyOCD/blob/master/docs/target_support.md> "
-                "for how to install additional target support." % self._target_type), exc)
+                "for how to install additional target support.") from exc
         
         # Tell the user what target type is selected.
         LOG.info("Target type is %s", self._target_type)

--- a/pyocd/commands/base.py
+++ b/pyocd/commands/base.py
@@ -17,7 +17,6 @@
 
 import logging
 import textwrap
-import six
 
 from ..core import exceptions
 from ..utility import conversion
@@ -55,8 +54,7 @@ class CommandMeta(type):
             ALL_COMMANDS.setdefault(info['group'], set()).add(new_type)
         return new_type
 
-@six.add_metaclass(CommandMeta)
-class CommandBase(object):
+class CommandBase(metaclass=CommandMeta):
     """! @brief Base class for a command.
     
     Each command class must have an `INFO` attribute with the following keys:
@@ -164,7 +162,7 @@ class CommandBase(object):
 
             return value
         except ValueError as err:
-            raise six.raise_from(exceptions.CommandError("invalid argument '{}'".format(arg)), None)
+            raise exceptions.CommandError("invalid argument '{}'".format(arg)) from None
 
     @classmethod
     def format_help(cls, context, max_width=72):

--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import logging
 import os
 import traceback

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -162,7 +162,7 @@ class CommandExecutionContext(object):
         if self._output is None:
             return
         end = kwargs.pop('end', "\n")
-        if not isinstance(message, six.string_types):
+        if not isinstance(message, str):
             message = str(message)
         self._output.write(message + end)
     
@@ -175,7 +175,7 @@ class CommandExecutionContext(object):
         @param self This object.
         @param fmt Format string using printf-style "%" formatters.
         """
-        assert isinstance(fmt, six.string_types)
+        assert isinstance(fmt, str)
         message = fmt % args
         self.write(message, **kwargs)
     
@@ -188,7 +188,7 @@ class CommandExecutionContext(object):
         @param self This object.
         @param fmt Format string using the format() mini-language.
         """
-        assert isinstance(fmt, six.string_types)
+        assert isinstance(fmt, str)
         message = fmt.format(*args, **kwargs)
         self.write(message, **kwargs)
 
@@ -394,7 +394,7 @@ class CommandExecutionContext(object):
             
             result = eval(invocation.cmd, globals(), self._python_namespace)
             if result is not None:
-                if isinstance(result, six.integer_types):
+                if isinstance(result, str):
                     self.writei("0x%08x (%d)", result, result)
                 else:
                     w, h = get_terminal_size()
@@ -411,4 +411,4 @@ class CommandExecutionContext(object):
             output = subprocess.check_output(invocation.cmd, stderr=subprocess.STDOUT, shell=True)
             self.write(six.ensure_str(output), end='')
         except subprocess.CalledProcessError as err:
-            six.raise_from(exceptions.CommandError(str(err)), err)
+            raise exceptions.CommandError(str(err)) from err

--- a/pyocd/commands/repl.py
+++ b/pyocd/commands/repl.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +18,6 @@
 from __future__ import print_function
 import logging
 import os
-import six
 import traceback
 import atexit
 
@@ -75,7 +75,7 @@ class PyocdRepl(object):
         try:
             while True:
                 try:
-                    line = six.moves.input(self.PROMPT)
+                    line = input(self.PROMPT)
                     self.run_one_command(line)
                 except KeyboardInterrupt:
                     print()

--- a/pyocd/commands/repl.py
+++ b/pyocd/commands/repl.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import logging
 import os
 import traceback

--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -178,7 +179,7 @@ class FaultValue(ValueBase):
         DFSR = 0xe000ed30
         MMFAR = 0xe000ed34
         BFAR = 0xe000ed38
-        AFSR = 0xe000ed3c
+#         AFSR = 0xe000ed3c
         
         MMFSR_fields = [
                 ('IACCVIOL', 0),

--- a/pyocd/core/core_registers.py
+++ b/pyocd/core/core_registers.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
 from copy import copy
 
 from ..utility import conversion
@@ -59,13 +59,13 @@ class CoreRegisterInfo(object):
         @exception KeyError
         """
         try:
-            if isinstance(reg, six.string_types):
+            if isinstance(reg, str):
                 reg = reg.lower()
                 return cls._NAME_MAP[reg]
             else:
                 return cls._INDEX_MAP[reg]
         except KeyError as err:
-            six.raise_from(KeyError('unknown core register %s' % reg), err)
+            raise KeyError('unknown core register %s' % reg) from err
 
     def __init__(self, name, index, bitsize, reg_type, reg_group, reg_num=None, feature=None):
         """! @brief Constructor."""

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -19,7 +19,6 @@ from .session import Session
 from ..probe.aggregator import DebugProbeAggregator
 from time import sleep
 import colorama
-import six
 import prettytable
 
 # Init colorama here since this is currently the only module that uses it.
@@ -168,7 +167,7 @@ class ConnectHelper(object):
             while True:
                 print(colorama.Style.RESET_ALL)
                 print("Enter the number of the debug probe or 'q' to quit", end='')
-                line = six.moves.input("> ")
+                line = input("> ")
                 valid = False
                 if line.strip().lower() == 'q':
                     return None

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from .session import Session
-from ..probe.aggregator import DebugProbeAggregator
 from time import sleep
 import colorama
 import prettytable
+
+from .session import Session
+from ..probe.aggregator import DebugProbeAggregator
 
 # Init colorama here since this is currently the only module that uses it.
 colorama.init()

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
-import yaml
-import os
 from functools import partial
 from collections import namedtuple
 

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -128,8 +128,7 @@ class OptionsManager(Notifier):
         for layer in self._layers:
             if key in layer:
                 return layer[key]
-        else:
-            return self.get_default(key)
+        return self.get_default(key)
     
     def set(self, key, value):
         """! @brief Set an option in the current highest priority layer."""

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -474,17 +474,17 @@ class Session(Notifier):
             try:
                 self.board.uninit()
                 self._inited = False
-            except:
+            except exceptions.Error:
                 LOG.error("exception during board uninit:", exc_info=self.log_tracebacks)
         
         if self._probe.is_open:
             try:
                 self._probe.disconnect()
-            except:
+            except exceptions.Error:
                 LOG.error("probe exception during disconnect:", exc_info=self.log_tracebacks)
             try:
                 self._probe.close()
-            except:
+            except exceptions.Error:
                 LOG.error("probe exception during close:", exc_info=self.log_tracebacks)
 
 class UserScriptFunctionProxy(object):

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) Chris Reed
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,6 @@
 
 import logging
 import logging.config
-import six
 import yaml
 import os
 import weakref
@@ -240,7 +239,7 @@ class Session(Notifier):
         config = self.options.get('logging')
         
         # Allow logging setting to refer to another file.
-        if isinstance(config, six.string_types):
+        if isinstance(config, str):
             loggingConfigPath = self.find_user_file(None, [config])
             
             if loggingConfigPath is not None:
@@ -423,7 +422,7 @@ class Session(Notifier):
                 # functions or classes. A single namespace is shared for both globals and
                 # locals so that script-level definitions are available within the
                 # script functions.
-                six.exec_(scriptCode, self._user_script_namespace, self._user_script_namespace)
+                exec(scriptCode, self._user_script_namespace, self._user_script_namespace)
                 
                 # Create the proxy for the user script. It becomes the delegate unless
                 # another delegate was already set.

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 from enum import Enum
-import copy
 
 from .memory_interface import MemoryInterface
 from .memory_map import MemoryMap

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -947,7 +947,6 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         num = self.dp.next_access_number
         TRACE.debug("read_mem:%06d (ap=0x%x; addr=0x%08x, size=%d) {",
             num, self.address.nominal_address, addr, transfer_size)
-        res = None
         try:
             self.write_reg(self._reg_offset + MEM_AP_CSW, self._csw | TRANSFER_SIZE[transfer_size])
             self.write_reg(self._reg_offset + MEM_AP_TAR, addr)
@@ -969,6 +968,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             raise
 
         def read_mem_cb():
+            res = None
             try:
                 res = result_cb()
                 if transfer_size == 8:

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,10 +54,6 @@ class CoreSightComponent(GraphNode):
     @address.setter
     def address(self, newAddr):
         self._address = newAddr
-    
-    @property
-    def session(self):
-        return self.ap.dp.target.session
 
 class CoreSightCoreComponent(CoreSightComponent):
     """! @brief CoreSight component for a CPU core.

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -16,18 +16,17 @@
 # limitations under the License.
 
 import logging
-from time import (time, sleep)
+from time import sleep
 
 from ..core.target import Target
 from ..core import exceptions
 from ..core.core_registers import CoreRegistersIndex
 from ..core.memory_map import (MemoryMap, RamRegion, DeviceRegion)
-from ..utility import (cmdline, conversion, timeout)
-from ..utility.notification import Notification
+from ..utility import (cmdline, timeout)
 from .component import CoreSightCoreComponent
 from .fpb import FPB
 from .dwt import DWT
-from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension )
+from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
 from .cortex_m_core_registers import (
     CortexMCoreRegisterInfo,
     CoreRegisterGroups,

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
 from copy import copy
 
 from ..core.core_registers import CoreRegisterInfo
@@ -50,11 +50,11 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
         @return Internal register number.
         @exception KeyError
         """
-        if isinstance(reg, six.string_types):
+        if isinstance(reg, str):
             try:
                 reg = cls._NAME_MAP[reg.lower()].index
             except KeyError as err:
-                six.raise_from(KeyError('unknown core register name %s' % reg), err)
+                raise KeyError('unknown core register name %s' % reg) from err
         return reg
 
     @property

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -16,10 +16,8 @@
 # limitations under the License.
 
 import logging
-from copy import copy
 
 from ..core.core_registers import CoreRegisterInfo
-from ..utility import conversion
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/coresight/cortex_m_v8m.py
+++ b/pyocd/coresight/cortex_m_v8m.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,6 @@ import logging
 
 from .cortex_m import CortexM
 from .core_ids import (CORE_TYPE_NAME, CoreArchitecture, CortexMExtension)
-from ..core import exceptions
 from ..core.target import Target
 from .cortex_m_core_registers import CoreRegisterGroups
 

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -23,7 +23,7 @@ from ..core import (exceptions, memory_interface)
 from ..core.target import Target
 from ..probe.debug_probe import DebugProbe
 from ..probe.swj import SWJSequenceSender
-from .ap import (MEM_AP_CSW, APSEL, APBANKSEL, APSEL_APBANKSEL, APREG_MASK, AccessPort)
+from .ap import APSEL_APBANKSEL
 from ..utility.sequencer import CallSequence
 from ..utility.timeout import Timeout
 

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -688,6 +688,7 @@ class DebugPort(object):
     def write_ap(self, addr, data):
         assert isinstance(addr, int)
         num = self.next_access_number
+        did_lock = False
 
         try:
             did_lock = self._select_ap(addr)
@@ -705,6 +706,7 @@ class DebugPort(object):
     def read_ap(self, addr, now=True):
         assert isinstance(addr, int)
         num = self.next_access_number
+        did_lock = False
 
         try:
             did_lock = self._select_ap(addr)
@@ -742,7 +744,8 @@ class DebugPort(object):
     def write_ap_multiple(self, addr, values):
         assert isinstance(addr, int)
         num = self.next_access_number
-        
+        did_lock = False
+
         try:
             did_lock = self._select_ap(addr)
             TRACE.debug("write_ap_multiple:%06d (addr=0x%08x) = (%i values)", num, addr, len(values))
@@ -757,6 +760,7 @@ class DebugPort(object):
     def read_ap_multiple(self, addr, count=1, now=True):
         assert isinstance(addr, int)
         num = self.next_access_number
+        did_lock = False
         
         try:
             did_lock = self._select_ap(addr)

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -444,8 +444,6 @@ class DebugPort(object):
                     break
             else:
                 return False
-
-        self.write_reg(DP_CTRL_STAT, CSYSPWRUPREQ | CDBGPWRUPREQ | MASKLANE | TRNNORMAL)
         
         return True
 

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
 from collections import namedtuple
 from enum import Enum
 
@@ -686,7 +686,7 @@ class DebugPort(object):
         return True
 
     def write_ap(self, addr, data):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         num = self.next_access_number
 
         try:
@@ -703,7 +703,7 @@ class DebugPort(object):
         return True
 
     def read_ap(self, addr, now=True):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         num = self.next_access_number
 
         try:
@@ -740,7 +740,7 @@ class DebugPort(object):
             return read_ap_cb
 
     def write_ap_multiple(self, addr, values):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         num = self.next_access_number
         
         try:
@@ -755,7 +755,7 @@ class DebugPort(object):
                 self.unlock()
 
     def read_ap_multiple(self, addr, count=1, now=True):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         num = self.next_access_number
         
         try:

--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2017-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..core.target import Target
 from ..core import exceptions
 from .component import CoreSightComponent
 

--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -359,7 +359,7 @@ class Class1ROMTable(ROMTable):
                 except exceptions.TransferError as err:
                     LOG.error("Error attempting to probe CoreSight component referenced by "
                             "ROM table entry #%d: %s", entryNumber, err,
-                            exc_info=self.session.get_current().log_tracebacks)
+                            exc_info=self.ap.dp.session.get_current().log_tracebacks)
 
                 entryAddress += 4
                 entryNumber += 1
@@ -548,7 +548,7 @@ class Class9ROMTable(ROMTable):
                     except exceptions.TransferError as err:
                         LOG.error("Error attempting to probe CoreSight component referenced by "
                                 "ROM table entry #%d: %s", entryNumber, err,
-                                exc_info=self.session.get_current().log_tracebacks)
+                                exc_info=self.ap.dp.session.get_current().log_tracebacks)
 
                 entryAddress += 4 * entrySizeMultiplier
                 entryNumber += 1

--- a/pyocd/coresight/sdc600.py
+++ b/pyocd/coresight/sdc600.py
@@ -401,7 +401,7 @@ class SDC600(CoreSightComponent):
         """
         with Timeout(timeout) as to_:
             if phase == self.LinkPhase.PHASE1:
-                assert self._current_link_phase == None
+                assert self._current_link_phase is None
 
                 # Close link phase 1 first, to put it in a known state.
                 self.close_link(self.LinkPhase.PHASE1)

--- a/pyocd/coresight/sdc600.py
+++ b/pyocd/coresight/sdc600.py
@@ -16,13 +16,11 @@
 # limitations under the License.
 
 import logging
-from time import sleep
 from enum import Enum
 
 from .component import CoreSightComponent
 from ..core import exceptions
 from ..utility.timeout import Timeout
-from ..utility.hex import dump_hex_data
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/debug/breakpoints/manager.py
+++ b/pyocd/debug/breakpoints/manager.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -127,7 +128,7 @@ class BreakpointManager(object):
                 free_hw_bp_count += 1
         for bp in added:
             likely_bp_type = self._select_breakpoint_type(bp, False)
-            if bp.type == Target.BreakpointType.HW:
+            if likely_bp_type == Target.BreakpointType.HW:
                 free_hw_bp_count -= 1
         
         return free_hw_bp_count > self.MIN_HW_BREAKPOINTS

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +16,8 @@
 # limitations under the License.
 
 from ..core.memory_interface import MemoryInterface
-from pyocd.coresight.component import CoreSightCoreComponent
+from ..coresight.component import CoreSightCoreComponent
 from ..coresight.cortex_m_core_registers import CortexMCoreRegisterInfo
-from ..utility import conversion
 
 class DebugContext(MemoryInterface):
     """! @brief Viewport for inspecting the system being debugged.

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2017 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import os
 from elftools.elf.elffile import ELFFile
 from elftools.dwarf.constants import DW_LNE_set_address

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -85,7 +85,8 @@ class ElfSymbolDecoder(object):
             self.symbol_tree.addi(sym_value, sym_value+sym_size, syminfo)
 
     def _process_arm_type_symbols(self):
-        type_symbols = self._get_arm_type_symbol_iter()
+        pass
+#         type_symbols = self._get_arm_type_symbol_iter()
 #         map(print, imap(lambda x:"%s : 0x%x" % (x.name, x['st_value']), type_symbols))
 
     def _get_arm_type_symbol_iter(self):

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2017 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +19,6 @@ from ...core.memory_map import (MemoryRange, MemoryMap)
 from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import SH_FLAGS
-import six
 
 class ELFSection(MemoryRange):
     """! @brief Memory range for a section of an ELF file.
@@ -109,7 +109,7 @@ class ELFBinaryFile(object):
     
     def __init__(self, elf, memory_map=None):
         self._owns_file = False
-        if isinstance(elf, six.string_types):
+        if isinstance(elf, str):
             self._file = open(elf, 'rb')
             self._owns_file = True
         else:

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -14,11 +14,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
-from ...core.memory_map import (MemoryRange, MemoryMap)
-from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
+
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import SH_FLAGS
+
+from ...core.memory_map import (MemoryRange, MemoryMap)
+from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
 
 class ELFSection(MemoryRange):
     """! @brief Memory range for a section of an ELF file.

--- a/pyocd/debug/elf/elf_reader.py
+++ b/pyocd/debug/elf/elf_reader.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from intervaltree import IntervalTree
+
 from ..context import DebugContext
 from ...utility import conversion
-import logging
-from intervaltree import (Interval, IntervalTree)
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/debug/svd/model.py
+++ b/pyocd/debug/svd/model.py
@@ -1,5 +1,6 @@
 #
 # Copyright 2015 Paul Osborne <osbpau@gmail.com>
+# Copyright (c) 2021 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +15,6 @@
 # limitations under the License.
 #
 import json
-import six
 
 # Sentinel value for lookup where None might be a valid value
 NOT_PRESENT = object()
@@ -52,7 +52,7 @@ class SVDJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, SVDElement):
             eldict = {}
-            for k, v in six.iteritems(obj.__dict__):
+            for k, v in obj.__dict__.items():
                 if k in TO_DICT_SKIP_KEYS:
                     continue
                 if k.startswith("_"):
@@ -202,7 +202,7 @@ class SVDRegisterArray(SVDElement):
 
     @property
     def registers(self):
-        for i in six.moves.range(self.dim):
+        for i in range(self.dim):
             reg = SVDRegister(
                 name=self.name % self.dim_indices[i],
                 fields=self._fields,
@@ -419,7 +419,7 @@ class SVDRegisterClusterArray(SVDElement):
 
     @property
     def registers(self):
-        for i in six.moves.range(self.dim):
+        for i in range(self.dim):
             for reg in self._register:
                 yield self.updated_register(reg, self, i)
             for cluster in self._cluster:
@@ -453,7 +453,7 @@ class SVDInterrupt(SVDElement):
     def __init__(self, name, value, description):
         SVDElement.__init__(self)
         self.name = name
-        self.value = _check_type(value, six.integer_types)
+        self.value = _check_type(value, int)
         self.description = description
 
 
@@ -553,8 +553,8 @@ class SVDDevice(SVDElement):
         self.version = version
         self.description = description
         self.cpu = cpu
-        self.address_unit_bits = _check_type(address_unit_bits, six.integer_types)
-        self.width = _check_type(width, six.integer_types)
+        self.address_unit_bits = _check_type(address_unit_bits, int)
+        self.width = _check_type(width, int)
         self.peripherals = peripherals
         self.size = size  # Defines the default bit-width of any register contained in the device (implicit inheritance).
         self.access = access  # Defines the default access rights for all registers.

--- a/pyocd/debug/svd/parser.py
+++ b/pyocd/debug/svd/parser.py
@@ -1,6 +1,7 @@
 #
 # Copyright 2015 Paul Osborne <osbpau@gmail.com>
 # Copyright (c) 2019 Arm Ltd
+# Copyright (c) 2021 Chris Reed
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +16,7 @@
 # limitations under the License.
 #
 from xml.etree import ElementTree as ET
-
-import six
+import re
 
 from .model import SVDDevice
 from .model import SVDPeripheral
@@ -27,7 +27,6 @@ from .model import SVDRegisterCluster, SVDRegisterClusterArray
 from .model import SVDField
 from .model import SVDEnumeratedValue
 from .model import SVDCpu
-import re
 
 
 def _get_text(node, tag, default=None):

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,14 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..core.target import Target
-from ..core.exceptions import (FlashFailure, FlashProgramFailure)
-from ..utility.notification import Notification
-from ..utility.mask import same
 import logging
-from struct import unpack
 from time import time
 from binascii import crc32
+
+from ..core.target import Target
+from ..core.exceptions import (FlashFailure, FlashProgramFailure)
+from ..utility.mask import same
 
 # Number of bytes in a page to read to quickly determine if the page has the same data
 PAGE_ESTIMATE_SIZE = 32

--- a/pyocd/flash/eraser.py
+++ b/pyocd/flash/eraser.py
@@ -19,8 +19,6 @@ import logging
 from enum import Enum
 
 from ..core.memory_map import MemoryType
-from ..core import exceptions
-from ..utility.progress import print_progress
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/flash/eraser.py
+++ b/pyocd/flash/eraser.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,6 @@
 
 import logging
 from enum import Enum
-import six
 
 from ..core.memory_map import MemoryType
 from ..core import exceptions
@@ -152,7 +152,7 @@ class FlashEraser(object):
             flash.cleanup()
 
     def _convert_spec(self, spec):
-        if isinstance(spec, six.string_types):
+        if isinstance(spec, str):
             # Convert spec from string to range.
             if '-' in spec:
                 a, b = spec.split('-')

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +20,6 @@ import logging
 import itertools
 from elftools.elf.elffile import ELFFile
 from intelhex import IntelHex
-import six
 import errno
 
 from .loader import FlashLoader
@@ -110,7 +110,7 @@ class FileProgrammer(object):
         @exception ValueError Invalid argument value, for instance providing a file object but
             not setting file_format.
         """
-        isPath = isinstance(file_or_path, six.string_types)
+        isPath = isinstance(file_or_path, str)
         
         # Check for valid path first.
         if isPath and not os.path.isfile(file_or_path):

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -24,7 +24,6 @@ import errno
 
 from .loader import FlashLoader
 from ..core import exceptions
-from ..debug.elf.elf import (ELFBinaryFile, SH_FLAGS)
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2013-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,13 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from enum import Enum
+
 from ..core.target import Target
 from ..core.exceptions import (FlashFailure, FlashEraseFailure, FlashProgramFailure)
 from ..utility.mask import msb
-import logging
-from struct import unpack
-from time import time
-from enum import Enum
 from .builder import FlashBuilder
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -325,7 +325,7 @@ class Flash(object):
 
         # update core register to execute the subroutine
         TRACE.debug("call compute crc(%x, %x)", self.begin_data, len(data))
-        result = self._call_function_and_wait(self.flash_algo['analyzer_address'], self.begin_data, len(data))
+        self._call_function_and_wait(self.flash_algo['analyzer_address'], self.begin_data, len(data))
 
         # Read back the CRCs for each section
         data = self.target.read_memory_block32(self.begin_data, len(data))
@@ -399,7 +399,7 @@ class Flash(object):
         # update core register to execute the program_page subroutine
         TRACE.debug("start_program_page_with_buffer(addr=%x, len=%x, data=%x)", address, self.region.page_size,
                 self.page_buffers[buffer_number])
-        result = self._call_function(self.flash_algo['pc_program_page'], address, self.region.page_size, self.page_buffers[buffer_number])
+        self._call_function(self.flash_algo['pc_program_page'], address, self.region.page_size, self.page_buffers[buffer_number])
 
     def load_page_buffer(self, buffer_number, address, bytes):
         """!
@@ -559,14 +559,14 @@ class Flash(object):
             expected_fp = self.flash_algo['static_base']
             expected_sp = self.flash_algo['begin_stack']
             expected_pc = self.flash_algo['load_address']
-            expected_flash_algo = self.flash_algo['instructions']
-            if self.use_analyzer:
-                expected_analyzer = analyzer
             final_ipsr = self.target.read_core_register('ipsr')
             final_fp = self.target.read_core_register('r9')
             final_sp = self.target.read_core_register('sp')
             final_pc = self.target.read_core_register('pc')
             #TODO - uncomment if Read/write and zero init sections can be moved into a separate flash algo section
+            #expected_flash_algo = self.flash_algo['instructions']
+            #if self.use_analyzer:
+            #    expected_analyzer = analyzer
             #final_flash_algo = self.target.read_memory_block32(self.flash_algo['load_address'], len(self.flash_algo['instructions']))
             #if self.use_analyzer:
             #    final_analyzer = self.target.read_memory_block32(self.flash_algo['analyzer_address'], len(analyzer))

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016,2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +25,6 @@ from ..utility.mask import (align_up, round_up_div)
 from ..core import exceptions
 from ..core.target import Target
 from ..core.memory_map import MemoryType
-from ..core.core_registers import CoreRegisterInfo
 from . import signals
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -20,6 +20,7 @@ from struct import unpack
 from time import (sleep, time)
 import sys
 import six
+import io
 from xml.etree.ElementTree import (Element, SubElement, tostring)
 
 from ..core import exceptions
@@ -1008,7 +1009,7 @@ class GDBServer(threading.Thread):
         LOG.debug('Remote command: %s', cmd)
 
         # Create a new stream to collect the command output.
-        stream = six.StringIO()
+        stream = io.StringIO()
         self._command_context.output_stream = stream
         
         # TODO run this in a separate thread so we can cancel the command with ^C from gdb?

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -623,7 +623,7 @@ class GDBServer(threading.Thread):
             except exceptions.Error as e:
                 try:
                     self.target.halt()
-                except:
+                except exceptions.Error:
                     pass
                 LOG.warning('Exception while target was running: %s', e, exc_info=self.session.log_tracebacks)
                 val = ('S%02x' % self.target_facade.get_signal_value()).encode()

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -575,7 +575,7 @@ class GDBServer(threading.Thread):
         return addr
 
     def resume(self, data):
-        addr = self._get_resume_step_addr(data)
+#         addr = self._get_resume_step_addr(data)
         self.target.resume()
         LOG.debug("target resumed")
 
@@ -630,7 +630,7 @@ class GDBServer(threading.Thread):
         return self.create_rsp_packet(val)
 
     def step(self, data, start=0, end=0):
-        addr = self._get_resume_step_addr(data)
+        #addr = self._get_resume_step_addr(data)
         LOG.debug("GDB step: %s (start=0x%x, end=0x%x)", data, start, end)
         
         # Use the step hook to check for an interrupt event.

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +18,7 @@
 import logging
 import threading
 from struct import unpack
-from time import (sleep, time)
+from time import sleep
 import sys
 import six
 import io
@@ -28,7 +29,6 @@ from ..core.target import Target
 from ..flash.loader import FlashLoader
 from ..utility.cmdline import convert_vector_catch
 from ..utility.conversion import (hex_to_byte_list, hex_encode, hex_decode, hex8_to_u32le)
-from ..utility.progress import print_progress
 from ..utility.compatibility import (iter_single_bytes, to_bytes_safe, to_str_safe)
 from ..utility.server import StreamServer
 from ..trace.swv import SWVReader
@@ -39,16 +39,14 @@ from .context_facade import GDBDebugContextFacade
 from .symbols import GDBSymbolProvider
 from ..rtos import RTOS
 from . import signals
-from . import gdbserver_commands
+from . import gdbserver_commands # lgtm[py/unused-import]
 from .packet_io import (
-    CTRL_C,
     checksum,
     ConnectionClosedException,
     GDBServerPacketIOThread,
     )
 from ..commands.execution_context import CommandExecutionContext
 from ..commands.commander import ToolExitException
-from ..commands.base import CommandBase
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,10 +16,8 @@
 # limitations under the License.
 
 import logging
-import six
 
 from ..core import exceptions
-from ..commands.execution_context import CommandExecutionContext
 from ..commands.base import CommandBase
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/gdbserver/packet_io.py
+++ b/pyocd/gdbserver/packet_io.py
@@ -18,7 +18,6 @@
 import logging
 import threading
 import socket
-import sys
 import six
 import queue
 

--- a/pyocd/gdbserver/packet_io.py
+++ b/pyocd/gdbserver/packet_io.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +20,7 @@ import threading
 import socket
 import sys
 import six
-from six.moves import queue
+import queue
 
 CTRL_C = b'\x03'
 

--- a/pyocd/gdbserver/syscall.py
+++ b/pyocd/gdbserver/syscall.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 from ..debug.semihost import SemihostIOHandler
 
 # Open mode flags

--- a/pyocd/probe/aggregator.py
+++ b/pyocd/probe/aggregator.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,8 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import pkg_resources
 
 from ..core import exceptions
 from ..core.plugin import load_plugin_classes_of_type

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 from time import sleep
 import logging
 
@@ -77,7 +77,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             return [cls(dev) for dev in DAPAccess.get_connected_devices()]
         except DAPAccess.Error as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+            raise cls._convert_exception(exc) from exc
     
     @classmethod
     def get_probe_with_id(cls, unique_id, is_explicit=False):
@@ -88,7 +88,7 @@ class CMSISDAPProbe(DebugProbe):
             else:
                 return None
         except DAPAccess.Error as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+            raise cls._convert_exception(exc) from exc
 
     def __init__(self, device):
         super(CMSISDAPProbe, self).__init__()
@@ -190,7 +190,7 @@ class CMSISDAPProbe(DebugProbe):
             if self._link.has_swo():
                 self._caps.add(self.Capability.SWO)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
     
     def close(self):
         try:
@@ -199,7 +199,7 @@ class CMSISDAPProbe(DebugProbe):
             self._link.close()
             self._is_open = False
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     # ------------------------------------------- #
     #          Target control functions
@@ -216,7 +216,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.connect(port)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
         
         # Read the current mode and save it.
         actualMode = self._link.get_swj_mode()
@@ -228,7 +228,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.swj_sequence(length, bits)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swd_sequence(self, sequences):
         TRACE.debug("trace: swd_sequence(sequences=%r)", sequences)
@@ -236,7 +236,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.swd_sequence(sequences)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):
         TRACE.debug("trace: jtag_sequence(cycles=%i, tms=%x, read_tdo=%s, tdi=%x)", cycles, tms, read_tdo, tdi)
@@ -244,7 +244,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.jtag_sequence(cycles, tms, read_tdo, tdi)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def disconnect(self):
         TRACE.debug("trace: disconnect")
@@ -253,7 +253,7 @@ class CMSISDAPProbe(DebugProbe):
             self._link.disconnect()
             self._protocol = None
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def set_clock(self, frequency):
         TRACE.debug("trace: set_clock(freq=%i)", frequency)
@@ -261,7 +261,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.set_clock(frequency)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def reset(self):
         TRACE.debug("trace: reset")
@@ -272,7 +272,7 @@ class CMSISDAPProbe(DebugProbe):
             self._link.assert_reset(False)
             sleep(self.session.options.get('reset.post_delay'))
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def assert_reset(self, asserted):
         TRACE.debug("trace: assert_reset(%s)", asserted)
@@ -280,7 +280,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.assert_reset(asserted)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
     
     def is_reset_asserted(self):
         try:
@@ -288,7 +288,7 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: is_reset_asserted -> %s", result)
             return result
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def flush(self):
         TRACE.debug("trace: flush")
@@ -297,7 +297,7 @@ class CMSISDAPProbe(DebugProbe):
             self._link.flush()
         except DAPAccess.Error as exc:
             TRACE.debug("trace: error from flush: %r", exc)
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     # ------------------------------------------- #
     #          DAP Access functions
@@ -312,7 +312,7 @@ class CMSISDAPProbe(DebugProbe):
             result = self._link.read_reg(reg_id, now=now)
         except DAPAccess.Error as error:
             TRACE.debug("trace: read_dp(addr=%#010x) -> error(%s)", addr, error)
-            six.raise_from(self._convert_exception(error), error)
+            raise self._convert_exception(error) from error
 
         # Read callback returned for async reads.
         def read_dp_result_callback():
@@ -322,7 +322,7 @@ class CMSISDAPProbe(DebugProbe):
                 return value
             except DAPAccess.Error as error:
                 TRACE.debug("trace: ... read_dp(addr=%#010x) -> error(%s)", addr, error)
-                six.raise_from(self._convert_exception(error), error)
+                raise self._convert_exception(error) from error
 
         if now:
             TRACE.debug("trace: read_dp(addr=%#010x) -> %#010x", addr, result)
@@ -339,12 +339,12 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: write_dp(addr=%#010x, data=%#010x)", addr, data)
         except DAPAccess.Error as error:
             TRACE.debug("trace: write_dp(addr=%#010x, data=%#010x) -> error(%s)", addr, data, error)
-            six.raise_from(self._convert_exception(error), error)
+            raise self._convert_exception(error) from error
 
         return True
 
     def read_ap(self, addr, now=True):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
         try:
@@ -352,7 +352,7 @@ class CMSISDAPProbe(DebugProbe):
                 TRACE.debug("trace: read_ap(addr=%#010x) -> ...", addr)
             result = self._link.read_reg(ap_reg, now=now)
         except DAPAccess.Error as error:
-            six.raise_from(self._convert_exception(error), error)
+            raise self._convert_exception(error) from error
 
         # Read callback returned for async reads.
         def read_ap_result_callback():
@@ -362,7 +362,7 @@ class CMSISDAPProbe(DebugProbe):
                 return value
             except DAPAccess.Error as error:
                 TRACE.debug("trace: ... read_ap(addr=%#010x) -> error(%s)", addr, error)
-                six.raise_from(self._convert_exception(error), error)
+                raise self._convert_exception(error) from error
 
         if now:
             TRACE.debug("trace: read_ap(addr=%#010x) -> %#010x", addr, result)
@@ -371,7 +371,7 @@ class CMSISDAPProbe(DebugProbe):
             return read_ap_result_callback
 
     def write_ap(self, addr, data):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
         try:
@@ -380,12 +380,12 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: write_ap(addr=%#010x, data=%#010x)", addr, data)
         except DAPAccess.Error as error:
             TRACE.debug("trace: write_ap(addr=%#010x, data=%#010x) -> error(%s)", addr, data, error)
-            six.raise_from(self._convert_exception(error), error)
+            raise self._convert_exception(error) from error
 
         return True
 
     def read_ap_multiple(self, addr, count=1, now=True):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
         
         try:
@@ -393,7 +393,7 @@ class CMSISDAPProbe(DebugProbe):
                 TRACE.debug("trace: read_ap_multi(addr=%#010x, count=%i) -> ...", addr, count)
             result = self._link.reg_read_repeat(count, ap_reg, dap_index=0, now=now)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
         # Need to wrap the deferred callback to convert exceptions.
         def read_ap_repeat_callback():
@@ -405,7 +405,7 @@ class CMSISDAPProbe(DebugProbe):
             except DAPAccess.Error as exc:
                 TRACE.debug("trace: ... read_ap_multi(addr=%#010x, count=%i) -> error(%s)",
                     addr, count, exc)
-                six.raise_from(self._convert_exception(exc), exc)
+                raise self._convert_exception(exc) from exc
 
         if now:
             TRACE.debug("trace: read_ap_multi(addr=%#010x, count=%i) -> [%s]", addr, count,
@@ -415,7 +415,7 @@ class CMSISDAPProbe(DebugProbe):
             return read_ap_repeat_callback
 
     def write_ap_multiple(self, addr, values):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
         
         try:
@@ -425,7 +425,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             TRACE.debug("trace: write_ap_multi(addr=%#010x, (%i)[%s]) -> error(%s)", addr, len(values),
                     ", ".join(["%#010x" % v for v in values]), exc)
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
     
     # ------------------------------------------- #
     #          SWO functions
@@ -438,7 +438,7 @@ class CMSISDAPProbe(DebugProbe):
             self._link.swo_configure(True, baudrate)
             self._link.swo_control(True)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swo_stop(self):
         TRACE.debug("trace: swo_stop")
@@ -446,7 +446,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.swo_configure(False, 0)
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swo_read(self):
         try:
@@ -454,7 +454,7 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: swo_read -> %i bytes", len(data))
             return data
         except DAPAccess.Error as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     @staticmethod
     def _convert_exception(exc):

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -68,7 +68,7 @@ class JLinkProbe(DebugProbe):
                 return []
             return [cls(cls._format_serial_number(info.SerialNumber)) for info in jlink.connected_emulators()]
         except JLinkException as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+            raise cls._convert_exception(exc) from exc
     
     @classmethod
     def get_probe_with_id(cls, unique_id, is_explicit=False):
@@ -83,7 +83,7 @@ class JLinkProbe(DebugProbe):
             else:
                 return None
         except JLinkException as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+            raise cls._convert_exception(exc) from exc
 
     @classmethod
     def _get_probe_info(cls, serial_number, jlink):
@@ -99,7 +99,7 @@ class JLinkProbe(DebugProbe):
             else:
                 return None
         except JLinkException as exc:
-            six.raise_from(cls._convert_exception(exc), exc)
+            raise cls._convert_exception(exc) from exc
 
     def __init__(self, serial_number):
         """! @brief Constructor.
@@ -182,14 +182,14 @@ class JLinkProbe(DebugProbe):
             else:
                 self._default_protocol = DebugProbe.Protocol.JTAG
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
     
     def close(self):
         try:
             self._link.close()
             self._is_open = False
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     # ------------------------------------------- #
     #          Target control functions
@@ -219,7 +219,7 @@ class JLinkProbe(DebugProbe):
             self._link.coresight_configure()
             self._protocol = protocol
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swj_sequence(self, length, bits):
         for chunk in range((length + 31) // 32):
@@ -242,7 +242,7 @@ class JLinkProbe(DebugProbe):
             if self.session.options.get('jlink.power'):
                 self._link.power_off()
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
         self._protocol = None
 
@@ -250,7 +250,7 @@ class JLinkProbe(DebugProbe):
         try:
             self._link.set_speed(frequency // 1000)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def reset(self):
         try:
@@ -259,7 +259,7 @@ class JLinkProbe(DebugProbe):
             self._link.set_reset_pin_high()
             sleep(self.session.options.get('reset.post_delay'))
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def assert_reset(self, asserted):
         try:
@@ -268,14 +268,14 @@ class JLinkProbe(DebugProbe):
             else:
                 self._link.set_reset_pin_high()
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
     
     def is_reset_asserted(self):
         try:
             status = self._link.hardware_status()
             return status.tres == 0
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     # ------------------------------------------- #
     #          DAP Access functions
@@ -285,7 +285,7 @@ class JLinkProbe(DebugProbe):
         try:
             value = self._link.coresight_read(addr // 4, ap=False)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
         else:
             def read_reg_cb():
                 return value
@@ -296,14 +296,14 @@ class JLinkProbe(DebugProbe):
         try:
             ack = self._link.coresight_write(addr // 4, data, ap=False)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def read_ap(self, addr, now=True):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         try:
             value = self._link.coresight_read((addr & self.A32) // 4, ap=True)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
         else:
             def read_reg_cb():
                 return value
@@ -311,11 +311,11 @@ class JLinkProbe(DebugProbe):
             return value if now else read_reg_cb
 
     def write_ap(self, addr, data):
-        assert type(addr) in (six.integer_types)
+        assert isinstance(addr, int)
         try:
             ack = self._link.coresight_write((addr & self.A32) // 4, data, ap=True)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def read_ap_multiple(self, addr, count=1, now=True):
         results = [self.read_ap(addr, now=True) for n in range(count)]
@@ -333,19 +333,19 @@ class JLinkProbe(DebugProbe):
         try:
             self._jlink.swo_start(baudrate)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swo_stop(self):
         try:
             self._jlink.swo_stop()
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     def swo_read(self):
         try:
             return self._jlink.swo_read(0, self._jlink.swo_num_bytes(), True)
         except JLinkException as exc:
-            six.raise_from(self._convert_exception(exc), exc)
+            raise self._convert_exception(exc) from exc
 
     @staticmethod
     def _convert_exception(exc):

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -22,7 +22,7 @@ import pylink
 from pylink.errors import (JLinkException, JLinkWriteException, JLinkReadException)
 
 from .debug_probe import DebugProbe
-from ..core import (exceptions, memory_interface)
+from ..core import exceptions
 from ..core.plugin import Plugin
 from ..core.options import OptionInfo
 

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -294,7 +294,7 @@ class JLinkProbe(DebugProbe):
 
     def write_dp(self, addr, data):
         try:
-            ack = self._link.coresight_write(addr // 4, data, ap=False)
+            self._link.coresight_write(addr // 4, data, ap=False)
         except JLinkException as exc:
             raise self._convert_exception(exc) from exc
 
@@ -313,7 +313,7 @@ class JLinkProbe(DebugProbe):
     def write_ap(self, addr, data):
         assert isinstance(addr, int)
         try:
-            ack = self._link.coresight_write((addr & self.A32) // 4, data, ap=True)
+            self._link.coresight_write((addr & self.A32) // 4, data, ap=True)
         except JLinkException as exc:
             raise self._convert_exception(exc) from exc
 

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -80,8 +80,7 @@ class JLinkProbe(DebugProbe):
                 sn = cls._format_serial_number(info.SerialNumber)
                 if sn == unique_id:
                     return cls(sn)
-            else:
-                return None
+            return None
         except JLinkException as exc:
             raise cls._convert_exception(exc) from exc
 
@@ -96,8 +95,7 @@ class JLinkProbe(DebugProbe):
             for info in jlink.connected_emulators():
                 if cls._format_serial_number(info.SerialNumber) == serial_number:
                     return info
-            else:
-                return None
+            return None
         except JLinkException as exc:
             raise cls._convert_exception(exc) from exc
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018-2021 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import array
 from .dap_access_api import DAPAccessIntf
 
 class Command:

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -19,7 +19,6 @@
 
 import re
 import logging
-import time
 import collections
 import threading
 from .dap_settings import DAPSettings
@@ -34,7 +33,6 @@ from .cmsis_dap_core import (
     DAPSWOTransport,
     DAPSWOMode,
     DAPSWOControl,
-    DAPSWOStatus,
     DAPTransferResponse,
     CMSISDAPVersion,
     )
@@ -1048,7 +1046,6 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
         # Build physical packet by adding it to command
         cmd = self._crnt_cmd
-        is_read = transfer_request & READ
         size_to_transfer = transfer_count
         trans_data_pos = 0
         while size_to_transfer > 0:

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -21,7 +21,6 @@ import re
 import logging
 import time
 import collections
-import six
 import threading
 from .dap_settings import DAPSettings
 from .dap_access_api import DAPAccessIntf
@@ -96,9 +95,9 @@ class _Transfer(object):
                  transfer_request, transfer_data):
         # Writes should not need a transfer object
         # since they don't have any response data
-        assert isinstance(dap_index, six.integer_types)
-        assert isinstance(transfer_count, six.integer_types)
-        assert isinstance(transfer_request, six.integer_types)
+        assert isinstance(dap_index, int)
+        assert isinstance(transfer_count, int)
+        assert isinstance(transfer_request, int)
         assert transfer_request & READ
         self.daplink = daplink
         self.dap_index = dap_index
@@ -482,7 +481,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     @staticmethod
     def get_device(device_id):
-        assert isinstance(device_id, six.string_types)
+        assert isinstance(device_id, str)
         iface = DAPAccessCMSISDAP._lookup_interface_for_unique_id(device_id)
         if iface is not None:
             return DAPAccessCMSISDAP(device_id, iface)
@@ -529,7 +528,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     #          CMSIS-DAP and Other Functions
     # ------------------------------------------- #
     def __init__(self, unique_id, interface=None):
-        assert isinstance(unique_id, six.string_types) or (unique_id is None and interface is not None)
+        assert isinstance(unique_id, str) or (unique_id is None and interface is not None)
         super(DAPAccessCMSISDAP, self).__init__()
 
         # Search for a matching interface if one wasn't provided.
@@ -864,8 +863,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def write_reg(self, reg_id, value, dap_index=0):
         assert reg_id in self.REG
-        assert isinstance(value, six.integer_types)
-        assert isinstance(dap_index, six.integer_types)
+        assert isinstance(value, int)
+        assert isinstance(dap_index, int)
 
         request = WRITE
         if reg_id.value < 4:
@@ -877,7 +876,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def read_reg(self, reg_id, dap_index=0, now=True):
         assert reg_id in self.REG
-        assert isinstance(dap_index, six.integer_types)
+        assert isinstance(dap_index, int)
         assert isinstance(now, bool)
 
         request = READ
@@ -901,10 +900,10 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             return read_reg_cb
 
     def reg_write_repeat(self, num_repeats, reg_id, data_array, dap_index=0):
-        assert isinstance(num_repeats, six.integer_types)
+        assert isinstance(num_repeats, int)
         assert num_repeats == len(data_array)
         assert reg_id in self.REG
-        assert isinstance(dap_index, six.integer_types)
+        assert isinstance(dap_index, int)
 
         request = WRITE
         if reg_id.value < 4:
@@ -916,9 +915,9 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def reg_read_repeat(self, num_repeats, reg_id, dap_index=0,
                         now=True):
-        assert isinstance(num_repeats, six.integer_types)
+        assert isinstance(num_repeats, int)
         assert reg_id in self.REG
-        assert isinstance(dap_index, six.integer_types)
+        assert isinstance(dap_index, int)
         assert isinstance(now, bool)
 
         request = READ
@@ -1036,8 +1035,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         """! @brief Write one or more commands
         """
         assert dap_index == 0  # dap index currently unsupported
-        assert isinstance(transfer_count, six.integer_types)
-        assert isinstance(transfer_request, six.integer_types)
+        assert isinstance(transfer_count, int)
+        assert isinstance(transfer_request, int)
         assert transfer_data is None or len(transfer_data) > 0
 
         # Create transfer and add to transfer list

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 try:
     import hid
-except:
+except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -51,7 +51,7 @@ class HidApiUSB(Interface):
         try:
             self.device.open_path(self.device_info['path'])
         except IOError as exc:
-            raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device: " + str(exc)), exc)
+            raise DAPAccessIntf.DeviceError("Unable to open device: " + str(exc)) from exc
 
     @staticmethod
     def get_all_connected_interfaces():

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 try:
     import usb.core
     import usb.util
-except:
+except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -28,7 +28,6 @@ from .common import (
     USB_CLASS_HID,
     filter_device_by_class,
     is_known_cmsis_dap_vid_pid,
-    check_ep,
     generate_device_unique_id,
     )
 from ..dap_access_api import DAPAccessIntf

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -19,7 +19,6 @@
 
 import logging
 import threading
-import six
 from time import sleep
 import platform
 import errno
@@ -111,7 +110,7 @@ class PyUSB(Interface):
         try:
             usb.util.claim_interface(dev, interface_number)
         except usb.core.USBError as exc:
-            raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device"), exc)
+            raise DAPAccessIntf.DeviceError("Unable to open device") from exc
 
         # Update all class variables if we made it here
         self.ep_out = ep_out

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -18,7 +18,6 @@
 
 import logging
 import threading
-import six
 from time import sleep
 import errno
 import platform
@@ -107,7 +106,7 @@ class PyUSBv2(Interface):
         try:
             usb.util.claim_interface(dev, interface_number)
         except usb.core.USBError as exc:
-            raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device"), exc)
+            raise DAPAccessIntf.DeviceError("Unable to open device") from exc
 
         # Update all class variables if we made it here
         self.ep_out = ep_out

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -38,7 +38,7 @@ LOG = logging.getLogger(__name__)
 try:
     import usb.core
     import usb.util
-except:
+except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 
 try:
     import pywinusb.hid as hid
-except:
+except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -18,7 +18,6 @@
 import logging
 import collections
 from time import sleep
-import six
 
 from .interface import Interface
 from .common import (
@@ -85,14 +84,13 @@ class PyWinUSB(Interface):
                     # If the device could not be opened in read only mode
                     # Then it either has been disconnected or is in use
                     # by another thread/process
-                    raise six.raise_from(DAPAccessIntf.DeviceError("Unable to open device %s"
-                            % self.serial_number), exc)
+                    raise DAPAccessIntf.DeviceError(f"Unable to open device {self.serial_number}") from exc
 
             else:
                 # If this timeout has elapsed then another process
                 # has locked this device in shared mode. This should
                 # not happen.
-                raise DAPAccessIntf.DeviceError("timed out attempting to open device %s" % self.serial_number)
+                raise DAPAccessIntf.DeviceError(f"Timed out attempting to open device {self.serial_number}")
 
     @staticmethod
     def get_all_connected_interfaces():

--- a/pyocd/probe/stlink/detect/base.py
+++ b/pyocd/probe/stlink/detect/base.py
@@ -54,7 +54,6 @@ class StlinkDetectBase(object):
           'mount_point', TargetID name etc.
         Function returns mbed list with platform names if possible
         """
-        platform_count = {}
         candidates = list(self.find_candidates())
         result = []
         for device in candidates:

--- a/pyocd/probe/stlink/detect/base.py
+++ b/pyocd/probe/stlink/detect/base.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2018-2019, Arm Limited and affiliates.
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,9 +18,8 @@ import re
 from abc import ABCMeta, abstractmethod
 from io import open
 from os import listdir
-from os.path import expanduser, isfile, join, exists, isdir
+from os.path import join, exists, isdir
 import logging
-import functools
 import six
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/probe/stlink/detect/factory.py
+++ b/pyocd/probe/stlink/detect/factory.py
@@ -17,7 +17,7 @@
 import platform
 
 # Make sure that any global generic setup is run
-from . import base  # noqa: F401
+from . import base  # noqa: F401 # lgtm[py/unused-import]
 
 def create_mbed_detector(**kwargs):
     """! Factory used to create host OS specific mbed-lstools object

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -15,16 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...core import exceptions
-from .. import common
 import usb.core
 import usb.util
 import logging
-import threading
 from collections import namedtuple
 import platform
 import errno
 from binascii import hexlify
+
+from ...core import exceptions
+from .. import common
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 from ...core import exceptions
 from .. import common
 import usb.core

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +21,6 @@ from .. import common
 import usb.core
 import usb.util
 import logging
-import six
 import threading
 from collections import namedtuple
 import platform
@@ -231,7 +231,7 @@ class STLinkUSBInterface(object):
                 TRACE.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
                 return data
         except usb.core.USBError as exc:
-            six.raise_from(exceptions.ProbeError("USB Error: %s" % exc), exc)
+            raise exceptions.ProbeError("USB Error: %s" % exc) from exc
         return None
 
     def read_swv(self, size, timeout=1000):

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 from time import sleep
 
 from .debug_probe import DebugProbe
 from ..core.memory_interface import MemoryInterface
-from ..core import exceptions
 from ..core.plugin import Plugin
 from ..coresight.ap import (APVersion, APSEL, APSEL_SHIFT)
 from .stlink.usb import STLinkUSBInterface

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -175,7 +175,7 @@ class StlinkProbe(DebugProbe):
         return result if now else read_dp_result_callback
 
     def write_dp(self, addr, data):
-        result = self._link.write_dap_register(STLink.DP_PORT, addr, data)
+        self._link.write_dap_register(STLink.DP_PORT, addr, data)
 
     def read_ap(self, addr, now=True):
         apsel = (addr & APSEL) >> APSEL_SHIFT
@@ -188,7 +188,7 @@ class StlinkProbe(DebugProbe):
 
     def write_ap(self, addr, data):
         apsel = (addr & APSEL) >> APSEL_SHIFT
-        result = self._link.write_dap_register(apsel, addr & 0xffff, data)
+        self._link.write_dap_register(apsel, addr & 0xffff, data)
 
     def read_ap_multiple(self, addr, count=1, now=True):
         results = [self.read_ap(addr, now=True) for n in range(count)]

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -56,6 +56,7 @@ class TCPClientProbe(DebugProbe):
         StatusCode.TRANSFER_FAULT: exceptions.TransferFaultError,
         }
     
+    @classmethod
     def _extract_address(cls, unique_id):
         parts = unique_id.split(':', 1)
         if len(parts) == 1:

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,8 +17,6 @@
 
 import logging
 import json
-import six
-import base64
 import threading
 
 from .debug_probe import DebugProbe
@@ -25,7 +24,6 @@ from ..core import exceptions
 from ..core.memory_interface import MemoryInterface
 from ..core.plugin import Plugin
 from ..utility.sockets import ClientSocket
-from ..utility.concurrency import locked
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020-2021 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +20,7 @@ import threading
 import json
 import base64
 import socket
-from six.moves.socketserver import (ThreadingTCPServer, StreamRequestHandler)
+from socketserver import (ThreadingTCPServer, StreamRequestHandler)
 
 from .shared_probe_proxy import SharedDebugProbeProxy
 from ..core.session import Session

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -18,12 +18,10 @@
 import logging
 import threading
 import json
-import base64
 import socket
 from socketserver import (ThreadingTCPServer, StreamRequestHandler)
 
 from .shared_probe_proxy import SharedDebugProbeProxy
-from ..core.session import Session
 from ..core import exceptions
 from .debug_probe import DebugProbe
 from ..coresight.ap import (APVersion, APv1Address, APv2Address)

--- a/pyocd/rtos/common.py
+++ b/pyocd/rtos/common.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .provider import (TargetThread, ThreadProvider)
-from ..core import exceptions
 import logging
+
+from .provider import TargetThread
+from ..core import exceptions
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/subcommands/gdbserver_cmd.py
+++ b/pyocd/subcommands/gdbserver_cmd.py
@@ -226,7 +226,7 @@ class GdbserverSubcommand(SubcommandBase):
                     session.gdbservers[core_number] = gdb
                     gdbs.append(gdb)
                     gdb.start()
-                gdb = gdbs[0]
+
                 while any(g.is_alive() for g in gdbs):
                     sleep(0.1)
                 if probe_server:

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,14 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
-from ...core import exceptions
-from ...coresight.coresight_target import CoreSightTarget
-from ...coresight.cortex_m import CortexM
-from ...coresight import (ap, dap)
-from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 import logging
 import time
+
+from ...flash.flash import Flash
+from ...coresight.coresight_target import CoreSightTarget
+from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/target/builtin/target_HC32F460.py
+++ b/pyocd/target/builtin/target_HC32F460.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_HC32L07x.py
+++ b/pyocd/target/builtin/target_HC32L07x.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_HC32L110.py
+++ b/pyocd/target/builtin/target_HC32L110.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_HC32L19x.py
+++ b/pyocd/target/builtin/target_HC32L19x.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_HC32x120.py
+++ b/pyocd/target/builtin/target_HC32x120.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2021 Huada Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,19 +15,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from time import sleep
+
 from ..family.target_kinetis import Kinetis
-from ...flash.flash import Flash
 from ...core import exceptions
 from ...core.target import Target
-from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-from ...coresight import ap
 from ...coresight.cortex_m import CortexM
 from ...utility.timeout import Timeout
-import logging
-import os.path
-from time import sleep
 
 SMC0_MR = 0x40020040
 SMC1_MR = 0x41020040

--- a/pyocd/target/builtin/target_LPC1114FN28_102.py
+++ b/pyocd/target/builtin/target_LPC1114FN28_102.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ...coresight.coresight_target import CoreSightTarget
-from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...coresight import ap
-from ...coresight.cortex_m import CortexM
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
 SYSCON_DEVICE_ID0 = 0x400000FF8

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ...coresight.coresight_target import CoreSightTarget
-from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
-from ...coresight import ap
-from ...coresight.cortex_m import CortexM
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = { 'load_address' : 0x20000000,

--- a/pyocd/target/builtin/target_LPC824M201JHI33.py
+++ b/pyocd/target/builtin/target_LPC824M201JHI33.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_M251.py
+++ b/pyocd/target/builtin/target_M251.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019 Nuvoton
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_M261.py
+++ b/pyocd/target/builtin/target_M261.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019 Nuvoton
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, DeviceRegion, MemoryMap)
 import logging

--- a/pyocd/target/builtin/target_MAX32620.py
+++ b/pyocd/target/builtin/target_MAX32620.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_MAX32630.py
+++ b/pyocd/target/builtin/target_MAX32630.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1021xxxxx.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2017 NXP
 # Copyright (c) 2018,2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ..family.target_imxrt import IMXRT

--- a/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
+++ b/pyocd/target/builtin/target_MIMXRT1052xxxxB.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2017 NXP
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,6 @@
 # limitations under the License.
 
 import logging
-from ...flash.flash import Flash
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ..family.target_imxrt import IMXRT

--- a/pyocd/target/builtin/target_MK82FN256xxx15.py
+++ b/pyocd/target/builtin/target_MK82FN256xxx15.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2009-2015,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,7 @@
 
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
-from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
 FLASH_ALGO = {

--- a/pyocd/target/builtin/target_MKL28Z512xxx7.py
+++ b/pyocd/target/builtin/target_MKL28Z512xxx7.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2020 NXP
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,15 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from ..family.target_kinetis import Kinetis
 from ..family.flash_kinetis import Flash_Kinetis
 from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight import ap
-from ...coresight.cortex_m import CortexM
 from ...debug.svd.loader import SVDFile
-import logging
-import os.path
-from time import (time, sleep)
 
 LOG = logging.getLogger(__name__)
 

--- a/pyocd/target/builtin/target_RTL8195AM.py
+++ b/pyocd/target/builtin/target_RTL8195AM.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from ...flash.flash import Flash
+
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (RamRegion, MemoryMap)
 

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32F412xx.py
+++ b/pyocd/target/builtin/target_STM32F412xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32F429xx.py
+++ b/pyocd/target/builtin/target_STM32F429xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32F767xx.py
+++ b/pyocd/target/builtin/target_STM32F767xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Bartek Wolowiec
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +17,8 @@
 
 import time
 import logging
-from ...utility import timeout
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
-from ...core import exceptions
 from ...coresight.cortex_m import CortexM
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/target/builtin/target_STM32L031x6.py
+++ b/pyocd/target/builtin/target_STM32L031x6.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32L432xx.py
+++ b/pyocd/target/builtin/target_STM32L432xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Wagner Sartori Junior
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_musca_a1.py
+++ b/pyocd/target/builtin/target_musca_a1.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_musca_s1.py
+++ b/pyocd/target/builtin/target_musca_s1.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,12 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-from ...core import exceptions
-from ...utility.timeout import Timeout
 import logging
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile

--- a/pyocd/target/builtin/target_nRF52832_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52832_xxAA.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ..family.target_nRF52 import NRF52

--- a/pyocd/target/builtin/target_nRF52840_xxAA.py
+++ b/pyocd/target/builtin/target_nRF52840_xxAA.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ..family.target_nRF52 import NRF52

--- a/pyocd/target/builtin/target_ncs36510.py
+++ b/pyocd/target/builtin/target_ncs36510.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 

--- a/pyocd/target/builtin/target_s5js100.py
+++ b/pyocd/target/builtin/target_s5js100.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,11 +19,9 @@ import logging
 from time import sleep
 from ...flash.flash import Flash
 from ...coresight.coresight_target import CoreSightTarget
-from ...coresight import (ap, dap)
-from ...core.memory_map import (RomRegion, FlashRegion, RamRegion, MemoryMap)
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...core.target import Target
 from ...coresight.cortex_m import CortexM
-from ...debug.svd.loader import SVDFile
 from ...core import exceptions
 from ...utility.timeout import Timeout
 

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2020 NXP
 # Copyright (c) 2006-2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,14 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...coresight import (dap, ap)
+import logging
+from time import sleep
+
+from ...coresight import ap
 from ...coresight.cortex_m import CortexM
 from ...core import exceptions
 from ...core.target import Target
 from ...coresight.coresight_target import CoreSightTarget
 from ...utility.timeout import Timeout
-import logging
-from time import sleep
 
 MDM_STATUS = 0x00000000
 MDM_CTRL = 0x00000004

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -164,7 +164,7 @@ class Kinetis(CoreSightTarget):
                 # until halt on connect is executed.
                 # assert self._force_halt_on_connect
 
-                isLocked = False
+#                 isLocked = False
             else:
                 LOG.warning("%s in secure state: not automatically unlocking", self.part_number)
         else:

--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
 # Copyright (C) 2020 Ted Tawara
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,10 +23,8 @@ from ...utility.sequencer import CallSequence
 from ...core import exceptions
 from ...core.target import Target
 from ...coresight.coresight_target import CoreSightTarget
-from ...core.memory_map import (FlashRegion, RamRegion, RomRegion, MemoryMap)
 from ...coresight.cortex_m import CortexM
 from ...coresight.cortex_m_v8m import CortexM_v8M
-from ...debug.svd.loader import SVDFile
 from ...utility import timeout
 
 FPB_CTRL                = 0xE0002000

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -25,7 +25,6 @@ from collections import namedtuple
 import logging
 import io
 import itertools
-import six
 import struct
 from typing import Optional
 
@@ -95,8 +94,7 @@ class CmsisPack(object):
             try:
                 self._pack_file = zipfile.ZipFile(file_or_path, 'r')
             except zipfile.BadZipFile as err:
-                six.raise_from(MalformedCmsisPackError("Failed to open CMSIS-Pack '{}': {}".format(
-                    file_or_path, err)), err)
+                raise MalformedCmsisPackError(f"Failed to open CMSIS-Pack '{file_or_path}': {err}") from err
         
         # Find the .pdsc file.
         for name in self._pack_file.namelist():
@@ -104,7 +102,7 @@ class CmsisPack(object):
                 self._pdscName = name
                 break
         else:
-            raise MalformedCmsisPackError("CMSIS-Pack '{}' is missing a .pdsc file".format(file_or_path))
+            raise MalformedCmsisPackError(f"CMSIS-Pack '{file_or_path}' is missing a .pdsc file")
         
         with self._pack_file.open(self._pdscName) as pdscFile:
             self._pdsc = CmsisPackDescription(self, pdscFile)

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -18,7 +18,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 from xml.etree.ElementTree import (ElementTree, Element)
 import zipfile
 from collections import namedtuple

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -20,11 +20,8 @@
 
 from xml.etree.ElementTree import (ElementTree, Element)
 import zipfile
-from collections import namedtuple
 import logging
 import io
-import itertools
-import struct
 from typing import Optional
 
 from .flash_algo import PackFlashAlgo

--- a/pyocd/target/pack/flash_algo.py
+++ b/pyocd/target/pack/flash_algo.py
@@ -15,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import os
 import struct
 import logging

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import logging
 import six
 import os

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2017-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
 import os
 
 from .cmsis_pack import (CmsisPack, MalformedCmsisPackError)

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -2,6 +2,7 @@
 # pyOCD debugger
 # Copyright (c) 2006-2018 Arm Limited
 # Copyright (c) 2020 Cypress Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,16 +22,13 @@ import os
 import logging
 import argparse
 import json
-import pkg_resources
 
 from .. import __version__
 from .. import target
 from ..core.session import Session
 from ..core.helpers import ConnectHelper
 from ..gdbserver import GDBServer
-from ..utility.cmdline import (split_command_line, VECTOR_CATCH_CHAR_MAP, convert_vector_catch,
-                                convert_session_options)
-from ..probe.cmsis_dap_probe import CMSISDAPProbe
+from ..utility.cmdline import (split_command_line, convert_session_options)
 from ..probe.pydapaccess import DAPAccess
 from ..core.session import Session
 from ..coresight.generic_mem_ap import GenericMemAPTarget

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -184,10 +184,10 @@ class GDBServerTool(object):
         if not self.args.output_json:
             ConnectHelper.list_connected_probes()
         else:
+            status = 0
+            error = ""
             try:
                 all_mbeds = ConnectHelper.get_sessions_for_all_connected_probes(blocking=False)
-                status = 0
-                error = ""
             except Exception as e:
                 all_mbeds = []
                 status = 1

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -16,7 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
 import sys
 import os
 import logging

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -35,10 +35,10 @@ class ListGenerator(object):
         Output version history:
         - 1.0, initial version
         """
+        status = 0
+        error = ""
         try:
             all_mbeds = ConnectHelper.get_sessions_for_all_connected_probes(blocking=False)
-            status = 0
-            error = ""
         except Exception as e:
             all_mbeds = []
             status = 1

--- a/pyocd/trace/swo.py
+++ b/pyocd/trace/swo.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2017-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -184,8 +185,9 @@ class SWOParser(object):
                     self._send_event(events.TraceTimestamp(tc, timestamp))
                 # Global timestamp.
                 elif hdr in (0b10010100, 0b10110100):
-                    t = (hdr >> 5) & 0x1
                     # TODO handle global timestamp
+                    # t = (hdr >> 5) & 0x1
+                    pass
                 # Extension.
                 elif (hdr & 0x8) == 0x8:
                     sh = (hdr >> 2) & 0x1

--- a/pyocd/trace/swv.py
+++ b/pyocd/trace/swv.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2019-2020 Arm Limited
 # Copyright (c) 2020 Patrick Huesmann
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +18,6 @@
 
 import logging
 import threading
-import sys
 from time import sleep
 
 from .sink import TraceEventSink

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -18,7 +18,6 @@ import struct
 import binascii
 from itertools import tee
 import six
-from six.moves import zip
 
 from .mask import align_up
 

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,6 @@
 
 import struct
 import binascii
-from itertools import tee
 import six
 
 from .mask import align_up

--- a/pyocd/utility/graph.py
+++ b/pyocd/utility/graph.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,14 +23,11 @@ class GraphNode(object):
     Supports indexing and iteration over children.
     """
 
-    def __init__(self, children=None):
+    def __init__(self):
         """! @brief Constructor."""
         super(GraphNode, self).__init__()
         self._parent = None
         self._children = []
-        if children is not None:
-            for c in children:
-                self.add_child(c)
     
     @property
     def parent(self):
@@ -115,7 +113,7 @@ class GraphNode(object):
         """! @brief Similar to __repr__ by used for dump_to_str()."""
         return str(self)
     
-    def dump_to_str(node):
+    def dump_to_str(self):
         """! @brief Returns a string describing the object graph."""
     
         def _dump(node, level):
@@ -124,7 +122,7 @@ class GraphNode(object):
                 result += _dump(child, level + 1)
             return result
     
-        return _dump(node, 0)
+        return _dump(self, 0)
     
     def dump(self):
         """! @brief Pretty print the object graph to stdout."""

--- a/pyocd/utility/server.py
+++ b/pyocd/utility/server.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,10 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 import logging
 import threading
 import socket
+
 from .sockets import ListenerSocket
 from .compatibility import to_bytes_safe
 

--- a/pyocd/utility/sockets.py
+++ b/pyocd/utility/sockets.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
 import socket
 import select
 

--- a/scripts/generate_flash_algo.py
+++ b/scripts/generate_flash_algo.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # pyOCD debugger
 # Copyright (c) 2011-2021 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +21,6 @@ import os
 import argparse
 import struct
 import binascii
-import logging
 import jinja2
 from pyocd.target.pack.flash_algo import PackFlashAlgo
 

--- a/scripts/generate_flash_algo.py
+++ b/scripts/generate_flash_algo.py
@@ -175,9 +175,6 @@ def main():
 
         print(algo.flash_info)
 
-        template_dir = os.path.dirname(os.path.realpath(__file__))
-        output_dir = os.path.dirname(args.elf_path)
-
         # Allocate stack after algo and its rw data, rounded up.
         SP = args.blob_start + HEADER_SIZE + algo.rw_start + algo.rw_size + STACK_SIZE
         SP = (SP + 0x100 - 1) // 0x100 * 0x100

--- a/test/commander_test.py
+++ b/test/commander_test.py
@@ -21,6 +21,7 @@ import traceback
 import logging
 import six
 import os
+from collections import UserDict
 
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
@@ -81,7 +82,7 @@ def commander_test(board_id):
     print("\n------ Testing commander ------\n")
     
     # Set up commander args.
-    args = six.moves.UserDict()
+    args = UserDict()
     args.no_init = False
     args.frequency = 1000000
     args.options = {} #get_session_options()


### PR DESCRIPTION
Mostly large numbers of little cleanup changes for warnings identified by LGTM:

- removed unused imports
- removed many uses of `six`; the remaining ones are related to str/byte conversion and will require a little more testing to verify removal of
- removed imports from `__future__` needed for Python 2/3 compatibility
- cleaned up all remaining catch-all exception handlers
- other misc warning fixes

One bug in `BreakpointManager` is included that was identified as an unused variable by LGTM.
And the `GraphNode` constructor had its `children` parameter removed since it could result in the constructor calling a method overridden by a subclass (and was not being used yet anyway).