### PR TITLE
Target type: dashes to underscores, save effective target type into options

### DIFF
--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -31,6 +31,10 @@ class Board(GraphNode):
     def __init__(self, session, target=None):
         super(Board, self).__init__()
         
+        # Use the session option if no target type was given to us.
+        if target is None:
+            target = session.options.get('target_override')
+        
         # As a last resort, default the target to 'cortex_m'.
         if target is None:
             target = 'cortex_m'
@@ -42,6 +46,12 @@ class Board(GraphNode):
                             " flash. To set the target type use the '--target' argument or "
                             "'target_override' option. Use 'pyocd list --targets' to see available "
                             "targets types.")
+
+        assert target is not None
+        
+        # Write the effective target type back to options if it's different.
+        if target != session.options.get('target_override'):
+            session.options['target_override'] = target
 
         self._session = session
         self._target_type = target.lower()

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -49,12 +49,15 @@ class Board(GraphNode):
 
         assert target is not None
         
+        # Convert dashes to underscores in the target type, and convert to lower case.
+        target = target.replace('-', '_').lower()
+        
         # Write the effective target type back to options if it's different.
         if target != session.options.get('target_override'):
             session.options['target_override'] = target
 
         self._session = session
-        self._target_type = target.lower()
+        self._target_type = target
         self._test_binary = session.options.get('test_binary')
         self._delegate = None
         self._inited = False

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -180,8 +180,7 @@ class Session(Notifier):
         self._load_user_script()
         
         # Ask the probe if it has an associated board, and if not then we create a generic one.
-        self._board = probe.create_associated_board() \
-                        or Board(self, self.options.get('target_override'))
+        self._board = probe.create_associated_board() or Board(self)
     
     def _get_config(self):
         # Load config file if one was provided via options, and no_config option was not set.

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -119,6 +119,9 @@ from . import target_MPS3_AN540
 from . import target_RP2040
 
 ## @brief Dictionary of all builtin targets.
+#
+# @note Target type names must be all lowercase and use _underscores_ instead of dashes. The code in Board
+#   automatically converts dashes in user-supplied target type names to underscores.
 BUILTIN_TARGETS = {
           'mps3_an522': target_MPS3_AN522.AN522,
           'mps3_an540': target_MPS3_AN540.AN540,

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -176,11 +176,13 @@ class PackTargets(object):
             tgt = PackTargets._generate_pack_target_class(dev)
             if tgt is None:
                 return
-            part = dev.part_number.lower()
+            part = dev.part_number.lower().replace("-", "_")
 
             # Make sure there isn't a duplicate target name.
             if part not in TARGET:
                 TARGET[part] = tgt
+            else:
+                LOG.debug("did not populate %s because there is already a %s target installed", dev.part_number, part)
         except (MalformedCmsisPackError, FileNotFoundError) as err:
             LOG.warning(err)
 


### PR DESCRIPTION
The most user-visible change is that dashes are converted to underscores in the target type. So selecting `cortex-m` works to select `cortex_m`, for instance.

Related:
- A comment was added to above the builtin targets dict stating that target type names must be in lowercase and use underscores.
- The target type names generated from CMSIS DFP target part numbers have dashes converted to underscores.

The other purpose of this change was to save the effective target type back to `target_override` option, so it can be read from user scripts amongst other uses. Attendant with this is a move of use of `target_override` option from `Session` to `Board`.