### PR TITLE
Load subcommand and related improvements

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -33,10 +33,10 @@ from .core import options
 from .subcommands.base import SubcommandBase
 from .subcommands.commander_cmd import CommanderSubcommand
 from .subcommands.erase_cmd import EraseSubcommand
-from .subcommands.flash_cmd import FlashSubcommand
 from .subcommands.gdbserver_cmd import GdbserverSubcommand
 from .subcommands.json_cmd import JsonSubcommand
 from .subcommands.list_cmd import ListSubcommand
+from .subcommands.load_cmd import LoadSubcommand
 from .subcommands.pack_cmd import PackSubcommand
 from .subcommands.reset_cmd import ResetSubcommand
 from .subcommands.server_cmd import ServerSubcommand
@@ -57,7 +57,7 @@ class PyOCDTool(SubcommandBase):
     SUBCOMMANDS = [
         CommanderSubcommand,
         EraseSubcommand,
-        FlashSubcommand,
+        LoadSubcommand,
         GdbserverSubcommand,
         JsonSubcommand,
         ListSubcommand,

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -21,7 +21,6 @@ from time import sleep
 from ..core.target import Target
 from ..core import exceptions
 from ..core.core_registers import CoreRegistersIndex
-from ..core.memory_map import (MemoryMap, RamRegion, DeviceRegion)
 from ..utility import (cmdline, timeout)
 from .component import CoreSightCoreComponent
 from .fpb import FPB
@@ -190,11 +189,6 @@ class CortexM(Target, CoreSightCoreComponent):
         return core
 
     def __init__(self, session, ap, memory_map=None, core_num=0, cmpid=None, address=None):
-        # Supply a default memory map.
-        if (memory_map is None) or (memory_map.region_count == 0):
-            memory_map = self._create_default_cortex_m_memory_map()
-            LOG.debug("Using default memory map for core #%d (no memory map supplied)", core_num)
-        
         Target.__init__(self, session, memory_map)
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
@@ -326,19 +320,6 @@ class CortexM(Target, CoreSightCoreComponent):
                 self.write32(CortexM.DHCSR, CortexM.DBGKEY | 0x0000)
 
         self.call_delegate('did_stop_debug_core', core=self)
-
-    def _create_default_cortex_m_memory_map(self):
-        """! @brief Create a MemoryMap for the Cortex-M system address map."""
-        return MemoryMap(
-                RamRegion(name="Code",          start=0x00000000, length=0x20000000, access='rwx'),
-                RamRegion(name="SRAM",          start=0x20000000, length=0x20000000, access='rwx'),
-                DeviceRegion(name="Peripheral", start=0x40000000, length=0x20000000, access='rw'),
-                RamRegion(name="RAM1",          start=0x60000000, length=0x20000000, access='rwx'),
-                RamRegion(name="RAM2",          start=0x80000000, length=0x20000000, access='rwx'),
-                DeviceRegion(name="Device1",    start=0xA0000000, length=0x20000000, access='rw'),
-                DeviceRegion(name="Device2",    start=0xC0000000, length=0x20000000, access='rw'),
-                DeviceRegion(name="PPB",        start=0xE0000000, length=0x20000000, access='rw'),
-                )
 
     def _build_registers(self):
         """! @brief Build set of core registers available on this code.

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -16,11 +16,15 @@
 # limitations under the License.
 
 import logging
+import abc
+from dataclasses import dataclass
 from time import time
 from binascii import crc32
+from typing import (Any, Union)
 
 from ..core.target import Target
 from ..core.exceptions import (FlashFailure, FlashProgramFailure)
+from ..core.memory_map import MemoryRegion
 from ..utility.mask import same
 
 # Number of bytes in a page to read to quickly determine if the page has the same data
@@ -29,38 +33,66 @@ DATA_TRANSFER_B_PER_S = 40 * 1000 # ~40KB/s, depends on clock speed, theoretical
 
 LOG = logging.getLogger(__name__)
 
-def get_page_count(count):
+def get_page_count(count: int) -> str:
     """! @brief Return string for page count with correct plurality."""
     if count == 1:
         return "1 page"
     else:
         return "{} pages".format(count)
 
-def get_sector_count(count):
+def get_sector_count(count: int) -> str:
     """! @brief Return string for sector count with correct plurality."""
     if count == 1:
         return "1 sector"
     else:
         return "{} sectors".format(count)
 
-class ProgrammingInfo(object):
-    def __init__(self):
-        self.program_type = None                # Type of programming performed - FLASH_SECTOR_ERASE or FLASH_CHIP_ERASE
-        self.program_time = None                # Total programming time
-        self.analyze_type = None                # Type of flash analysis performed - FLASH_ANALYSIS_CRC32 or FLASH_ANALYSIS_PARTIAL_PAGE_READ
-        self.analyze_time = None                # Time to analyze flash contents
-        self.total_byte_count = 0
-        self.program_byte_count = 0
-        self.program_page_count = 0
-        self.erase_byte_count = 0
-        self.erase_sector_count = 0
-        self.skipped_byte_count = 0
-        self.skipped_page_count = 0
+@dataclass
+class ProgrammingInfo:
+    program_type: Any = None                # Type of programming performed - FLASH_SECTOR_ERASE or FLASH_CHIP_ERASE
+    program_time: float = 0.0               # Total programming time
+    analyze_type: Any = None                # Type of flash analysis performed - FLASH_ANALYSIS_CRC32 or FLASH_ANALYSIS_PARTIAL_PAGE_READ
+    analyze_time: float = 0.0               # Time to analyze flash contents
+    total_byte_count: int = 0
+    program_byte_count: int = 0
+    program_page_count: int = 0
+    erase_byte_count: int = 0
+    erase_sector_count: int = 0
+    skipped_byte_count: int = 0
+    skipped_page_count: int = 0
+
+class MemoryBuilder(abc.ABC):
+    """@brief Abstract class for memory builders."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._buffered_data_size: int = 0
+    
+    @property
+    def buffered_data_size(self) -> int:
+        """@brief Total amount of memory buffered by this builder."""
+        return self._buffered_data_size
+
+    @property
+    @abc.abstractmethod
+    def region(self) -> MemoryRegion:
+        """@brief The memory region that can be written to by this builder."""
+        ...
+
+    @abc.abstractmethod
+    def add_data(self, addr: int, data: Union[bytes, bytearray]) -> None:
+        """@brief Add a chunk of data to the builder."""
+        ...
+
+    @abc.abstractmethod
+    def program(self, **kwargs: Any) -> ProgrammingInfo:
+        """@brief Commit the buffered data to the destination memory region."""
+        ...
 
 def _stub_progress(percent):
     pass
 
-class _FlashSector(object):
+class _FlashSector:
     """! @brief Info about an erase sector and all pages to be programmed within it."""
     def __init__(self, sector_info):
         self.addr = sector_info.base_addr
@@ -93,7 +125,7 @@ class _FlashSector(object):
         return "<_FlashSector@%x addr=%x size=%x wgt=%g pages=%s>" % (
             id(self), self.addr, self.size, self.erase_weight, self.page_list)
 
-class _FlashPage(object):
+class _FlashPage:
     """! @brief A page to be programmed and its data."""
     def __init__(self, page_info):
         self.addr = page_info.base_addr
@@ -101,8 +133,8 @@ class _FlashPage(object):
         self.data = []
         self.program_weight = page_info.program_weight
         self.erased = None # Whether the data all matches the erased value.
-        self.same = None
-        self.crc = None
+        self.same = False
+        self.crc = 0
         self.cached_estimate_data = None
 
     def get_program_weight(self):
@@ -118,13 +150,13 @@ class _FlashPage(object):
         return "<_FlashPage@%x addr=%x size=%x datalen=%x wgt=%g erased=%s same=%s>" % (
             id(self), self.addr, self.size, len(self.data), self.program_weight, self.erased, self.same)
 
-class _FlashOperation(object):
+class _FlashOperation:
     """! @brief Holds requested data to be programmed at a given address."""
     def __init__(self, addr, data):
         self.addr = addr
         self.data = data
 
-class FlashBuilder(object):
+class FlashBuilder(MemoryBuilder):
     """! @brief Manages programming flash within one flash memory region.
 
     The purpose of this class is to optimize flash programming within a single region to achieve
@@ -151,6 +183,7 @@ class FlashBuilder(object):
     FLASH_ANALYSIS_PARTIAL_PAGE_READ = "PAGE_READ"
 
     def __init__(self, flash):
+        super().__init__()
         self.flash = flash
         self.flash_start = flash.region.start
         self.flash_operation_list = []
@@ -159,7 +192,7 @@ class FlashBuilder(object):
         self.perf = ProgrammingInfo()
         self.enable_double_buffering = True
         self.log_performance = True
-        self.buffered_data_size = 0
+        self._buffered_data_size = 0
         self.program_byte_count = 0
         self.sector_erase_count = 0
         self.chip_erase_count = 0 # Number of pages to program using chip erase method.
@@ -167,6 +200,10 @@ class FlashBuilder(object):
         self.sector_erase_count = 0 # Number of pages to program using sector erase method.
         self.sector_erase_weight = 0 # Erase/program weight using sector erase method.
         self.algo_inited_for_read = False
+
+    @property
+    def region(self) -> MemoryRegion:
+        return self.flash.region
 
     def enable_double_buffer(self, enable):
         self.enable_double_buffering = enable
@@ -195,7 +232,7 @@ class FlashBuilder(object):
 
         # Add operation to list
         self.flash_operation_list.append(_FlashOperation(addr, data))
-        self.buffered_data_size += len(data)
+        self._buffered_data_size += len(data)
 
         # Keep list sorted
         self.flash_operation_list = sorted(self.flash_operation_list, key=lambda operation: operation.addr)
@@ -420,7 +457,7 @@ class FlashBuilder(object):
         # Convert the list of flash operations into flash sectors and pages
         self._build_sectors_and_pages(keep_unwritten)
         assert len(self.sector_list) != 0 and len(self.sector_list[0].page_list) != 0
-        self.flash_operation_list = None # Don't need this data in memory anymore.
+        self.flash_operation_list = [] # Don't need this data in memory anymore.
         
         # If smart flash was set to false then mark all pages
         # as requiring programming
@@ -451,6 +488,8 @@ class FlashBuilder(object):
         # If chip erase isn't True then analyze the flash
         if chip_erase is not True:
             sector_erase_count, page_program_time = self._compute_sector_erase_pages_and_weight(fast_verify)
+        else:
+            sector_erase_count, page_program_time = 0, 0
 
         # If chip erase hasn't been set then determine fastest method to program
         if chip_erase is None:

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -15,12 +15,15 @@
 # limitations under the License.
 
 import logging
+from typing import (Callable, Union)
 
 from .builder import (FlashBuilder, get_page_count, get_sector_count)
 from ..core import exceptions
 from ..utility.progress import print_progress
 
 LOG = logging.getLogger(__name__)
+
+ProgressCallback = Callable[[Union[int, float]], None]
 
 class FlashLoader(object):
     """! @brief Handles high level programming of raw binary data to flash.

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -17,7 +17,7 @@
 import argparse
 import logging
 import prettytable
-from typing import (Iterable, List, Any, Optional)
+from typing import (List, Optional)
 
 from ..utility.cmdline import convert_frequency
 
@@ -166,10 +166,5 @@ class SubcommandBase:
         pt.hrules = prettytable.HEADER
         pt.vrules = prettytable.NONE
         return pt
-
-    @staticmethod
-    def flatten_args(args: Iterable[Iterable[Any]]) -> List[Any]:
-        """! @brief Converts a list of lists to a single list."""
-        return [item for sublist in args for item in sublist]
     
 

--- a/pyocd/subcommands/commander_cmd.py
+++ b/pyocd/subcommands/commander_cmd.py
@@ -23,7 +23,7 @@ from ..commands.commander import PyOCDCommander
 from ..utility.cmdline import split_command_line
 
 class CommanderSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd commander` subcommand."""
     
     NAMES = ['commander', 'cmd']
     HELP = "Interactive command console."

--- a/pyocd/subcommands/commander_cmd.py
+++ b/pyocd/subcommands/commander_cmd.py
@@ -20,7 +20,10 @@ from typing import List
 
 from .base import SubcommandBase
 from ..commands.commander import PyOCDCommander
-from ..utility.cmdline import split_command_line
+from ..utility.cmdline import (
+    flatten_args,
+    split_command_line,
+)
 
 class CommanderSubcommand(SubcommandBase):
     """! @brief `pyocd commander` subcommand."""
@@ -52,7 +55,7 @@ class CommanderSubcommand(SubcommandBase):
         if self._args.commands is not None:
             cmds = []
             for cmd in self._args.commands:
-                cmds.append(self.flatten_args(split_command_line(arg) for arg in cmd))
+                cmds.append(flatten_args(split_command_line(arg) for arg in cmd))
         else:
             cmds = None
 

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -26,7 +26,7 @@ from ..utility.cmdline import convert_session_options
 LOG = logging.getLogger(__name__)
 
 class EraseSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd erase` subcommand."""
     
     NAMES = ['erase']
     HELP = "Erase entire device flash or specified sectors."

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -56,7 +56,8 @@ class EraseSubcommand(SubcommandBase):
             help="Erase the sectors listed as positional arguments. This is the default.")
         erase_options.add_argument("--mass", dest="erase_mode", action="store_const", const=FlashEraser.Mode.MASS,
             help="Perform a mass erase. On some devices this is different than a chip erase.")
-        erase_options.add_argument("addresses", metavar="<sector-address>", action='append', nargs='*',
+
+        erase_parser.add_argument("addresses", metavar="<sector-address>", action='append', nargs='*',
             help="List of sector addresses or ranges to erase.")
         
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, erase_parser]

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -21,7 +21,10 @@ import logging
 from .base import SubcommandBase
 from ..core.helpers import ConnectHelper
 from ..flash.eraser import FlashEraser
-from ..utility.cmdline import convert_session_options
+from ..utility.cmdline import (
+    convert_session_options,
+    flatten_args,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -89,7 +92,7 @@ class EraseSubcommand(SubcommandBase):
             mode = self._args.erase_mode or FlashEraser.Mode.SECTOR
             eraser = FlashEraser(session, mode)
             
-            addresses = self.flatten_args(self._args.addresses)
+            addresses = flatten_args(self._args.addresses)
             eraser.erase(addresses)
 
         return 0

--- a/pyocd/subcommands/flash_cmd.py
+++ b/pyocd/subcommands/flash_cmd.py
@@ -21,13 +21,12 @@ import logging
 from .base import SubcommandBase
 from ..core.helpers import ConnectHelper
 from ..flash.file_programmer import FileProgrammer
-from ..utility.cmdline import convert_session_options
+from ..utility.cmdline import (
+    convert_session_options,
+    int_base_0,
+)
 
 LOG = logging.getLogger(__name__)
-
-def int_base_0(x):
-    """! @brief Converts a string to an int with support for base prefixes."""
-    return int(x, base=0)
 
 class FlashSubcommand(SubcommandBase):
     """! @brief `pyocd flash` subcommand."""

--- a/pyocd/subcommands/flash_cmd.py
+++ b/pyocd/subcommands/flash_cmd.py
@@ -30,7 +30,7 @@ def int_base_0(x):
     return int(x, base=0)
 
 class FlashSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd flash` subcommand."""
     
     NAMES = ['flash']
     HELP = "Program an image to device flash."

--- a/pyocd/subcommands/gdbserver_cmd.py
+++ b/pyocd/subcommands/gdbserver_cmd.py
@@ -37,7 +37,7 @@ from ..utility.notification import Notification
 LOG = logging.getLogger(__name__)
 
 class GdbserverSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd gdbserver` subcommand."""
     
     NAMES = ['gdbserver', 'gdb']
     HELP = "Run the gdb remote server(s)."

--- a/pyocd/subcommands/json_cmd.py
+++ b/pyocd/subcommands/json_cmd.py
@@ -29,7 +29,7 @@ from .. import __version__
 LOG = logging.getLogger(__name__)
 
 class JsonSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd json` subcommand."""
     
     NAMES = ['json']
     HELP = "Output information as JSON."

--- a/pyocd/subcommands/list_cmd.py
+++ b/pyocd/subcommands/list_cmd.py
@@ -28,7 +28,7 @@ from ..utility.cmdline import convert_session_options
 LOG = logging.getLogger(__name__)
 
 class ListSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd list` subcommand."""
     
     NAMES = ['list']
     HELP = "List information about probes, targets, or boards."

--- a/pyocd/subcommands/load_cmd.py
+++ b/pyocd/subcommands/load_cmd.py
@@ -28,11 +28,12 @@ from ..utility.cmdline import (
 
 LOG = logging.getLogger(__name__)
 
-class FlashSubcommand(SubcommandBase):
-    """! @brief `pyocd flash` subcommand."""
+class LoadSubcommand(SubcommandBase):
+    """! @brief `pyocd load` and `flash` subcommand."""
     
-    NAMES = ['flash']
-    HELP = "Program an image to device flash."
+    NAMES = ['load', 'flash']
+    HELP = "Load one or more images into target device memory."
+    EPILOG = "Supported file formats are: binary, Intel hex, and ELF32."
     DEFAULT_LOG_LEVEL = logging.WARNING
     
     ## @brief Valid erase mode options.
@@ -45,27 +46,32 @@ class FlashSubcommand(SubcommandBase):
     @classmethod
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
-        flash_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
+        parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
 
-        flash_options = flash_parser.add_argument_group("flash options")
-        flash_options.add_argument("-e", "--erase", choices=cls.ERASE_OPTIONS, default='sector',
+        parser_options = parser.add_argument_group("load options")
+        parser_options.add_argument("-e", "--erase", choices=cls.ERASE_OPTIONS, default='sector',
             help="Choose flash erase method. Default is sector.")
-        flash_options.add_argument("-a", "--base-address", metavar="ADDR", type=int_base_0,
-            help="Base address used for the address where to flash a binary. Defaults to start of flash.")
-        flash_options.add_argument("--trust-crc", action="store_true",
+        parser_options.add_argument("-a", "--base-address", metavar="ADDR", type=int_base_0,
+            help="Base address used for the address where to write a binary. Defaults to start of flash. "
+                 "Only allowed if a single binary file is being loaded.")
+        parser_options.add_argument("--trust-crc", action="store_true",
             help="Use only the CRC of each page to determine if it already has the same data.")
-        flash_options.add_argument("--format", choices=("bin", "hex", "elf"),
-            help="File format. Default is to use the file's extension.")
-        flash_options.add_argument("--skip", metavar="BYTES", default=0, type=int_base_0,
-            help="Skip programming the first N bytes. This can only be used with binary files.")
-        flash_options.add_argument("file", metavar="PATH",
-            help="File to program into flash.")
+        parser_options.add_argument("--format", choices=("bin", "hex", "elf"),
+            help="File format. Default is to use the file's extension. If multiple files are provided, then "
+                 "all must be of this type.")
+        parser_options.add_argument("--skip", metavar="BYTES", default=0, type=int_base_0,
+            help="Skip programming the first N bytes. Binary files only.")
+        parser_options.add_argument("file", metavar="<file-path>", nargs="+",
+            help="File to write to memory.")
         
-        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, flash_parser]
+        return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, parser]
     
     def invoke(self) -> int:
-        """! @brief Handle 'flash' subcommand."""
-        self._increase_logging(["pyocd.flash.loader"])
+        """! @brief Handle 'load' subcommand."""
+        self._increase_logging(["pyocd.flash.loader", __name__])
+        
+        # Validate arguments.
+        
         
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
@@ -80,16 +86,18 @@ class FlashSubcommand(SubcommandBase):
                             connect_mode=self._args.connect_mode,
                             options=convert_session_options(self._args.options))
         if session is None:
-            LOG.error("No device available to flash")
+            LOG.error("No target device available")
             return 1
         with session:
             programmer = FileProgrammer(session,
                             chip_erase=self._args.erase,
                             trust_crc=self._args.trust_crc)
-            programmer.program(self._args.file,
-                            base_address=self._args.base_address,
-                            skip=self._args.skip,
-                            file_format=self._args.format)
+            for filename in self._args.file:
+                LOG.info("Loading %s", filename)
+                programmer.program(filename,
+                                base_address=self._args.base_address,
+                                skip=self._args.skip,
+                                file_format=self._args.format)
 
         return 0
 

--- a/pyocd/subcommands/load_cmd.py
+++ b/pyocd/subcommands/load_cmd.py
@@ -61,7 +61,8 @@ class LoadSubcommand(SubcommandBase):
                  "all must be of this type.")
         parser_options.add_argument("--skip", metavar="BYTES", default=0, type=int_base_0,
             help="Skip programming the first N bytes. Binary files only.")
-        parser_options.add_argument("file", metavar="<file-path>", nargs="+",
+
+        parser.add_argument("file", metavar="<file-path>", nargs="+",
             help="File to write to memory.")
         
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, parser]

--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -166,7 +166,7 @@ class PackFindSubcommand(PackSubcommandBase):
         display_options.add_argument('-H', '--no-header', action='store_true',
             help="Don't print a table header.")
         
-        parser.add_argument("patterns", metavar="PATTERN", nargs='+',
+        parser.add_argument("patterns", metavar="<pattern>", nargs='+',
             help="Glob-style pattern for matching a target part number.")
         
         return [cls.CommonOptions.LOGGING, parser]
@@ -228,7 +228,7 @@ class PackInstallSubcommand(PackSubcommandBase):
         download_options.add_argument("-n", "--no-download", action='store_true',
             help="Just list the pack(s) that would be downloaded, don't actually download anything.")
         
-        parser.add_argument("patterns", metavar="PATTERN", nargs="+",
+        parser.add_argument("patterns", metavar="<pattern>", nargs="+",
             help="Glob-style pattern for matching a target part number.")
         
         return [cls.CommonOptions.LOGGING, parser]

--- a/pyocd/subcommands/reset_cmd.py
+++ b/pyocd/subcommands/reset_cmd.py
@@ -30,7 +30,7 @@ from ..utility.cmdline import (
 LOG = logging.getLogger(__name__)
 
 class ResetSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd reset` subcommand."""
     
     NAMES = ['reset']
     HELP = "Reset a device."

--- a/pyocd/subcommands/reset_cmd.py
+++ b/pyocd/subcommands/reset_cmd.py
@@ -25,6 +25,7 @@ from ..core.target import Target
 from ..utility.cmdline import (
     convert_session_options,
     convert_reset_type,
+    int_base_0,
     )
 
 LOG = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class ResetSubcommand(SubcommandBase):
     """! @brief `pyocd reset` subcommand."""
     
     NAMES = ['reset']
-    HELP = "Reset a device."
+    HELP = "Reset a target device."
     DEFAULT_LOG_LEVEL = logging.WARNING
     
     @classmethod
@@ -45,6 +46,11 @@ class ResetSubcommand(SubcommandBase):
         reset_options.add_argument("-m", "--method", default='hw', dest='reset_type', metavar="METHOD",
             help="Reset method to use (default, hw, sw, sysresetreq, vectreset, emulated). "
                  "'sw' is the default software reset for the target. Default is 'hw'.")
+        reset_options.add_argument("-c", "--core", default=0, type=int_base_0,
+            help="Core number used to perform software reset. Only applies to software reset methods."
+                 "Default is core 0.")
+        reset_options.add_argument("-l", "--halt", action="store_true",
+            help="Halt the core on the first instruction after reset. Defaults to disabled.")
         
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, reset_parser]
     
@@ -70,12 +76,12 @@ class ResetSubcommand(SubcommandBase):
                             connect_mode=self._args.connect_mode,
                             options=convert_session_options(self._args.options))
         if session is None:
-            LOG.error("No device available to reset")
+            LOG.error("No target device available to reset")
             sys.exit(1)
         try:
             # Handle hw reset specially using the probe, so we don't need a valid connection
-            # and can skip discovery.
-            is_hw_reset = the_reset_type == Target.ResetType.HW
+            # and can skip discovery. If we're halting we need a connection even if performing a hardware reset.
+            is_hw_reset = (the_reset_type == Target.ResetType.HW) and not self._args.halt
             
             # Only init the board if performing a sw reset.
             session.open(init_board=(not is_hw_reset))
@@ -84,7 +90,11 @@ class ResetSubcommand(SubcommandBase):
             if is_hw_reset:
                 session.probe.reset()
             else:
-                session.target.reset(reset_type=the_reset_type)
+                session.selected_core = self._args.core
+                if self._args.halt:
+                    session.target.reset_and_halt(reset_type=the_reset_type)
+                else:
+                    session.target.reset(reset_type=the_reset_type)
             LOG.info("Done.")
         finally:
             session.close()

--- a/pyocd/subcommands/server_cmd.py
+++ b/pyocd/subcommands/server_cmd.py
@@ -28,7 +28,7 @@ from ..probe.tcp_probe_server import DebugProbeServer
 LOG = logging.getLogger(__name__)
 
 class ServerSubcommand(SubcommandBase):
-    """! @brief Base class for pyocd command line subcommand."""
+    """! @brief `pyocd server` subcommand."""
     
     NAMES = ['server']
     HELP = "Run debug probe server."

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -165,3 +165,13 @@ def convert_frequency(value: str) -> int:
     else:
         return int(float(value))
 
+
+def int_base_0(x: str) -> int:
+    """! @brief Converts a string to an int with support for base prefixes."""
+    return int(x, base=0)
+
+
+def flatten_args(args: Iterable[Iterable[Any]]) -> List[Any]:
+    """! @brief Converts a list of lists to a single list."""
+    return [item for sublist in args for item in sublist]
+

--- a/pyocd/utility/progress.py
+++ b/pyocd/utility/progress.py
@@ -82,12 +82,12 @@ class ProgressReportTTY(ProgressReport):
     """
 
     ## These width constants can't be changed yet without changing the code below to match.
-    WIDTH = 20
+    WIDTH = 50
     
     def _update(self, progress):
         self._file.write('\r')
         i = int(progress * self.WIDTH)
-        self._file.write("[%-20s] %3d%%" % ('=' * i, round(progress * 100)))
+        self._file.write("[%-50s] %3d%%" % ('=' * i, round(progress * 100)))
         self._file.flush()
 
     def _finish(self):

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup(
         'capstone>=4.0,<5.0',
         'cmsis-pack-manager>=0.2.10',
         'colorama<1.0',
+        'dataclasses;python_version<"3.7"', # Need backport for Python 3.6
         'hidapi;platform_system!="Linux"', # Use hidapi on macOS and Windows
         'intelhex>=2.0,<3.0',
         'intervaltree>=3.0.2,<4.0',


### PR DESCRIPTION
The main purpose of this change is to replace the `flash` subcommand with `load` (keeping `flash` as an alias), and support loading of files to RAM or other writable memories in addition to flash.

Along with RAM loading come a couple other new features. Multiple files may be passed to `load`. And binary files may have a base address suffix like `myapp.bin@0x20000`.

Some related command line cleanup and improvements are included:
- Memory programming progress base is increased in size.
- The architectural Cortex-M memory map is used for the default `cortex_m` target type.
- The `reset` subcommand accepts `--core` and `--halt` arguments.
- Normalised positional arguments description in usage text.
