### PR TITLE
Packaging: dependency version bumps and classifier update.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development
     Topic :: Software Development :: Debuggers
     Topic :: Software Development :: Embedded Systems
@@ -43,16 +44,16 @@ install_requires =
     cmsis-pack-manager>=0.3.0
     colorama<1.0
     dataclasses; python_version < "3.7"
-    hidapi; platform_system != "Linux"
+    hidapi>=0.10.1,<1.0; platform_system != "Linux"
     intelhex>=2.0,<3.0
     intervaltree>=3.0.2,<4.0
     naturalsort>=1.5,<2.0
     prettytable>=2.0,<3.0
     pyelftools<1.0
-    pylink-square>=0.8.2,<1.0
+    pylink-square>=0.11.1,<1.0
     pyocd_pemicro>=1.0.6
     pyusb>=1.2.1,<2.0
-    pyyaml>=5.1,<6.0
+    pyyaml>=6.0,<7.0
     six>=1.15.0,<2.0
 
 [options.extras_require]


### PR DESCRIPTION
- Bump minimum pyyaml version to 6.0, maximum <7.0.
- Set minimum version for hidapi.
- Increment pylink-square minimum to 0.11.1.
- Add Python 3.10 to classifiers.