### PR TITLE
Use libusb-package as wrapper around pyusb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,22 +141,6 @@ You have a few options here:
 4. Run the command in a [virtualenv](https://virtualenv.pypa.io/en/latest/)
    local to a specific project working set.
 
-### libusb installation
-
-[pyusb](https://github.com/pyusb/pyusb) and its backend library [libusb](https://libusb.info/) are
-dependencies on all supported operating systems. pyusb is a regular Python package and will be
-installed along with pyOCD. However, libusb is a binary shared library that does not get installed
-automatically via pip dependency management.
-
-How to install libusb depends on your OS:
-
-- macOS: use Homebrew: `brew install libusb`
-- Linux and BSD: should already be installed.
-- Windows: download libusb from [libusb.info](https://libusb.info/) and place the .dll file in your Python
-  installation folder next to python.exe. Make sure to use the same 32- or 64-bit architecture as
-  your Python installation. The latest release is [available on GitHub](https://github.com/libusb/libusb/releases);
-  download the .7z archive under Assets. Use the library from the VS2019 folder in the archive.
-
 ### udev rules on Linux
 
 On Linux, particularly Ubuntu 16.04+, you must configure udev rules to allow pyOCD to access debug

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -41,24 +41,6 @@ For notes about installing and using on non-x86 systems such as Raspberry Pi, se
 [relevant documentation]({% link _docs/installing_on_non_x86.md %}).
 
 
-libusb installation
--------------------
-
-[pyusb](https://github.com/pyusb/pyusb) and its backend library [libusb](https://libusb.info/) are
-dependencies on all supported operating systems. pyusb is a regular Python package and will be
-installed along with pyOCD. However, libusb is a binary shared library that does not get installed
-automatically via pip dependency management.
-
-How to install libusb depends on your OS:
-
-- macOS: use Homebrew: `brew install libusb`
-- Linux: should already be installed.
-- Windows: download libusb from [libusb.info](https://libusb.info/) and place the .dll file in your Python
-  installation folder next to python.exe. Make sure to use the same 32- or 64-bit architecture as
-  your Python installation. The latest release is [available on GitHub](https://github.com/libusb/libusb/releases);
-  download the .7z archive under Assets. Use the library from the VS2019 folder in the archive.
-
-
 udev rules on Linux
 -------------------
 

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -19,6 +19,7 @@ from array import array
 
 from time import sleep
 from usb import core, util
+import libusb_package
 
 import platform
 import errno
@@ -107,7 +108,7 @@ class PicoLink(object):
         """! @brief Find and return all Picoprobes """
         try:
             # Use a custom matcher to make sure the probe is a Picoprobe and accessible.
-            return [PicoLink(probe) for probe in core.find(find_all=True, custom_match=FindPicoprobe(uid))]
+            return [PicoLink(probe) for probe in libusb_package.find(find_all=True, custom_match=FindPicoprobe(uid))]
         except core.NoBackendError:
             show_no_libusb_warning()
             return []

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -35,6 +35,7 @@ from ..dap_access_api import DAPAccessIntf
 LOG = logging.getLogger(__name__)
 
 try:
+    import libusb_package
     import usb.core
     import usb.util
 except ImportError:
@@ -68,7 +69,7 @@ class PyUSB(Interface):
         assert self.closed is True
 
         # Get device handle
-        dev = usb.core.find(custom_match=FindDap(self.serial_number))
+        dev = libusb_package.find(custom_match=FindDap(self.serial_number))
         if dev is None:
             raise DAPAccessIntf.DeviceError("Device %s not found" % self.serial_number)
 
@@ -153,7 +154,7 @@ class PyUSB(Interface):
         """
         # find all cmsis-dap devices
         try:
-            all_devices = usb.core.find(find_all=True, custom_match=FindDap())
+            all_devices = libusb_package.find(find_all=True, custom_match=FindDap())
         except usb.core.NoBackendError:
             if not PyUSB.did_show_no_libusb_warning:
                 LOG.warning("CMSIS-DAPv1 probes may not be detected because no libusb library was found.")

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -36,6 +36,7 @@ from ... import common
 LOG = logging.getLogger(__name__)
 
 try:
+    import libusb_package
     import usb.core
     import usb.util
 except ImportError:
@@ -78,7 +79,7 @@ class PyUSBv2(Interface):
         assert self.closed is True
 
         # Get device handle
-        dev = usb.core.find(custom_match=HasCmsisDapv2Interface(self.serial_number))
+        dev = libusb_package.find(custom_match=HasCmsisDapv2Interface(self.serial_number))
         if dev is None:
             raise DAPAccessIntf.DeviceError("Device %s not found" %
                                             self.serial_number)
@@ -176,7 +177,7 @@ class PyUSBv2(Interface):
         """! @brief Returns all the connected devices with a CMSIS-DAPv2 interface."""
         # find all cmsis-dap devices
         try:
-            all_devices = usb.core.find(find_all=True, custom_match=HasCmsisDapv2Interface())
+            all_devices = libusb_package.find(find_all=True, custom_match=HasCmsisDapv2Interface())
         except usb.core.NoBackendError:
             common.show_no_libusb_warning()
             return []

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import libusb_package
 import usb.core
 import usb.util
 import logging
@@ -96,7 +97,7 @@ class STLinkUSBInterface:
     @classmethod
     def get_all_connected_devices(cls):
         try:
-            devices = usb.core.find(find_all=True, custom_match=cls._usb_match)
+            devices = libusb_package.find(find_all=True, custom_match=cls._usb_match)
         except usb.core.NoBackendError:
             common.show_no_libusb_warning()
             return []

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,7 @@ install_requires =
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
     intelhex>=2.0,<3.0
     intervaltree>=3.0.2,<4.0
+    libusb-package>=1.0,<2.0
     naturalsort>=1.5,<2.0
     prettytable>=2.0,<3.0
     pyelftools<1.0


### PR DESCRIPTION
Replace direct use of `usb.core.find()` with `libusb_package.find()`. This will use the version of libusb included with [libusb_package](https://github.com/pyocd/libusb-package) by default. The benefit is that users no longer have to install libusb manually, and on Linux a recent version of libusb is guaranteed.