### PR TITLE
Handle invalid CMSIS-DAP protocol versions

### DIFF
--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import (Set, Tuple)
+
 from .dap_access_api import DAPAccessIntf
 
 class Command:
@@ -77,7 +79,8 @@ INTEGER_INFOS = [
 class CMSISDAPVersion:
     """! @brief Known CMSIS-DAP versions.
 
-    The tuple fields are major, minor, patch.
+    The tuple fields are major, minor, patch. Generally, patch release versions are excluded from this
+    list, unless there is a specific reason to know about a particular patch release.
     """
     V1_0_0 = (1, 0, 0)
     V1_1_0 = (1, 1, 0)
@@ -85,6 +88,14 @@ class CMSISDAPVersion:
     V1_3_0 = (1, 3, 0)
     V2_0_0 = (2, 0, 0)
     V2_1_0 = (2, 1, 0)
+
+    @classmethod
+    def minor_versions(cls) -> Set[Tuple[int, int]]:
+        """@brief Returns a set of minor version tuples."""
+        return {
+            v[:2] for k, v in cls.__dict__.items()
+            if k.startswith('V')
+            }
 
 DAP_DEFAULT_PORT = 0
 DAP_SWD_PORT = 1


### PR DESCRIPTION
Some CMSIS-DAP compatible debug probes return their own firmware version from DAP_Info value 0x04, rather than the expected CMSIS-DAP protocol version (mostly due to misleading documentation).

Two approaches are used to handle invalid CMSIS-DAP protocol versions:

- Catch exceptions from attempting to parse versions that have non-numeric characters.
- Check the major.minor of the parsed version against all known CMSIS-DAP protocol versions.

If either check fails then the protocol version defaults to v1.0.0. Currently this doesn't have any real impact. The only place the version is used in pyocd is to check for the availability of the DAP_Info firmware version value 0x09 added in CMSIS-DAP v2.1 (in response to the documentation issues causing this trouble in the first place).
