### PR TITLE
Musca-B1 and Musca-S1: enable software reset from both cores

### DIFF
--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -15,12 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 
+LOG = logging.getLogger(__name__)
+
 RESET_MASK = 0x50021104
-RESET_MASK_SYSRESETREQ0_EN = 1 << 4
+RESET_MASK_SYSRSTREQ0_EN = 1 << 4
+RESET_MASK_SYSRSTREQ1_EN = 1 << 5
 
 FLASH_ALGO_QSPI = {
     'load_address' : 0x20000000,
@@ -298,8 +303,9 @@ class MuscaB1(CoreSightTarget):
         return seq
     
     def _enable_sysresetreq(self):
+        LOG.info("Enabling SYSRSTREQ0_EN and SYSRSTREQ1_EN")
         reset_mask = self.read32(RESET_MASK)
-        reset_mask |= RESET_MASK_SYSRESETREQ0_EN
+        reset_mask |= RESET_MASK_SYSRSTREQ0_EN | RESET_MASK_SYSRSTREQ1_EN
         self.write32(RESET_MASK, reset_mask)
     
     

--- a/pyocd/target/builtin/target_musca_s1.py
+++ b/pyocd/target/builtin/target_musca_s1.py
@@ -15,14 +15,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
-import logging
 
 LOG = logging.getLogger(__name__)
+
 RESET_MASK = 0x50021104
 RESET_MASK_SYSRSTREQ0_EN = 1 << 4
+RESET_MASK_SYSRSTREQ1_EN = 1 << 5
 
 FLASH_ALGO_QSPI = {
     'load_address' : 0x20000000,
@@ -107,12 +110,12 @@ class MuscaS1(CoreSightTarget):
     VENDOR = "Arm"
 
     MEMORY_MAP = MemoryMap(
-        RamRegion(name='nemram',     start=0x0A000000, length=0x00200000, access='rx',
+        RamRegion(name='nemram',     start=0x0A000000, length=0x00200000, access='rwx',
                         # is_boot_memory=True,
                         # is_external=False,
                         # is_default=True
                         ),
-        RamRegion(name='semram',     start=0x1A000000, length=0x00200000, access='rxs',
+        RamRegion(name='semram',     start=0x1A000000, length=0x00200000, access='rwxs',
                         # is_boot_memory=True,
                         # is_external=False,
                         # is_default=True,
@@ -159,7 +162,7 @@ class MuscaS1(CoreSightTarget):
         return seq
 
     def _enable_sysresetreq(self):
-        LOG.info("Enabling SYSRSTREQ0_EN")
+        LOG.info("Enabling SYSRSTREQ0_EN and SYSRSTREQ1_EN")
         reset_mask = self.read32(RESET_MASK)
-        reset_mask |= RESET_MASK_SYSRSTREQ0_EN
+        reset_mask |= RESET_MASK_SYSRSTREQ0_EN | RESET_MASK_SYSRSTREQ1_EN
         self.write32(RESET_MASK, reset_mask)


### PR DESCRIPTION
Also makes the MRAM regions on Musca-S1 writable.