### PR TITLE
Gdbserver fault resilience

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -396,6 +396,15 @@ Whether to enable SWV printf output over the semihosting console. Requires the <
 option to be set. The SWO baud rate can be controlled with the <tt>swv_clock</tt> option.
 </td></tr>
 
+<tr><td>debug.status_fault_retry_timeout</td>
+<td>float</td>
+<td>1</td>
+<td>
+Duration in seconds that a failed target status check will be retried before an error is raised. Only
+applies while the target is running after a resume operation in the debugger and pyOCD is waiting for
+it to halt again.
+</td></tr>
+
 <tr><td>gdbserver_port</td>
 <td>int</td>
 <td>3333</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -133,6 +133,10 @@ BUILTIN_OPTIONS = [
         "Whether to enable SWV printf output over the semihosting console. Requires the "
         "swv_system_clock option to be set. The SWO baud rate can be controlled with the "
         "swv_clock option."),
+    OptionInfo('debug.status_fault_retry_timeout', float, 1.0,
+        "Duration in seconds that a failed target status check will be retried before an error is raised. "
+        "Only applies while the target is running after a resume operation in the debugger and pyOCD is waiting "
+        "for it to halt again."),
     OptionInfo('gdbserver_port', int, 3333,
         "Base TCP port for the gdbserver."),
     OptionInfo('persist', bool, False,


### PR DESCRIPTION
When the gdbserver has resumed the target and is waiting for it to halt (for instance from a breakpoint), don't immediately report an error on a fault from the `DHCSR` read. Instead, a timeout timer is started for a configurable length of time via the `debug.status_fault_retry_timeout` option. Only if faults continue to be returned for the timeout duration will an error be reported to gdb (and an attempt made to halt the target).

This is primarily intended for the use case of a target temporarily going into a low power state. However, the timeout default is set to 1 second so as to be close to the current behaviour—and because only the user knows if faults are really expected for an extended period.

There are many improvements that can be made to this initial change. For one, if the connection to the DP is lost it is not re-established (which partially negates the low power use case for some targets depending on which low power state is entered…).