### PR TITLE
Commander: fix printing of D register values

### DIFF
--- a/pyocd/commands/base.py
+++ b/pyocd/commands/base.py
@@ -104,7 +104,9 @@ class CommandBase(metaclass=CommandMeta):
 
     def _format_core_register(self, info, value):
         hex_width = round_up_div(info.bitsize, 4) + 2 # add 2 for the "0x" prefix
-        if info.is_float_register:
+        if info.is_double_float_register:
+            value_str = "{f:g} ({i:#0{w}x})".format(f=conversion.u64_to_float64(value), i=value, w=hex_width)
+        elif info.is_single_float_register:
             value_str = "{f:g} ({i:#0{w}x})".format(f=conversion.u32_to_float32(value), i=value, w=hex_width)
         elif info.gdb_type in ('data_ptr', 'code_ptr'):
             value_str = "{h:#0{w}x}".format(h=value, w=hex_width)

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -97,7 +97,7 @@ def byte_list_to_u16le_list(byteData):
 
 def u32_to_float32(data):
     """! @brief Convert a 32-bit int to an IEEE754 float"""
-    d = struct.pack(">I", data)
+    d = struct.pack(">I", data & 0xffff_ffff)
     return struct.unpack(">f", d)[0]
 
 def float32_to_u32(data):
@@ -107,7 +107,7 @@ def float32_to_u32(data):
 
 def u64_to_float64(data):
     """! @brief Convert a 64-bit int to an IEEE754 float"""
-    d = struct.pack(">Q", data)
+    d = struct.pack(">Q", data & 0xffff_ffff_ffff_ffff)
     return struct.unpack(">d", d)[0]
 
 def float64_to_u64(data):


### PR DESCRIPTION
Any D core register with a bit higher than 31 set would result in a `struct.error` exception when formatted for printing.

The int to float conversion utilities were amended to ensure that the passed-in int is no larger than the specified bit width.