### PR TITLE
Harden reset against DP connection loss

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -248,11 +248,28 @@ Number of seconds to hold hardware reset asserted.
 Number of seconds to delay after a reset is issued.
 </td></tr>
 
+<tr><td>reset.dap_recover.timeout</td>
+<td>float</td>
+<td>5.0</td>
+<td>
+Timeout for waiting for the DAP to be accessible after reset, in seconds. If the timeout lapses, an attempt
+will be made to reconnect the DP and retry.
+</td></tr>
+
+<tr><td>reset.core_recover.timeout</td>
+<td>float</td>
+<td>2.0</td>
+<td>
+Timeout in seconds for waiting for a core to be accessible after reset. A warning is printed if the timeout
+lapses. Set to 0 to disable the core accessibility test. For halting reset, this is also the timeout for waiting
+for the core to halt.
+</td></tr>
+
 <tr><td>reset.halt_timeout</td>
 <td>float</td>
 <td>2.0</td>
 <td>
-Timeout for waiting for the core to halt after a reset and halt.
+Timeout in seconds for waiting for the core to halt after a reset and halt.
 </td></tr>
 
 <tr><td>resume_on_disconnect</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -90,6 +90,12 @@ BUILTIN_OPTIONS = [
         "Number of seconds to delay after a reset is issued. Default is 0.1 s (100 ms)."),
     OptionInfo('reset.halt_timeout', float, 2.0,
         "Timeout for waiting for the core to halt after a reset and halt. Default is 2.0 s."),
+    OptionInfo('reset.dap_recover.timeout', float, 2.0,
+        "Timeout for waiting for the DAP to be accessible after reset. If the timeout lapses, an attempt will be "
+        "made to reconnect the DP and retry. Default is 2.0 s."),
+    OptionInfo('reset.core_recover.timeout', float, 2.0,
+        "Timeout for waiting for a core to be accessible after reset. A warning is printed if the timeout lapses. "
+        "Set to 0 to disable the core accessibility test. Default is 2.0 s."),
     OptionInfo('resume_on_disconnect', bool, True,
         "Whether to run target on disconnect."),
     OptionInfo('scan_all_aps', bool, False,

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -208,11 +208,9 @@ class SoCTarget(Target, GraphNode):
     def reset(self, reset_type=None):
         # Perform a hardware reset if there is not a core.
         if self.selected_core is None:
-            # Use the probe to reset if the DP doesn't exist yet.
-            if self.dp is None:
-                self.session.probe.reset()
-            else:
-                self.dp.reset()
+            # Use the probe to reset. (We can't use the DP here because that's a class layering violation;
+            # the DP is only created by the CoreSightTarget subclass.)
+            self.session.probe.reset()
             return
         self.selected_core.reset(reset_type)
 

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -388,7 +388,7 @@ class AccessPort(object):
     def init(self):
         # Read IDR if it wasn't given to us in the ctor.
         if self.idr is None:
-            self.idr = self.read_reg(AP_IDR)
+            self.idr = self.read_reg(self.address.idr_address)
         
         self.variant = (self.idr & AP_IDR_VARIANT_MASK) >> AP_IDR_VARIANT_SHIFT
         self.revision = (self.idr & AP_IDR_REVISION_MASK) >> AP_IDR_REVISION_SHIFT

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -228,5 +228,15 @@ class CoreSightTarget(SoCTarget):
             else:
                 self._irq_table = {}
         return self._irq_table
-    
-        
+
+    # Override this method from SoCTarget so we can use the DP for hardware resets when there isn't a
+    # valid core (instead of the probe), so reset notifications will be sent. We can't use the DP in
+    # SoCTarget because it is only created by this class.
+    def reset(self, reset_type=None, halt=False):
+        # Perform a hardware reset if there is not a core.
+        if self.selected_core is None:
+            # Use the probe to reset if the DP doesn't exist yet.
+            self.dp.reset()
+            return
+        self.selected_core.reset(reset_type, halt)
+

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -716,12 +716,17 @@ class CortexM(Target, CoreSightCoreComponent):
             else:
                 raise exceptions.InternalError("unhandled reset type")
         
+            # Transfer errors are ignored on the AIRCR write for resets. On a few systems, the reset
+            # apparently happens so quickly that we can't even finish the SWD transaction.
             try:
                 self.write_memory(CortexM.NVIC_AIRCR, CortexM.NVIC_AIRCR_VECTKEY | mask)
                 # Without a flush a transfer error can occur
                 self.flush()
             except exceptions.TransferError:
                 self.flush()
+            
+            # Post reset delay.
+            sleep(self.session.options.get('reset.post_delay'))
 
     def reset(self, reset_type=None):
         """! @brief Reset the core.

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -169,6 +169,8 @@ class CortexM(Target, CoreSightCoreComponent):
     MVFR2_VFP_MISC_MASK = 0x000000f0
     MVFR2_VFP_MISC_SHIFT = 4
 
+    _RESET_RECOVERY_SLEEP_INTERVAL = 0.01 # 10 ms
+
     @classmethod
     def factory(cls, ap, cmpid, address):
         # Create a new core instance.
@@ -728,6 +730,36 @@ class CortexM(Target, CoreSightCoreComponent):
             # Post reset delay.
             sleep(self.session.options.get('reset.post_delay'))
 
+    def _post_reset_core_accessibility_test(self):
+        """! @brief Wait for the system to come out of reset and this core to be accessible.
+        
+        Keep reading the DHCSR until we get a good response with S_RESET_ST cleared, or we time out. There's nothing
+        we can do if the test times out, and in fact if this is a secondary core on a multicore system then timing out
+        is almost guaranteed.
+        """
+        recover_timeout = self.session.options.get('reset.core_recover.timeout')
+        if recover_timeout == 0:
+            return
+        with timeout.Timeout(recover_timeout, self._RESET_RECOVERY_SLEEP_INTERVAL) as time_out:
+            dhcsr = None
+            while time_out.check():
+                try:
+                    dhcsr = self.read32(CortexM.DHCSR)
+                    if (dhcsr & CortexM.S_RESET_ST) == 0:
+                        break
+                except exceptions.TransferError:
+                    # Ignore errors caused by flushing.
+                    try:
+                        self.flush()
+                    except exceptions.TransferError:
+                        pass
+            else:
+                # If dhcsr is None then we know that we never were able to read the register.
+                if dhcsr is None:
+                    LOG.warning("Core #%d is not accessible after reset")
+                else:
+                    LOG.debug("Core #%d did not come out of reset within timeout")
+
     def reset(self, reset_type=None):
         """! @brief Reset the core.
         
@@ -758,19 +790,18 @@ class CortexM(Target, CoreSightCoreComponent):
         if not self.call_delegate('will_reset', core=self, reset_type=reset_type):
             self._perform_reset(reset_type)
 
+        # Post reset recovery tests.
+        # We only need to test accessibility after reset for system-level resets.
+        # If a hardware reset is being used, then the DP will perform its post-reset recovery for us. Out of the
+        # other reset types, only a system-level reset by SW_SYSRESETREQ require us to ensure the DP reset recovery
+        # is performed. VECTRESET 
+        if reset_type is Target.ResetType.SW_SYSRESETREQ:
+            self.ap.dp.post_reset_recovery()
+        if reset_type in (Target.ResetType.HW, Target.ResetType.SW_SYSRESETREQ):
+            # Now run the core accessibility test.
+            self._post_reset_core_accessibility_test()
+
         self.call_delegate('did_reset', core=self, reset_type=reset_type)
-        
-        # Now wait for the system to come out of reset. Keep reading the DHCSR until
-        # we get a good response with S_RESET_ST cleared, or we time out.
-        with timeout.Timeout(2.0) as t_o:
-            while t_o.check():
-                try:
-                    dhcsr = self.read32(CortexM.DHCSR)
-                    if (dhcsr & CortexM.S_RESET_ST) == 0:
-                        break
-                except exceptions.TransferError:
-                    self.flush()
-                    sleep(0.01)
 
         if reset_type is not Target.ResetType.HW:
             self.session.notify(Target.Event.POST_RESET, self)
@@ -818,7 +849,7 @@ class CortexM(Target, CoreSightCoreComponent):
                     break
                 sleep(0.01)
             else:
-                LOG.warning("Timed out waiting for target to complete reset (state is %s)", self.get_state().name)
+                LOG.warning("Timed out waiting for core to halt after reset (state is %s)", self.get_state().name)
 
         # Make sure the thumb bit is set in XPSR in case the reset handler
         # points to an invalid address. Only do this if the core is actually halted, otherwise we

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -707,7 +707,8 @@ class CortexM(Target, CoreSightCoreComponent):
         """! @brief Perform a reset of the specified type."""
         assert isinstance(reset_type, Target.ResetType)
         if reset_type is Target.ResetType.HW:
-            self.session.target.dp.reset()
+            # Tell DP to not send reset notifications because we are doing it.
+            self.session.target.dp.reset(send_notifications=False)
         elif reset_type is Target.ResetType.SW_EMULATED:
             self._perform_emulated_reset()
         else:
@@ -779,9 +780,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
         LOG.debug("reset, core %d, type=%s", self.core_number, reset_type.name)
 
-        # The HW reset type is passed to the DP, which itself sends reset notifications.
-        if reset_type is not Target.ResetType.HW:
-            self.session.notify(Target.Event.PRE_RESET, self)
+        self.session.notify(Target.Event.PRE_RESET, self)
 
         self._run_token += 1
 
@@ -803,8 +802,7 @@ class CortexM(Target, CoreSightCoreComponent):
 
         self.call_delegate('did_reset', core=self, reset_type=reset_type)
 
-        if reset_type is not Target.ResetType.HW:
-            self.session.notify(Target.Event.POST_RESET, self)
+        self.session.notify(Target.Event.POST_RESET, self)
 
     def set_reset_catch(self, reset_type=None):
         """! @brief Prepare to halt core on reset."""

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -16,8 +16,8 @@
 # limitations under the License.
 
 import logging
-from collections import namedtuple
 from enum import Enum
+from typing import NamedTuple
 
 from ..core import (exceptions, memory_interface)
 from ..core.target import Target
@@ -98,14 +98,19 @@ MASKLANE = 0x00000f00
 DP_POWER_REQUEST_TIMEOUT = 5.0
 
 ## @brief Class to hold fields from DP IDR register.
-DPIDR = namedtuple('DPIDR', 'idr partno version revision mindp')
+class DPIDR(NamedTuple):
+    idr: int
+    partno: int
+    version: int
+    revision: int
+    mindp: int
 
 class ADIVersion(Enum):
     """! @brief Supported versions of the Arm Debug Interface."""
     ADIv5 = 5
     ADIv6 = 6
 
-class DPConnector(object):
+class DPConnector:
     """! @brief Establishes a connection to the DP for a given wire protocol.
     
     This class will ask the probe to connect using a given wire protocol. Then it makes multiple
@@ -237,9 +242,9 @@ class DPConnector(object):
         is_mindp = (dpidr & DPIDR_MIN_MASK) != 0
         return DPIDR(dpidr, dp_partno, dp_version, dp_revision, is_mindp)
 
-class DebugPort(object):
+class DebugPort:
     """! @brief Represents the Arm Debug Interface (ADI) Debug Port (DP)."""
-    
+
     def __init__(self, probe, target):
         """! @brief Constructor.
         @param self The DebugPort object.

--- a/test/unit/test_timeout.py
+++ b/test/unit/test_timeout.py
@@ -64,4 +64,24 @@ class TestTimeout:
                 cnt += 1
         assert not timedout
         assert not to.did_time_out
+    
+    def test_timeout_reset(self):
+        cnt = 0
+        cnta = 0
+        with Timeout(0.05) as to:
+            cnta = 0
+            while cnta < 3:
+                cnt = 0
+                while to.check():
+                    sleep(0.01)
+                    if cnta > 1:
+                        break
+                    cnt += 1
+                else:
+                    assert to.did_time_out
+                    to.clear()
+                    to.start()
+                cnta += 1
+        assert cnta == 3 and cnt == 0
+        assert not to.did_time_out
 


### PR DESCRIPTION
This change improves reset handling for both hardware and software reset by checking for and handling cases where the connection to the DP is lost, usually as a result of the target performing a cold reset.

Two session options are added: `reset.dap_recover.timeout` and `reset.core_recover.timeout`. These set the times in seconds for which pyocd will attempt to establish a broken DP connection, and wait for a CPU core to become accessible again, respectively.

The existing `reset.post_delay` option is now used for software resets.