### PR TITLE
Packaging: bump cmsis-pack-manager to v0.4.0 release.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ python_requires = >=3.6.0
 # Use hidapi on macOS and Windows, not needed on Linux.
 install_requires =
     capstone>=4.0,<5.0
-    cmsis-pack-manager>=0.3.0
+    cmsis-pack-manager>=0.4.0,<1.0
     colorama<1.0
     dataclasses; python_version < "3.7"
     hidapi>=0.10.1,<1.0; platform_system != "Linux"


### PR DESCRIPTION
This also restricts CPM to <1.0.