### PR TITLE
STLink: use command to read board ID faster.

### DIFF
--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,10 +57,20 @@ class Commands:
     JTAG_WRITE_DAP_REG = 0x46 # From V2J24
     JTAG_READMEM_16BIT = 0x47 # From V2J26
     JTAG_WRITEMEM_16BIT = 0x48 # From V2J26
+    JTAG_BLINK_LED = 0x49 # From V2J28
+    JTAG_GET_DISK_NAME = 0x4a # From V2J28
     JTAG_INIT_AP = 0x4b # From V2J28
     JTAG_CLOSE_AP_DBG = 0x4c # From V2J28
+    JTAG_WRITEMEM_32BIT_NO_ADDR_INC = 0x50 # From V2J26
+    JTAG_READWRITEMISC_OUT = 0x51 # From V2J32 or from V3J2
+    JTAG_READWRITEMISC_IN  = 0x52 # Internal from V2J32 or from V3J2
+    JTAG_READWRITEMISC_GET_MAX = 0x53 # Internal from V2J32 or from V3J2
+    JTAG_READMEM_32BIT_NO_ADDR_INC = 0x54 # From V2J32 or from V3J2
+    JTAG_WRITE_DFTREG = 0x55 # From V2J35 or from V3J5
+    JTAG_GET_BOARD_IDENTIFIERS = 0x56 # From V2J36 or from V3J6
     SET_COM_FREQ = 0x61 # V3 only, replaces SWD/JTAG_SET_FREQ
     GET_COM_FREQ = 0x62 # V3 only
+    SWITCH_STLINK_FREQ = 0x63 # V3 only
     
     # Parameters for JTAG_ENTER2.
     JTAG_ENTER_SWD = 0xa3
@@ -78,7 +89,7 @@ class Commands:
     JTAG_STLINK_SWD_COM = 0x00
     JTAG_STLINK_JTAG_COM = 0x01
     
-class Status(object):
+class Status:
     """!
     @brief STLink status codes and messages.
     """

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -186,11 +186,11 @@ class STLink(object):
         # Check versions.
         if self._jtag_version == 0:
             raise exceptions.ProbeError(f"{self._version_str} firmware does not support JTAG/SWD. Please update"
-                "to a firmware version that supports JTAG/SWD")
+                "to a firmware version that supports JTAG/SWD.")
         if not self._check_version(self.MIN_JTAG_VERSION):
             raise exceptions.ProbeError(f"STLink {self.serial_number} is using an unsupported, older firmware version. "
                 f"Please update to the latest STLink firmware. Current version is {self._version_str}, must be at "
-                f"least version v2J{self.MIN_JTAG_VERSION}.)")
+                f"least version v2J{self.MIN_JTAG_VERSION}.")
 
     def _check_version(self, min_version):
         return (self._hw_version >= 3) or (self._jtag_version >= min_version)


### PR DESCRIPTION
This PR changes the STLink probe driver to attempt to send the `JTAG_GET_BOARD_IDENTIFIERS` command to get the board ID. This command is available starting with STLink firmware versions V2J36 and V3J6. If the command is not available or fails, it will fall back to reading the board ID from the `mbed.htm` file on the MSD volume (which takes much longer).

Also included are some missing command ID constants, Python 3 code cleanup, some type annotations, and type error fixes.