### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pyocd/coresight/sdc600.py
+++ b/pyocd/coresight/sdc600.py
@@ -57,7 +57,7 @@ class SDC600(CoreSightComponent):
         """! @brief COM Port link phases."""
         ## Hardware-defined link phase.
         PHASE1 = 1
-        ## Software-defiend link phase.
+        ## Software-defined link phase.
         PHASE2 = 2
     
     class Register:

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -116,7 +116,7 @@ class DebugProbe(object):
         
         @param cls The class instance.
         @param unique_id String. Optional partial unique ID value used to filter available probes. May be used by the
-            probe to optimize retreiving the probe list; there is no requirement to filter the results.
+            probe to optimize retrieving the probe list; there is no requirement to filter the results.
         @param is_explicit Boolean. Whether the probe type was explicitly specified in the unique ID. This
             can be used, for instance, to specially interpret the unique ID as an IP address or
             domain name when the probe class was specifically requested but not for general lists
@@ -315,7 +315,7 @@ class DebugProbe(object):
         """! @brief Assert or de-assert target's nRESET signal.
         
         Because nRESET is negative logic and usually open drain, passing True will drive it low, and
-        pasing False will stop driving so nRESET will be pulled up.
+        passing False will stop driving so nRESET will be pulled up.
         """
         raise NotImplementedError()
     

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -438,7 +438,7 @@ class Picoprobe(DebugProbe):
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
         """
-        # Init leghts to pack and cmd queue
+        # Init lengths to pack and cmd queue
         reads_lengths = []
         self._link.start_queue()
         # Take each sequence 'seq' in sequences

--- a/test/gdb_test_script.py
+++ b/test/gdb_test_script.py
@@ -498,7 +498,7 @@ def post_interrupt_task(interrupt_arg):
     gdb.post_event(interrupt_task)
 
 
-# Run the main test by repreatedly calling the generator
+# Run the main test by repeatedly calling the generator
 # This must only run on GDB's queue
 def run_generator(event):
     global ignore_events


### PR DESCRIPTION
There are small typos in:
- pyocd/coresight/sdc600.py
- pyocd/probe/debug_probe.py
- pyocd/probe/picoprobe.py
- test/gdb_test_script.py

Fixes:
- Should read `retrieving` rather than `retreiving`.
- Should read `repeatedly` rather than `repreatedly`.
- Should read `passing` rather than `pasing`.
- Should read `lengths` rather than `leghts`.
- Should read `defined` rather than `defiend`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md