### PR TITLE
Session: allow project_dir as an env var

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -149,7 +149,7 @@ class Session(Notifier):
         
         # Init project directory.
         if self.options.get('project_dir') is None:
-            self._project_dir = os.environ('PYOCD_PROJECT_DIR') or os.getcwd()
+            self._project_dir = os.environ.get('PYOCD_PROJECT_DIR') or os.getcwd()
         else:
             self._project_dir = os.path.abspath(os.path.expanduser(self.options.get('project_dir')))
         LOG.debug("Project directory: %s", self.project_dir)

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -149,7 +149,7 @@ class Session(Notifier):
         
         # Init project directory.
         if self.options.get('project_dir') is None:
-            self._project_dir = os.getcwd()
+            self._project_dir = os.environ('PYOCD_PROJECT_DIR') or os.getcwd()
         else:
             self._project_dir = os.path.abspath(os.path.expanduser(self.options.get('project_dir')))
         LOG.debug("Project directory: %s", self.project_dir)


### PR DESCRIPTION
It's a very common use case to have env files that setup a workspace for a given project (i.e virtualenv). This feature can be very handy in these situations