### PR TITLE
Add work-around for incorrectly reported DAP version in microchip EDBG

### DIFF
--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -25,7 +25,7 @@ from .dap_settings import DAPSettings
 from .dap_access_api import DAPAccessIntf
 from .cmsis_dap_core import CMSISDAPProtocol
 from .interface import (INTERFACE, USB_BACKEND, USB_BACKEND_V2)
-from .interface.common import ARM_DAPLINK_ID
+from .interface.common import ARM_DAPLINK_ID, MICROCHIP_EDBG
 from .cmsis_dap_core import (
     Command,
     Pin,
@@ -601,6 +601,8 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         # version number for DAP_INFO_FW_VER instead of the CMSIS-DAP version, due to a misunderstanding
         # based on unclear documentation.
         elif (self._vidpid == ARM_DAPLINK_ID) and (fw_version_str in ("0254", "0255", "0256")):
+            self._cmsis_dap_version = CMSISDAPVersion.V2_0_0
+        elif (self._vidpid == MICROCHIP_EDBG) and (fw_version_str == "03.25.01B6"):
             self._cmsis_dap_version = CMSISDAPVersion.V2_0_0
         else:
             # Convert the version to a single BCD value for easy comparison.

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -36,6 +36,7 @@ CMSIS_DAP_USB_CLASSES = [
 CMSIS_DAP_HID_USAGE_PAGE = 0xff00
 
 # Known USB VID/PID pairs.
+MICROCHIP_EDBG = (0x03eb, 0x2111) # Microchip EDBG (as used on xplained pro boards)
 ARM_DAPLINK_ID = (0x0d28, 0x0204) # Arm DAPLink firmware
 ATMEL_ICE_ID = (0x03eb, 0x2141) # Atmel-ICE
 CYPRESS_KITPROG1_2_ID = (0x04b4, 0xf138) # Cypress KitProg1, KitProg2 in CMSIS-DAP mode


### PR DESCRIPTION
Addresses issue #1143, by adding an exception for the Microchip EDBG firmware (found on xplained pro boards) which incorrectly reports some number -- I assume a firmware version for EDBG -- instead of the DAP protocol version in the DAP_Info command.