### PR TITLE
CoreSightTarget reset halt param and layer violation fixes

### DIFF
--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -129,7 +129,6 @@ class SoCTarget(Target, GraphNode):
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
             core.disconnect(resume)
-        self.dp.power_down_debug()
         self.call_delegate('did_disconnect', target=self, resume=resume)
 
     @property
@@ -206,7 +205,7 @@ class SoCTarget(Target, GraphNode):
         return self.selected_core.remove_watchpoint(addr, size, type)
 
     def reset(self, reset_type=None):
-        # Perform a hardware reset if there is not a core.
+        # Use the probe to reset to perform a hardware reset if there is not a core.
         if self.selected_core is None:
             # Use the probe to reset. (We can't use the DP here because that's a class layering violation;
             # the DP is only created by the CoreSightTarget subclass.)

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -109,7 +109,7 @@ class CoreSightTarget(SoCTarget):
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
             core.disconnect(resume)
-        self.dp.power_down_debug()
+        self.dp.disconnect()
         self.call_delegate('did_disconnect', target=self, resume=resume)
             
     def create_discoverer(self):

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -99,6 +99,18 @@ class CoreSightTarget(SoCTarget):
             )
         
         return seq
+
+    def disconnect(self, resume=True):
+        """! @brief Disconnect from the target.
+        
+        Same as SoCTarget.disconnect(), except that it asks the DebugPort to power down.
+        """
+        self.session.notify(Target.Event.PRE_DISCONNECT, self)
+        self.call_delegate('will_disconnect', target=self, resume=resume)
+        for core in self.cores.values():
+            core.disconnect(resume)
+        self.dp.power_down_debug()
+        self.call_delegate('did_disconnect', target=self, resume=resume)
             
     def create_discoverer(self):
         """! @brief Init task to create the discovery object.
@@ -250,11 +262,11 @@ class CoreSightTarget(SoCTarget):
     # Override this method from SoCTarget so we can use the DP for hardware resets when there isn't a
     # valid core (instead of the probe), so reset notifications will be sent. We can't use the DP in
     # SoCTarget because it is only created by this class.
-    def reset(self, reset_type=None, halt=False):
-        # Perform a hardware reset if there is not a core.
-        if self.selected_core is None:
-            # Use the probe to reset if the DP doesn't exist yet.
+    def reset(self, reset_type=None):
+        # Use the DP to reset if there is not a core.
+        if (self.selected_core is None) and (self.dp is not None):
             self.dp.reset()
-            return
-        self.selected_core.reset(reset_type, halt)
-
+        else:
+            super().reset(reset_type)
+    
+        

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -339,6 +339,13 @@ class DebugPort:
         """
         self._protocol = protocol
         self.create_connect_sequence().invoke()
+    
+    def disconnect(self):
+        """! @brief Disconnect from target.
+        
+        DP debug is powered down. See power_down_debug().
+        """
+        self.power_down_debug()
 
     def create_connect_sequence(self):
         """! @brief Returns call sequence to connect to the target.


### PR DESCRIPTION
This PR has three changes in related areas:
- An extra `halt` parameter from another commit accidentally got introduced into `CoreSightTarget.reset()` during a rebase.
- Fix for layer violation of accessing the `dp` attribute from `SoCTarget`, even though this attribute is only created by the subclass `CoreSightTarget`.
- Add a `disconnect()` method to `DebugPort` so that `CoreSightTarget` isn't assuming knowledge of what happens when disconnecting a DP.