### PR TITLE
Cleanup trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,14 +1,27 @@
+# EditorConfig: https://editorconfig.org/
+
 # top-most EditorConfig file
 root = true
 
 # Unix-style newlines with a newline ending every file
+# 4 space indentation for all files
+# No trailing whitespace
 [*]
-end_of_line = lf
-insert_final_newline = true
 charset = utf-8
-
-# 4 space indentation for Python
-[*.py]
 indent_style = space
 indent_size = 4
-trim_trailing_whitespace = false
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 120
+
+# Exceptions to the rule...
+
+[Makefile]
+indent_style = tab
+
+[*.bat]
+end_of_line = crlf
+
+[*.{yaml,yml,xml,svd}]
+indent_size = 2

--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -51,9 +51,9 @@ LOG = logging.getLogger("pyocd.tool")
 class PyOCDTool(SubcommandBase):
     """! @brief Main class for the pyocd tool and subcommands.
     """
-    
+
     HELP = "PyOCD debug tools for Arm Cortex devices"
-    
+
     ## List of subcommand classes.
     SUBCOMMANDS = [
         CommanderSubcommand,
@@ -67,7 +67,7 @@ class PyOCDTool(SubcommandBase):
         ServerSubcommand,
         RTTSubcommand,
         ]
-    
+
     ## @brief Logging level names.
     LOG_LEVEL_NAMES = {
             'debug': logging.DEBUG,
@@ -91,21 +91,21 @@ class PyOCDTool(SubcommandBase):
         parser.add_argument('-V', '--version', action='version', version=__version__)
         parser.add_argument('--help-options', action='store_true',
             help="Display available session options.")
-            
+
         self.add_subcommands(parser)
 
         return parser
 
     def _setup_logging(self) -> None:
         """! @brief Configure the logging module.
-        
+
         The quiet and verbose argument counts are used to set the log verbosity level.
-        
+
         Log level for specific loggers are also configured here.
         """
         level = max(1, self._args.command_class.DEFAULT_LOG_LEVEL + self._get_log_level_delta())
         logging.basicConfig(level=level, format=LOG_FORMAT)
-        
+
         # Handle settings for individual loggers from --log-level arguments.
         for logger_setting in self._args.log_level:
             try:
@@ -131,7 +131,7 @@ class PyOCDTool(SubcommandBase):
         else:
             self._parser.print_help()
         return 0
-    
+
     def __call__(self, *args: Any, **kwds: Any) -> "PyOCDTool":
         """! @brief Hack to allow the root command object instance to be used as default command class."""
         return self
@@ -140,13 +140,13 @@ class PyOCDTool(SubcommandBase):
         """! @brief Main entry point for command line processing."""
         try:
             self._args = self._parser.parse_args(args)
-            
+
             self._setup_logging()
-            
+
             # Pass any options to DAPAccess.
             if hasattr(self._args, 'daparg'):
                 DAPAccess.set_args(self._args.daparg)
-            
+
             # Create an instance of the subcommand and invoke it.
             cmd = self._args.command_class(self._args)
             status = cmd.invoke()
@@ -161,7 +161,7 @@ class PyOCDTool(SubcommandBase):
         except Exception as e:
             LOG.critical("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
             return 1
-    
+
     def show_options_help(self) -> None:
         """! @brief Display help for session options."""
         for info_name in sorted(options.OPTIONS_INFO.keys()):

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -30,15 +30,15 @@ class Board(GraphNode):
     """
     def __init__(self, session, target=None):
         super(Board, self).__init__()
-        
+
         # Use the session option if no target type was given to us.
         if target is None:
             target = session.options.get('target_override')
-        
+
         # As a last resort, default the target to 'cortex_m'.
         if target is None:
             target = 'cortex_m'
-        
+
             # Log a helpful warning when defaulting to the generic cortex_m target.
             if session.options.get('warning.cortex_m_default'):
                 LOG.warning("Generic 'cortex_m' target type is selected by default; is this "
@@ -48,10 +48,10 @@ class Board(GraphNode):
                             "targets types.")
 
         assert target is not None
-        
+
         # Convert dashes to underscores in the target type, and convert to lower case.
         target = target.replace('-', '_').lower()
-        
+
         # Write the effective target type back to options if it's different.
         if target != session.options.get('target_override'):
             session.options['target_override'] = target
@@ -61,7 +61,7 @@ class Board(GraphNode):
         self._test_binary = session.options.get('test_binary')
         self._delegate = None
         self._inited = False
-        
+
         # Create targets from provided CMSIS pack.
         if session.options['pack'] is not None:
             pack_target.PackTargets.populate_targets_from_pack(session.options['pack'])
@@ -79,10 +79,10 @@ class Board(GraphNode):
                 "available target types. "
                 "See <https://github.com/pyocd/pyOCD/blob/master/docs/target_support.md> "
                 "for how to install additional target support.") from exc
-        
+
         # Tell the user what target type is selected.
         LOG.info("Target type is %s", self._target_type)
-        
+
         self.add_child(self.target)
 
     def init(self):
@@ -90,15 +90,15 @@ class Board(GraphNode):
         # If we don't have a delegate set yet, see if there is a session delegate.
         if (self.delegate is None) and (self.session.delegate is not None):
             self.delegate = self.session.delegate
-        
+
         # Delegate pre-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'will_connect'):
             self.delegate.will_connect(board=self)
-        
+
         # Init the target.
         self.target.init()
         self._inited = True
-        
+
         # Delegate post-init hook.
         if (self.delegate is not None) and hasattr(self.delegate, 'did_connect'):
             self.delegate.did_connect(board=self)
@@ -117,31 +117,31 @@ class Board(GraphNode):
     @property
     def session(self):
         return self._session
-    
+
     @property
     def delegate(self):
         return self._delegate
-    
+
     @delegate.setter
     def delegate(self, the_delegate):
         self._delegate = the_delegate
-        
+
     @property
     def unique_id(self):
         return self.session.probe.unique_id
-    
+
     @property
     def target_type(self):
         return self._target_type
-    
+
     @property
     def test_binary(self):
         return self._test_binary
-    
+
     @property
     def name(self):
         return "generic"
-    
+
     @property
     def description(self):
         return "Generic board via " + self.session.probe.vendor_name + " " \

--- a/pyocd/board/mbed_board.py
+++ b/pyocd/board/mbed_board.py
@@ -22,7 +22,7 @@ LOG = logging.getLogger(__name__)
 
 class MbedBoard(Board):
     """! @brief Mbed board class.
-    
+
     This class inherits from Board and is specific to mbed boards. Particularly, this class
     will dynamically determine the type of connected board based on the board ID encoded in
     the debug probe's serial number. If the board ID is all "0" characters, it indicates the
@@ -30,7 +30,7 @@ class MbedBoard(Board):
     """
     def __init__(self, session, target=None, board_id=None):
         """! @brief Constructor.
-        
+
         This constructor attempts to use the board ID from the serial number to determine
         the target type. See #BOARD_ID_TO_INFO.
         """
@@ -38,7 +38,7 @@ class MbedBoard(Board):
         unique_id = session.probe.unique_id
         if board_id is None:
             board_id = unique_id[0:4]
-        
+
         # Check for null board ID. This indicates a standalone probe or generic firmware.
         if board_id == "0000":
             board_info = None

--- a/pyocd/cache/memory.py
+++ b/pyocd/cache/memory.py
@@ -26,19 +26,19 @@ LOG = logging.getLogger(__name__)
 
 class MemoryCache(object):
     """! @brief Memory cache.
-    
+
     Maintains a cache of target memory. The constructor is passed a backing DebugContext object that
     will be used to fill the cache.
-    
+
     The cache is invalidated whenever the target has run since the last cache operation (based on run
     tokens). If the target is currently running, all accesses cause the cache to be invalidated.
-    
+
     The target's memory map is referenced. All memory accesses must be fully contained within a single
     memory region, or a TransferFaultError will be raised. However, if an access is outside of all regions,
     the access is passed to the underlying context unmodified. When an access is within a region, that
     region's cacheability flag is honoured.
     """
-    
+
     def __init__(self, context, core):
         self._context = context
         self._core = core
@@ -143,11 +143,11 @@ class MemoryCache(object):
 
     def _merge_data(self, combined, addr, size):
         """! @brief Extracts data from the intersection of an address range across a list of interval objects.
-        
+
         The range represented by @a addr and @a size are assumed to overlap the intervals. The first
         and last interval in the list may have ragged edges not fully contained in the address range, in
         which case the correct slice of those intervals is extracted.
-        
+
         @param self
         @param combined List of Interval objects forming a contiguous range. The @a data attribute of
           each interval must be a bytearray.
@@ -165,7 +165,7 @@ class MemoryCache(object):
             endOffset = offset + size
             result = combined[0].data[offset:endOffset]
             return result
-        
+
         # Take slice of leading ragged edge.
         if len(combined) and combined[0].begin < addr:
             offset = addr - combined[0].begin

--- a/pyocd/cache/register.py
+++ b/pyocd/cache/register.py
@@ -24,20 +24,20 @@ LOG = logging.getLogger(__name__)
 
 class RegisterCache(object):
     """! @brief Cache of a core's register values.
-    
+
     The only interesting part of this cache is how it handles the special registers: CONTROL,
     FAULTMASK, BASEPRI, PRIMASK, and CFBP. The values of the first four registers are read and written
     all at once as the CFBP register through the hardware DCRSR register. On reads of any of these
     registers, or the combined CFBP, the cache will ask the underlying context to read CFBP. It will
     then update the cache entries for all five registers. Writes to any of these registers just
     invalidate all five.
-    
+
     Same logic applies for XPSR submasks.
     """
 
     CFBP_INDEX = index_for_reg('cfbp')
     XPSR_INDEX = index_for_reg('xpsr')
-    
+
     CFBP_REGS = [index_for_reg(name) for name in [
                 'cfbp',
                 'control',
@@ -116,7 +116,7 @@ class RegisterCache(object):
                 read_list.append(self.XPSR_INDEX)
             xpsr_index = read_list.index(self.XPSR_INDEX)
         self._metrics.misses += len(read_list)
-        
+
         # Read registers not in the cache from the target.
         if read_list:
             try:

--- a/pyocd/commands/base.py
+++ b/pyocd/commands/base.py
@@ -29,7 +29,7 @@ ALL_COMMANDS = {}
 
 class CommandMeta(type):
     """! @brief Metaclass for commands.
-    
+
     Examines the `INFO` attribute of the command class and builds the @ref pyocd.commands.commands.ALL_COMMANDS
     "ALL_COMMANDS" table.
     """
@@ -37,11 +37,11 @@ class CommandMeta(type):
     def __new__(mcs, name, bases, dict):
         # Create the new type.
         new_type = type.__new__(mcs, name, bases, dict)
-        
+
         # The Command base class won't have an INFO.
         if 'INFO' in dict:
             info = dict['INFO']
-            
+
             # Validate the INFO dict.
             assert (('names' in info)
                     and ('group' in info)
@@ -49,14 +49,14 @@ class CommandMeta(type):
                     and ('help' in info)
                     and ((('nargs' in info) and ('usage' in info)) # Required for commands.
                         or ('access' in info))) # Required for values.
-            
+
             # Add this command to our table of commands by group.
             ALL_COMMANDS.setdefault(info['group'], set()).add(new_type)
         return new_type
 
 class CommandBase(metaclass=CommandMeta):
     """! @brief Base class for a command.
-    
+
     Each command class must have an `INFO` attribute with the following keys:
     - `names`: List of names for the info. The first element is the primary name.
     - `group`: Optional name for the command group. The group is meant to be a context group, not type of
@@ -72,7 +72,7 @@ class CommandBase(metaclass=CommandMeta):
     def __init__(self, context):
         """! @brief Constructor."""
         self._context = context
-    
+
     @property
     def context(self):
         """! @brief The command execution context."""
@@ -116,7 +116,7 @@ class CommandBase(metaclass=CommandMeta):
 
     def _convert_value(self, arg):
         """! @brief Convert an argument to a 32-bit integer.
-        
+
         Handles the usual decimal, binary, and hex numbers with the appropriate prefix.
         Also recognizes register names and address dereferencing. Dereferencing using the
         ARM assembler syntax. To dereference, put the value in brackets, i.e. '[r0]' or
@@ -179,12 +179,12 @@ class CommandBase(metaclass=CommandMeta):
 
 class ValueBase(CommandBase):
     """! @brief Base class for value commands.
-    
+
     Value commands are special commands representing a value that can be read and/or written. They are used
     through the `show` and `set` commands. A value command has an associated access mode of read-only,
     write-only, or read-write. The access mode sets which of the `show` and `set` commands may be used with
     the value.
-    
+
     Each value class must have an `INFO` attribute with the following keys:
     - `names`: List of names for the value. The first element is the primary name.
     - `group`: Optional name for the command group. The group is meant to be a context group, not type of
@@ -195,11 +195,11 @@ class ValueBase(CommandBase):
     - `help`: String for the short help. Typically should be no more than one sentence.
     - `extra_help`: Optional key for a string with more detailed help.
     """
-    
+
     def display(self, args):
         """! @brief Output the value of the info."""
         raise NotImplementedError()
-    
+
     def modify(self, args):
         """! @brief Change the info to a new value."""
         raise NotImplementedError()

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -74,7 +74,7 @@ class ListCommand(CommandBase):
             'usage': "",
             'help': "Show available targets.",
             }
-    
+
     def execute(self):
         ConnectHelper.list_connected_probes()
 
@@ -87,7 +87,7 @@ class ExitCommand(CommandBase):
             'usage': "",
             'help': "Quit pyocd commander.",
             }
-    
+
     def execute(self):
         from .repl import ToolExitException
         raise ToolExitException()
@@ -101,7 +101,7 @@ class StatusCommand(CommandBase):
             'usage': "",
             'help': "Show the target's current state.",
             }
-    
+
     def execute(self):
         if not self.context.target.is_locked():
             for i, c in enumerate(self.context.target.cores):
@@ -119,12 +119,12 @@ class RegisterCommandBase(CommandBase):
         regs = natsort(self.context.selected_core.core_registers.iter_matching(
                 lambda r: r.group == group_name), key=lambda r: r.name)
         reg_values = self.context.selected_core.read_core_registers_raw(r.name for r in regs)
-        
+
         col_printer = ColumnFormatter()
         for info, value in zip(regs, reg_values):
             value_str = self._format_core_register(info, value)
             col_printer.add_items([(info.name, value_str)])
-        
+
         col_printer.write()
 
     def dump_registers(self, show_all=False, show_group=None):
@@ -141,7 +141,7 @@ class RegisterCommandBase(CommandBase):
             groups_to_show = [show_group]
         else:
             groups_to_show = ['general']
-        
+
         for group in groups_to_show:
             self.context.writei("%s registers:", group)
             self.dump_register_group(group)
@@ -196,12 +196,12 @@ class RegCommand(RegisterCommandBase):
                            "be printed. If the -f option is passed, then individual fields of "
                            "peripheral registers will be printed in addition to the full value.",
             }
-    
+
     def parse(self, args):
         self.show_all = False
         self.reg = None
         self.show_fields = False
-        
+
         if len(args) == 0:
             self.reg = "general"
         else:
@@ -217,7 +217,7 @@ class RegCommand(RegisterCommandBase):
         if self.show_all:
             self.dump_registers(show_all=True)
             return
-        
+
         # Check register names first.
         if self.reg in self.context.selected_core.core_registers.by_name:
             if not self.context.selected_core.is_halted():
@@ -229,14 +229,14 @@ class RegCommand(RegisterCommandBase):
             value_str = self._format_core_register(info, value)
             self.context.writei("%s = %s", self.reg, value_str)
             return
-        
+
         # Now look for matching group name.
         matcher = UniquePrefixMatcher(self.context.selected_core.core_registers.groups)
         group_matches = matcher.find_all(self.reg)
         if len(group_matches) == 1:
             self.dump_registers(show_group=group_matches[0])
             return
-        
+
         # And finally check for peripherals.
         subargs = self.reg.split('.')
         if subargs[0] in self.context.peripherals:
@@ -265,7 +265,7 @@ class WriteRegCommand(RegisterCommandBase):
                            "When a peripheral register is written, if the -r option is passed then "
                            "it is read back and the updated value printed.",
             }
-    
+
     def parse(self, args):
         idx = 0
         if len(args) == 3:
@@ -338,7 +338,7 @@ class ResetCommand(CommandBase):
                           "or 'emulated'.",
 
             }
-    
+
     def parse(self, args):
         self.do_halt = False
         self.reset_type = None
@@ -374,7 +374,7 @@ class DisassembleCommand(CommandBase):
             'extra_help': "Only available if the capstone library is installed. To install "
                            "capstone, run 'pip install capstone'.",
             }
-    
+
     def parse(self, args):
         self.center = (len(args) > 1) and (args[0] in ('-c', '--center'))
         if self.center:
@@ -505,7 +505,7 @@ class WriteCommandBase(CommandBase):
             if not region.is_flash:
                 raise exceptions.CommandError("address 0x%08x is not in flash", self.addr)
             assert region.flash is not None
-            
+
             # Program phrase to flash.
             region.flash.init(region.flash.Operation.PROGRAM)
             region.flash.program_phrase(self.addr, self.data)
@@ -582,7 +582,7 @@ class SavememCommand(CommandBase):
             'usage': "ADDR LEN FILENAME",
             'help': "Save a range of memory to a binary file.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
         self.count = self._convert_value(args[1])
@@ -616,7 +616,7 @@ class LoadmemCommand(CommandBase):
             'help': "Load a binary file to an address in memory (RAM or flash).",
             'extra_help': "This command is deprecated in favour of the more flexible 'load'.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
         self.filename = args[1]
@@ -639,7 +639,7 @@ class LoadCommand(CommandBase):
             'usage': "FILENAME [ADDR]",
             'help': "Load a binary, hex, or elf file with optional base address.",
             }
-    
+
     def parse(self, args):
         self.filename = args[0]
         if len(args) > 1:
@@ -661,7 +661,7 @@ class CompareCommand(CommandBase):
             'help': "Compare a memory range against a binary file.",
             'extra_help': "If the length is not provided, then the length of the file is used.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
         if len(args) < 3:
@@ -685,7 +685,7 @@ class CompareCommand(CommandBase):
                 file_data = bytearray(f.read())
             else:
                 file_data = bytearray(f.read(self.length))
-        
+
         if self.length is None:
             length = len(file_data)
         elif len(file_data) < self.length:
@@ -693,36 +693,36 @@ class CompareCommand(CommandBase):
             length = len(file_data)
         else:
             length = self.length
-        
+
         # Divide into 32 kB chunks.
         CHUNK_SIZE = 32 * 1024
         chunk_count = (length + CHUNK_SIZE - 1) // CHUNK_SIZE
-        
+
         addr = self.addr
         end_addr = addr + length
         offset = 0
         mismatch = False
-        
+
         for chunk in range(chunk_count):
             # Get this chunk's size.
             chunk_size = min(end_addr - addr, CHUNK_SIZE)
             self.context.writei("Comparing %d bytes @ 0x%08x", chunk_size, addr)
-            
+
             data = bytearray(self.context.selected_ap.read_memory_block8(addr, chunk_size))
-            
+
             for i in range(chunk_size):
                 if data[i] != file_data[offset+i]:
                     mismatch = True
                     self.context.writei("Mismatched byte at 0x%08x (offset 0x%x): 0x%02x (memory) != 0x%02x (file)",
                         addr + i, offset + i, data[i], file_data[offset+i])
                     break
-        
+
             if mismatch:
                 break
-        
+
             offset += chunk_size
             addr += chunk_size
-        
+
         if not mismatch:
             self.context.writei("All %d bytes match.", length)
 
@@ -741,7 +741,7 @@ class FillCommand(CommandBase):
                            "provided, the size is determined by the pattern value's most "
                            "significant set bit. Only RAM regions may be filled.",
             }
-    
+
     def parse(self, args):
         if len(args) == 3:
             self.size = None
@@ -755,7 +755,7 @@ class FillCommand(CommandBase):
             self.addr = self._convert_value(args[1])
             self.length = self._convert_value(args[2])
             self.pattern = self._convert_value(args[3])
-        
+
         # Determine size by the highest set bit in the pattern.
         if self.size is None:
             highest = msb(self.pattern)
@@ -779,20 +779,20 @@ class FillCommand(CommandBase):
         elif self.size == 32:
             pattern_str = "0x%08x" % (self.pattern & 0xffffffff)
             self.pattern = conversion.u32le_list_to_byte_list([self.pattern])
-        
+
         # Divide into 32 kB chunks.
         CHUNK_SIZE = 32 * 1024
         chunk_count = (self.length + CHUNK_SIZE - 1) // CHUNK_SIZE
-        
+
         addr = self.addr
         end_addr = addr + self.length
         self.context.writei("Filling 0x%08x-0x%08x with pattern %s", addr, end_addr - 1, pattern_str)
-        
+
         for chunk in range(chunk_count):
             # Get this chunk's size.
             chunk_size = min(end_addr - addr, CHUNK_SIZE)
             self.context.writei("Wrote %d bytes @ 0x%08x", chunk_size, addr)
-            
+
             # Construct data for the chunk.
             if self.size == 8:
                 data = self.pattern * chunk_size
@@ -800,7 +800,7 @@ class FillCommand(CommandBase):
                 data = (self.pattern * ((chunk_size + 1) // 2))[:chunk_size]
             elif self.size == 32:
                 data = (self.pattern * ((chunk_size + 3) // 4))[:chunk_size]
-            
+
             # Write to target.
             self.context.selected_ap.write_memory_block8(addr, data)
             addr += chunk_size
@@ -816,7 +816,7 @@ class FindCommand(CommandBase):
             'extra_help': "A pattern of any number of bytes can be searched for. Each BYTE "
                            "parameter must be an 8-bit value.",
             }
-    
+
     def parse(self, args):
         if len(args) < 3:
             raise exceptions.CommandError("missing argument")
@@ -826,32 +826,32 @@ class FindCommand(CommandBase):
         for p in args[2:]:
             self.pattern += bytearray([self._convert_value(p)])
         self.pattern_str = " ".join("%02x" % p for p in self.pattern)
-        
+
     def execute(self):
         # Divide into 32 kB chunks.
         CHUNK_SIZE = 32 * 1024
         chunk_count = (self.length + CHUNK_SIZE - 1) // CHUNK_SIZE
-        
+
         addr = self.addr
         end_addr = addr + self.length
         self.context.writei("Searching 0x%08x-0x%08x for pattern [%s]", addr, end_addr - 1, self.pattern_str)
-        
+
         match = False
         for chunk in range(chunk_count):
             # Get this chunk's size.
             chunk_size = min(end_addr - addr, CHUNK_SIZE)
             self.context.writei("Read %d bytes @ 0x%08x", chunk_size, addr)
-            
+
             data = bytearray(self.context.selected_ap.read_memory_block8(addr, chunk_size))
-            
+
             offset = data.find(self.pattern)
             if offset != -1:
                 match = True
                 self.context.writei("Found pattern at address 0x%08x", addr + offset)
                 break
-            
+
             addr += chunk_size - len(self.pattern)
-        
+
         if not match:
             self.context.writei("Failed to find pattern in range 0x%08x-0x%08x", self.addr, end_addr - 1)
 
@@ -864,7 +864,7 @@ class EraseCommand(CommandBase):
             'usage': "[ADDR] [COUNT]",
             'help': "Erase all internal flash or a range of sectors.",
             }
-    
+
     def parse(self, args):
         if len(args) == 0:
             self.erase_chip = True
@@ -908,7 +908,7 @@ class UnlockCommand(CommandBase):
             'usage': "",
             'help': "Unlock security on the target.",
             }
-    
+
     def execute(self):
         self.context.target.mass_erase()
 
@@ -924,7 +924,7 @@ class ContinueCommand(CommandBase):
                           "then it's state is reported. For instance, if the target is halted immediately "
                           "after resuming, a debug event such as a breakpoint most likely occurred.",
             }
-    
+
     def execute(self):
         self.context.selected_core.resume()
         status = self.context.selected_core.get_state()
@@ -950,13 +950,13 @@ class StepCommand(CommandBase):
             'usage': "[COUNT]",
             'help': "Step one or more instructions.",
             }
-    
+
     def parse(self, args):
         if len(args) == 1:
             self.count = self._convert_value(args[0])
         else:
             self.count = 1
-    
+
     def execute(self):
         if not self.context.selected_core.is_halted():
             self.context.write("Core is not halted; cannot step")
@@ -981,7 +981,7 @@ class HaltCommand(CommandBase):
             'usage': "",
             'help': "Halt the target.",
             }
-    
+
     def execute(self):
         self.context.selected_core.halt()
 
@@ -1001,7 +1001,7 @@ class BreakpointCommand(CommandBase):
             'usage': "ADDR",
             'help': "Set a breakpoint address.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
 
@@ -1021,7 +1021,7 @@ class RemoveBreakpointCommand(CommandBase):
             'usage': "ADDR",
             'help': "Remove a breakpoint.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
 
@@ -1042,7 +1042,7 @@ class ListBreakpointsCommand(CommandBase):
             'usage': "",
             'help': "List breakpoints.",
             }
-    
+
     def execute(self):
         availableBpCount = self.context.selected_core.available_breakpoint_count
         self.context.writei("%d hardware breakpoints available", availableBpCount)
@@ -1062,7 +1062,7 @@ class WatchpointCommand(CommandBase):
             'usage': "ADDR [r|w|rw] [1|2|4]",
             'help': "Set a watchpoint address, and optional access type (default rw) and size (4).",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
         if len(args) > 1:
@@ -1096,7 +1096,7 @@ class RemoveWatchpointCommand(CommandBase):
             'usage': "ADDR",
             'help': "Remove a watchpoint.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
 
@@ -1118,7 +1118,7 @@ class ListWatchpointsCommand(CommandBase):
             'usage': "",
             'help': "List watchpoints.",
             }
-    
+
     def execute(self):
         if self.context.selected_core.dwt is None:
             raise exceptions.CommandError("DWT not present")
@@ -1131,7 +1131,7 @@ class ListWatchpointsCommand(CommandBase):
             for i, wp in enumerate(wps):
                 # TODO fix requirement to access WATCH_TYPE_TO_FUNCT
                 self.context.writei("%d: 0x%08x, %d bytes, %s",
-                    i, wp.addr, wp.size, 
+                    i, wp.addr, wp.size,
                     WATCHPOINT_FUNCTION_NAME_MAP[self.context.selected_core.dwt.WATCH_TYPE_TO_FUNCT[wp.func]])
 
 class SelectCoreCommand(CommandBase):
@@ -1143,7 +1143,7 @@ class SelectCoreCommand(CommandBase):
             'usage': "[NUM]",
             'help': "Select CPU core by number or print selected core.",
             }
-    
+
     def parse(self, args):
         if len(args) == 0:
             self.show_core = True
@@ -1170,7 +1170,7 @@ class ReadDpCommand(CommandBase):
             'usage': "ADDR",
             'help': "Read DP register.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
 
@@ -1187,7 +1187,7 @@ class WriteDpCommand(CommandBase):
             'usage': "ADDR DATA",
             'help': "Write DP register.",
             }
-    
+
     def parse(self, args):
         self.addr = self._convert_value(args[0])
         self.data = self._convert_value(args[1])
@@ -1314,7 +1314,7 @@ class WhereCommand(CommandBase):
         if self.context.elf is None:
             self.context.write("No ELF available")
             return
-        
+
         lineInfo = self.context.elf.address_decoder.get_line_for_address(self.addr)
         if lineInfo is not None:
             path = os.path.join(lineInfo.dirname, lineInfo.filename).decode()
@@ -1322,7 +1322,7 @@ class WhereCommand(CommandBase):
             pathline = "{}:{}".format(path, line)
         else:
             pathline = "<unknown file>"
-        
+
         fnInfo = self.context.elf.address_decoder.get_function_for_address(self.addr)
         if fnInfo is not None:
             name = fnInfo.name.decode()
@@ -1330,7 +1330,7 @@ class WhereCommand(CommandBase):
         else:
             name = "<unknown symbol>"
             offset = 0
-        
+
         self.context.writef("{addr:#10x} : {fn}+{offset} : {pathline}",
                 addr=self.addr, fn=name, offset=offset, pathline=pathline)
 
@@ -1352,7 +1352,7 @@ class SymbolCommand(CommandBase):
         if self.context.elf is None:
             self.context.write("No ELF available")
             return
-        
+
         sym = self.context.elf.symbol_decoder.get_symbol_for_name(self.name)
         if sym is not None:
             if sym.type == 'STT_FUNC':
@@ -1394,7 +1394,7 @@ class GdbserverCommand(CommandBase):
             if self.context.session.gdbservers[core_number] is not None:
                 server = self.context.session.gdbservers[core_number]
                 del self.context.session.gdbservers[core_number]
-                
+
                 # Stop the server and wait for it to terminate.
                 server.stop()
                 while server.is_alive():
@@ -1404,7 +1404,7 @@ class GdbserverCommand(CommandBase):
         elif self.action == 'status':
             if core_number in self.context.session.gdbservers:
                 self.context.writef("gdbserver for core {0} is running", core_number)
-            else:            
+            else:
                 self.context.writef("gdbserver for core {0} is not running", core_number)
 
 class ProbeserverCommand(CommandBase):
@@ -1469,7 +1469,7 @@ class ShowCommand(CommandBase):
         # Check readability.
         if 'r' not in value_class.INFO['access']:
             raise exceptions.CommandError("value '%s' is not readable" % self.name)
-        
+
         # Execute show operation.
         value_object = value_class(self.context)
         value_object.display(self.args)
@@ -1515,7 +1515,7 @@ class SetCommand(CommandBase):
         # Check writability.
         if 'w' not in value_class.INFO['access']:
             raise exceptions.CommandError("value '%s' is not modifiable" % self.name)
-        
+
         # Execute set operation.
         value_object = value_class(self.context)
         value_object.modify(self.args)
@@ -1544,7 +1544,7 @@ class HelpCommand(CommandBase):
             'usage': "[CMD]",
             'help': "Show help for commands.",
             }
-    
+
     HELP_ADDENDUM = """
 All register names are also available as commands that print the register's value.
 Any ADDR or LEN argument will accept a register name.
@@ -1591,19 +1591,19 @@ Prefix line with ! to execute a shell command."""
                     return
                 except IndexError:
                     pass
-            
+
             self.context.write(cmd_class.format_help(self.context, self.term_width))
 
     def _list_commands(self, title, command_list, help_format):
         cmds = {}
         nominal_cmds = []
-        
+
         for klass in command_list:
             cmd_name = klass.INFO['names'][0]
             cmds[cmd_name] = klass
             nominal_cmds.append(cmd_name)
         nominal_cmds.sort()
-        
+
         self.context.write(title + ":\n" + ("-" * len(title)))
         for cmd_name in nominal_cmds:
             cmd_klass = cmds[cmd_name]

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -33,7 +33,7 @@ LOG = logging.getLogger(__name__)
 
 class CommandSet(object):
     """! @brief Holds a set of command classes."""
-    
+
     ## Whether command and infos modules have been loaded yet.
     DID_LOAD_COMMAND_MODULES = False
 
@@ -44,10 +44,10 @@ class CommandSet(object):
         self._values = {}
         self._value_classes = set()
         self._value_matcher = UniquePrefixMatcher()
-        
+
         # Ensure these modules get loaded so the ALL_COMMANDS dicts are filled.
         self._load_modules()
-    
+
     @classmethod
     def _load_modules(cls):
         # Load these modules in order to populate the dicts with standard commands. This must be
@@ -57,31 +57,31 @@ class CommandSet(object):
             from . import commands
             from . import values
             cls.DID_LOAD_COMMAND_MODULES = True
-    
+
     @property
     def commands(self):
         return self._commands
-    
+
     @property
     def command_classes(self):
         return self._command_classes
-    
+
     @property
     def command_matcher(self):
         return self._command_matcher
-    
+
     @property
     def values(self):
         return self._values
-    
+
     @property
     def value_classes(self):
         return self._value_classes
-    
+
     @property
     def value_matcher(self):
         return self._value_matcher
-    
+
     def add_command_group(self, group_name):
         """! @brief Add commands belonging to a group to the command set.
         @param self The command set.
@@ -89,7 +89,7 @@ class CommandSet(object):
         """
         from .base import ALL_COMMANDS
         self.add_commands(ALL_COMMANDS.get(group_name, set()))
-    
+
     def add_commands(self, commands):
         """! @brief Add some commands to the command set.
         @param self The command set.
@@ -102,7 +102,7 @@ class CommandSet(object):
         self._commands.update(cmd_names)
         self._command_classes.update(cmd_classes)
         self._command_matcher.add_items(cmd_names.keys())
-    
+
         value_names = {name: klass for klass in value_classes for name in klass.INFO['names']}
         self._values.update(value_names)
         self._value_classes.update(value_classes)
@@ -117,11 +117,11 @@ CommandInvocation instance.
 
 class CommandExecutionContext(object):
     """! @brief Manages command execution.
-    
+
     This class holds persistent state for command execution, and provides the interface for executing
     commands and command lines.
     """
-    
+
     def __init__(self, no_init=False, output_stream=None):
         """! @brief Constructor.
         @param self This object.
@@ -142,18 +142,18 @@ class CommandExecutionContext(object):
         self._selected_ap_address = None
         self._peripherals = {}
         self._loaded_peripherals = False
-        
+
         # Add in the standard commands.
         self._command_set.add_command_group('standard')
-    
+
     def write(self, message='', **kwargs):
         """! @brief Write a fixed message to the output stream.
-        
+
         The message is written to the output stream passed to the constructor, terminated with
         a newline by default. The `end` keyword argument can be passed to change the terminator. No
         formatting is applied to the message. If formatting is required, use the writei() or writef()
         methods instead.
-        
+
         @param self This object.
         @param message The text to write to the output. If not a string object, it is run through str().
         """
@@ -163,26 +163,26 @@ class CommandExecutionContext(object):
         if not isinstance(message, str):
             message = str(message)
         self._output.write(message + end)
-    
+
     def writei(self, fmt, *args, **kwargs):
         """! @brief Write an interpolated string to the output stream.
-        
+
         The formatted string is written to the output stream passed to the constructor, terminated with
         a newline by default. The `end` keyword argument can be passed to change the terminator.
-        
+
         @param self This object.
         @param fmt Format string using printf-style "%" formatters.
         """
         assert isinstance(fmt, str)
         message = fmt % args
         self.write(message, **kwargs)
-    
+
     def writef(self, fmt, *args, **kwargs):
         """! @brief Write a formatted string to the output stream.
-        
+
         The formatted string is written to the output stream passed to the constructor, terminated with
         a newline by default. The `end` keyword argument can be passed to change the terminator.
-        
+
         @param self This object.
         @param fmt Format string using the format() mini-language.
         """
@@ -192,10 +192,10 @@ class CommandExecutionContext(object):
 
     def attach_session(self, session):
         """! @brief Associate a session with the command context.
-        
+
         Various data for the context are initialized. This includes selecting the initially selected core and MEM-AP,
         and getting an ELF file that was set on the target.
-        
+
         @param self This object.
         @param session A @ref pyocd.core.session.Session "Session" instance.
         @retval True Session attached and context state inited successfully.
@@ -211,47 +211,47 @@ class CommandExecutionContext(object):
                 # Selected core defaults to the target's default selected core.
                 if self.selected_core is None:
                     self.selected_core = self.target.selected_core
-            
+
                 # Get the AP for the selected core.
                 if self.selected_core is not None:
                     self.selected_ap_address = self.selected_core.ap.address
             except IndexError:
                 pass
-            
+
             # Fall back to the first MEM-AP.
             if self.selected_ap_address is None:
                 for ap_num in sorted(self.target.aps.keys()):
                     if isinstance(self.target.aps[ap_num], MEM_AP):
                         self.selected_ap_address = ap_num
                         break
-        
+
         return True
-    
+
     @property
     def session(self):
         return self._session
-    
+
     @property
     def board(self):
         return self._session and self._session.board
-    
+
     @property
     def target(self):
         return self._session and self._session.target
-    
+
     @property
     def probe(self):
         return self._session and self._session.probe
-    
+
     @property
     def elf(self):
         return self.target and self.target.elf
-    
+
     @property
     def command_set(self):
         """! @brief CommandSet with commands available in this context."""
         return self._command_set
-    
+
     @property
     def peripherals(self):
         """! @brief Dict of SVD peripherals."""
@@ -260,24 +260,24 @@ class CommandExecutionContext(object):
                 self._peripherals[p.name.lower()] = p
             self._loaded_peripherals = True
         return self._peripherals
-    
+
     @property
     def output_stream(self):
         return self._output
-    
+
     @output_stream.setter
     def output_stream(self, stream):
         self._output = stream
-    
+
     @property
     def selected_core(self):
         """! @brief The Target instance for the selected core."""
         return self._selected_core
-    
+
     @selected_core.setter
     def selected_core(self, value):
         self._selected_core = value
-    
+
     @property
     def selected_ap_address(self):
         return self._selected_ap_address
@@ -285,7 +285,7 @@ class CommandExecutionContext(object):
     @selected_ap_address.setter
     def selected_ap_address(self, value):
         self._selected_ap_address = value
-    
+
     @property
     def selected_ap(self):
         if self.selected_ap_address is None:
@@ -327,7 +327,7 @@ class CommandExecutionContext(object):
     def parse_command(self, cmdline):
         """! @brief Create a CommandInvocation from a single command."""
         cmdline = cmdline.strip()
-        
+
         # Check for Python or shell command lines.
         first_char = cmdline[0]
         if first_char in '$!':
@@ -353,7 +353,7 @@ class CommandExecutionContext(object):
                         ", ".join("'%s'" % c for c in all_matches)))
             else:
                 raise exceptions.CommandError("unrecognized command '%s'" % cmd)
-        
+
         return CommandInvocation(matched_command, args, self.execute_command)
 
     def execute_command(self, invocation):
@@ -389,7 +389,7 @@ class CommandExecutionContext(object):
             # Lazily build the python environment.
             if self._python_namespace is None:
                 self._build_python_namespace()
-            
+
             result = eval(invocation.cmd, globals(), self._python_namespace)
             if result is not None:
                 if isinstance(result, int):
@@ -402,7 +402,7 @@ class CommandExecutionContext(object):
             if self.session.log_tracebacks:
                 LOG.error("Exception while executing expression: %s", e, exc_info=True)
             raise exceptions.CommandError("exception while executing expression: %s" % e)
-    
+
     def handle_system(self, invocation):
         """! @brief Evaluate a system call command."""
         try:

--- a/pyocd/commands/repl.py
+++ b/pyocd/commands/repl.py
@@ -26,23 +26,23 @@ LOG = logging.getLogger(__name__)
 
 class ToolExitException(Exception):
     """! @brief Special exception indicating the tool should exit.
-    
+
     This exception is only raised by the `exit` command.
     """
     pass
 
 class PyocdRepl(object):
     """! @brief Read-Eval-Print-Loop for pyOCD commander."""
-    
+
     PROMPT = 'pyocd> '
-    
+
     PYOCD_HISTORY_ENV_VAR = 'PYOCD_HISTORY'
     PYOCD_HISTORY_LENGTH_ENV_VAR = 'PYOCD_HISTORY_LENGTH'
     DEFAULT_HISTORY_FILE = ".pyocd_history"
 
     def __init__(self, command_context):
         self.context = command_context
-        
+
         # Attempt to import readline. If we import readline from the module level, it may be imported
         # when initing non-interactive subcommands such as gdbserver, and it causes the process to be
         # stopped if started in the background (& suffix in sh).
@@ -52,11 +52,11 @@ class PyocdRepl(object):
             # Enable readline history.
             self._history_path = os.environ.get(self.PYOCD_HISTORY_ENV_VAR,
                     os.path.join(os.path.expanduser("~"), self.DEFAULT_HISTORY_FILE))
-        
+
             # Read command history and set history length.
             try:
                 readline.read_history_file(self._history_path)
-            
+
                 history_len = int(os.environ.get(self.PYOCD_HISTORY_LENGTH_ENV_VAR,
                         session.Session.get_current().options.get('commander.history_length')))
                 readline.set_history_length(history_len)
@@ -87,7 +87,7 @@ class PyocdRepl(object):
                 print()
         except ToolExitException:
             pass
-    
+
     def run_one_command(self, line):
         """! @brief Execute a single command line and handle exceptions."""
         try:

--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -173,14 +173,14 @@ class FaultValue(ValueBase):
 
     def display(self, args):
         showAll = ('-a' in args)
-        
+
         CFSR = 0xe000ed28
         HFSR = 0xe000ed2c
         DFSR = 0xe000ed30
         MMFAR = 0xe000ed34
         BFAR = 0xe000ed38
 #         AFSR = 0xe000ed3c
-        
+
         MMFSR_fields = [
                 ('IACCVIOL', 0),
                 ('DACCVIOL', 1),
@@ -218,7 +218,7 @@ class FaultValue(ValueBase):
                 ('VCATCH', 3),
                 ('EXTERNAL', 4),
             ]
-        
+
         def print_fields(regname, value, fields, showAll):
             if value == 0 and not showAll:
                 return
@@ -227,7 +227,7 @@ class FaultValue(ValueBase):
                 bit = (value >> bitpos) & 1
                 if showAll or bit != 0:
                     self.context.writei("    %s = 0x%x", name, bit)
-        
+
         if self.context.selected_core is None:
             self.context.write("No core is selected")
             return
@@ -240,7 +240,7 @@ class FaultValue(ValueBase):
         dfsr = self.context.selected_core.read32(DFSR)
         mmfar = self.context.selected_core.read32(MMFAR)
         bfar = self.context.selected_core.read32(BFAR)
-        
+
         print_fields('MMFSR', mmfsr, MMFSR_fields, showAll)
         if showAll or mmfsr & (1 << 7): # MMFARVALID
             self.context.writei("  MMFAR = 0x%08x", mmfar)
@@ -270,7 +270,7 @@ class NresetValue(ValueBase):
             raise exceptions.CommandError("missing reset state")
         state = int(args[0], base=0)
         self.context.writef("nRESET = {}", state)
-        
+
         # Use the probe to assert reset if the DP doesn't exist for some reason, otherwise
         # use the DP so reset notifications are sent.
         if self.context.target.dp is None:
@@ -327,7 +327,7 @@ class MemApValue(ValueBase):
     def modify(self, args):
         if len(args) == 0:
             raise exceptions.CommandError("missing argument")
-            
+
         ap_num = int(args[0], base=0)
         if self.context.target.dp.adi_version == coresight.dap.ADIVersion.ADIv5:
             ap_addr = coresight.ap.APv1Address(ap_num)
@@ -415,7 +415,7 @@ class TargetGraphValue(ValueBase):
 
     def display(self, args):
         self.context.board.dump()
-    
+
 class LockedValue(ValueBase):
     INFO = {
             'names': ['locked'],
@@ -479,7 +479,7 @@ class VectorCatchValue(ValueBase):
         if self.context.selected_core is None:
             self.context.write("No core is selected")
             return
-    
+
         try:
             self.context.selected_core.set_vector_catch(convert_vector_catch(args[0]))
         except ValueError as e:

--- a/pyocd/core/core_registers.py
+++ b/pyocd/core/core_registers.py
@@ -24,10 +24,10 @@ LOG = logging.getLogger(__name__)
 
 class CoreRegisterInfo(object):
     """! @brief Useful information about a core register.
-    
+
     Provides properties for classification of the register, and utilities to convert to and from
     the raw integer representation of the register value.
-    
+
     Each core register has both a name (string), which is always lowercase, and an integer index.
     The index is a unique identifier with an architecture-specified meaning.
     """
@@ -37,7 +37,7 @@ class CoreRegisterInfo(object):
     # This is just a placeholder. The architecture-specific subclass should override the definition. Its
     # value is set to None to cause an exception if used.
     _NAME_MAP = None
-    
+
     ## Map of register index to info.
     #
     # This is just a placeholder. The architecture-specific subclass should override the definition. Its
@@ -50,7 +50,7 @@ class CoreRegisterInfo(object):
         for reg in all_regs:
             cls._NAME_MAP[reg.name] = reg
             cls._INDEX_MAP[reg.index] = reg
-    
+
     @classmethod
     def get(cls, reg):
         """! @brief Return the CoreRegisterInfo instance for a register.
@@ -81,32 +81,32 @@ class CoreRegisterInfo(object):
     def name(self):
         """! @brief Name of the register. Always lowercase."""
         return self._name
-    
+
     @property
     def index(self):
         """! @brief Integer index of the register."""
         return self._index
-    
+
     @property
     def bitsize(self):
         """! @brief Bit width of the register.."""
         return self._bitsize
-    
+
     @property
     def group(self):
         """! @brief Named group the register is contained within."""
         return self._group
-    
+
     @property
     def gdb_type(self):
         """! @brief Value type specific to gdb."""
         return self._gdb_type
-    
+
     @property
     def gdb_regnum(self):
         """! @brief Register number specific to gdb."""
         return self._gdb_regnum
-    
+
     @property
     def gdb_feature(self):
         """! @brief GDB architecture feature to which the register belongs."""
@@ -126,7 +126,7 @@ class CoreRegisterInfo(object):
     def is_double_float_register(self):
         """! @brief Returns true for registers holding double-precision float values"""
         return self.gdb_type == 'ieee_double'
-    
+
     def from_raw(self, value):
         """! @brief Convert register value from raw (integer) to canonical type."""
         # Convert int to float.
@@ -135,7 +135,7 @@ class CoreRegisterInfo(object):
         elif self.is_double_float_register:
             value = conversion.u64_to_float64(value)
         return value
-    
+
     def to_raw(self, value):
         """! @brief Convert register value from canonical type to raw (integer)."""
         # Convert float to int.
@@ -147,23 +147,23 @@ class CoreRegisterInfo(object):
             else:
                 raise TypeError("non-float register value has float type")
         return value
-    
+
     def clone(self):
         """! @brief Return a copy of the register info."""
         return copy(self)
-    
+
     def __eq__(self, other):
         return isinstance(other, CoreRegisterInfo) and (self.index == other.index)
-    
+
     def __hash__(self):
         return hash(self.index)
-    
+
     def __repr__(self):
         return "<{}@{:#x} {}={} {}-bit>".format(self.__class__.__name__, id(self), self.name, self.index, self.bitsize)
 
 class CoreRegistersIndex(object):
     """! @brief Class to hold indexes of available core registers.
-    
+
     This class is meant to be used by a core to hold the set of core registers that are actually present on
     a particular device, as determined by runtime inspection of the core. A number of properties are made
     available to access the core registers by various keys.
@@ -175,17 +175,17 @@ class CoreRegistersIndex(object):
         self._by_name = {}
         self._by_index = {}
         self._by_feature = {}
-    
+
     @property
     def groups(self):
         """! @brief Set of unique register group names."""
         return self._groups
-    
+
     @property
     def as_set(self):
         """! @brief Set of available registers as CoreRegisterInfo objects."""
         return self._all
-    
+
     @property
     def by_name(self):
         """! @brief Dict of (register name) -> CoreRegisterInfo."""
@@ -200,7 +200,7 @@ class CoreRegistersIndex(object):
     def by_feature(self):
         """! @brief Dict of (register gdb feature) -> List[CoreRegisterInfo]."""
         return self._by_feature
-    
+
     def iter_matching(self, predicate):
         """! @brief Iterate over registers matching a given predicate callable.
         @param self The object.
@@ -210,7 +210,7 @@ class CoreRegistersIndex(object):
         for reg in self._all:
             if predicate(reg):
                 yield reg
-    
+
     def add_group(self, regs):
         """! @brief Add a list of registers.
         @param self The object.

--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -20,7 +20,7 @@ class Error(RuntimeError):
 
 class InternalError(Error):
     """! @brief Internal consistency or logic error.
-    
+
     This error indicates that something has happened that shouldn't be possible.
     """
     pass
@@ -63,11 +63,11 @@ class TransferTimeoutError(TransferError):
 
 class TransferFaultError(TransferError):
     """! @brief A memory fault occurred.
-    
+
     This exception class is extended to optionally record the start address and an optional length of the
     attempted memory access that caused the fault. The address and length, if available, will be included
     in the description of the exception when it is converted to a string.
-    
+
     Positional arguments passed to the constructor are passed through to the superclass'
     constructor, and thus operate like any other standard exception class. Keyword arguments of
     'fault_address' and 'length' can optionally be passed to the constructor to initialize the fault
@@ -86,15 +86,15 @@ class TransferFaultError(TransferError):
     @fault_address.setter
     def fault_address(self, addr):
         self._address = addr
-    
+
     @property
     def fault_end_address(self):
         return (self._address + self._length - 1) if (self._length is not None) else self._address
-    
+
     @property
     def fault_length(self):
         return self._length
-    
+
     @fault_length.setter
     def fault_length(self, length):
         self._length = length
@@ -111,10 +111,10 @@ class TransferFaultError(TransferError):
             if self._length is not None:
                 desc += "-0x%08x" % self.fault_end_address
         return desc
-  
+
 class FlashFailure(TargetError):
     """! @brief Exception raised when flashing fails for some reason.
-    
+
     Positional arguments passed to the constructor are passed through to the superclass'
     constructor, and thus operate like any other standard exception class. The flash address that
     failed and/or result code from the algorithm can optionally be recorded in the exception, if
@@ -124,11 +124,11 @@ class FlashFailure(TargetError):
         super(FlashFailure, self).__init__(*args)
         self._address = kwargs.get('address', None)
         self._result_code = kwargs.get('result_code', None)
-    
+
     @property
     def address(self):
         return self._address
-    
+
     @property
     def result_code(self):
         return self._result_code

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -27,29 +27,29 @@ colorama.init()
 
 class ConnectHelper(object):
     """! @brief Helper class for streamlining the probe discovery and session creation process.
-    
+
     This class provides several static methods that wrap the DebugProbeAggregator methods
     with a simple command-line user interface, or provide a single method that performs
     a common access pattern.
     """
-    
+
     @staticmethod
     def get_sessions_for_all_connected_probes(blocking=True, unique_id=None, options=None, **kwargs):
         """! @brief Return a list of Session objects for all connected debug probes.
-        
+
         This method is useful for listing detailed information about connected probes, especially
         those that have associated boards, as the Session object will have a Board instance.
-        
+
         The returned list of sessions is sorted by the combination of the debug probe's
         description and unique ID.
-        
+
         @param blocking Specifies whether to wait for a probe to be connected if there are no
               available probes.
         @param unique_id String to match against probes' unique IDs using a contains match. If the
               default of None is passed, then all available probes are matched.
         @param options Dictionary of session options.
         @param kwargs Session options passed as keyword arguments.
-        
+
         @return A list of Session objects. The returned Session objects are not yet active, in that
               open() has not yet been called. If _blocking_ is True, the list will contain at least
               one session. If _blocking_ is False and there are no probes connected then an empty list
@@ -62,17 +62,17 @@ class ConnectHelper(object):
     @staticmethod
     def get_all_connected_probes(blocking=True, unique_id=None, print_wait_message=True):
         """! @brief Return a list of DebugProbe objects for all connected debug probes.
-        
+
         The returned list of debug probes is always sorted by the combination of the probe's
         description and unique ID.
-        
+
         @param blocking Specifies whether to wait for a probe to be connected if there are no
               available probes. A message will be printed
         @param unique_id String to match against probes' unique IDs using a contains match. If the
               default of None is passed, then all available probes are matched.
         @param print_wait_message Whether to print a message to the command line when waiting for a
               probe to be connected and _blocking_ is True.
-        
+
         @return A list of DebugProbe instances. If _blocking_ is True, the list will contain at least
               one probe. If _blocking_ is False and there are no probes connected then an empty list
               will be returned.
@@ -101,8 +101,8 @@ class ConnectHelper(object):
 
     @staticmethod
     def list_connected_probes():
-        """! @brief List the connected debug probes.   
-        
+        """! @brief List the connected debug probes.
+
         Prints a list of all connected probes to stdout. If no probes are connected, a message
         saying as much is printed instead.
         """
@@ -116,22 +116,22 @@ class ConnectHelper(object):
     @staticmethod
     def choose_probe(blocking=True, return_first=False, unique_id=None):
         """! @brief Return a debug probe possibly chosen by the user.
-        
+
         This method provides an easy to use command line interface for selecting one of the
         connected debug probes. It has parameters that control filtering of probes by unique ID and
         automatic selection of the first discovered probe.
-        
+
         If, after application of the _unique_id_ and _return_first_ parameters, there are still
         multiple debug probes to choose from, the user is presented with a simple command-line UI
         to select a probe (or abort the selection process).
-        
+
         @param blocking Specifies whether to wait for a probe to be connected if there are no
               available probes.
         @param return_first If more than one probe is connected, a _return_first_ of True will select
               the first discovered probe rather than present a selection choice to the user.
         @param unique_id String to match against probes' unique IDs using a contains match. If the
               default of None is passed, then all available probes are matched.
-        
+
         @return Either None or a DebugProbe instance.
         """
         # Get all matching probes, sorted by name.
@@ -191,17 +191,17 @@ class ConnectHelper(object):
     def session_with_chosen_probe(blocking=True, return_first=False, unique_id=None,
                     auto_open=True, options=None, **kwargs):
         """! @brief Create a session with a probe possibly chosen by the user.
-        
+
         This method provides an easy to use command line interface for selecting one of the
         connected debug probes, then creating and opening a Session instance. It has several
         parameters that control filtering of probes by unique ID and automatic selection of the
         first discovered probe. In addition, you can pass session options to the Session either with
         the _options_ parameter or directly as keyword arguments.
-        
+
         If, after application of the _unique_id_ and _return_first_ parameter, there are still
         multiple debug probes to choose from, the user is presented with a simple command-line UI
         to select a probe (or abort the selection process).
-        
+
         Most commonly, this method will be used directly in a **with** statement:
         @code
         with ConnectHelper.session_with_chosen_probe() as session:
@@ -216,7 +216,7 @@ class ConnectHelper(object):
         with session:
             # the session is open and ready for use
         @endcode
-        
+
         @param blocking Specifies whether to wait for a probe to be connected if there are no
               available probes.
         @param return_first If more than one probe is connected, a _return_first_ of True will select
@@ -227,7 +227,7 @@ class ConnectHelper(object):
               context manager.
         @param options Dictionary of session options.
         @param kwargs Session options passed as keyword arguments.
-        
+
         @return Either None or a Session instance.
         """
         # Choose a probe.

--- a/pyocd/core/memory_interface.py
+++ b/pyocd/core/memory_interface.py
@@ -21,13 +21,13 @@ class MemoryInterface(object):
 
     def write_memory(self, addr, data, transfer_size=32):
         """! @brief Write a single memory location.
-        
+
         By default the transfer size is a word."""
         raise NotImplementedError()
-        
+
     def read_memory(self, addr, transfer_size=32, now=True):
         """! @brief Read a memory location.
-        
+
         By default, a word will be read."""
         raise NotImplementedError()
 
@@ -38,11 +38,11 @@ class MemoryInterface(object):
     def read_memory_block32(self, addr, size):
         """! @brief Read an aligned block of 32-bit words."""
         raise NotImplementedError()
-  
+
     def write64(self, addr, value):
         """! @brief Shorthand to write a 64-bit word."""
         self.write_memory(addr, value, 64)
-  
+
     def write32(self, addr, value):
         """! @brief Shorthand to write a 32-bit word."""
         self.write_memory(addr, value, 32)

--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -45,7 +45,7 @@ def check_range(start, end=None, length=None, range=None):
 @total_ordering
 class MemoryRangeBase(object):
     """! @brief Base class for a range of memory.
-    
+
     This base class provides the basic address range support and methods to test for containment
     or intersection with another range.
     """
@@ -87,13 +87,13 @@ class MemoryRangeBase(object):
         start, end = check_range(start, end, length, range)
         return (start <= self.start and end >= self.start) or (start <= self.end and end >= self.end) \
             or (start >= self.start and end <= self.end)
-    
+
     def __hash__(self):
         return hash("%08x%08x%08x" % (self.start, self.end, self.length))
-    
+
     def __eq__(self, other):
         return self.start == other.start and self.length == other.length
-    
+
     def __lt__(self, other):
         return self.start < other.start or (self.start == other.start and self.length == other.length)
 
@@ -106,13 +106,13 @@ class MemoryRange(MemoryRangeBase):
     @property
     def region(self):
         return self._region
-    
+
     def __hash__(self):
         h = super(MemoryRange, self).__hash__()
         if self.region is not None:
             h ^= hash(self.region)
         return h
-    
+
     def __eq__(self, other):
         return self.start == other.start and self.length == other.length and self.region == other.region
 
@@ -122,9 +122,9 @@ class MemoryRange(MemoryRangeBase):
 
 class MemoryRegion(MemoryRangeBase):
     """! @brief One contiguous range of memory.
-    
+
     Memory regions have attributes accessible via the normal dot syntax.
-    
+
     - `name`: Name of the region, which defaults to the region type in lowercase.
     - `access`: Composition of r, w, x, s.
     - `alias`: If set, this is the name of another region that of which this region is an alias.
@@ -141,7 +141,7 @@ class MemoryRegion(MemoryRangeBase):
         as memory-mapped OTP or configuration flash.
     - `is_testable`: Whether pyOCD should consider the region in its functional tests.
     - `is_external`: If true, the region is backed by an external memory device such as SDRAM or QSPI.
-    
+
     Several attributes are available whose values are computed from other attributes. These should
     not be set when creating the region.
     - `is_ram`
@@ -154,7 +154,7 @@ class MemoryRegion(MemoryRangeBase):
     - `is_secure`
     - `is_nonsecure`
     """
-    
+
     ## Default attribute values for all memory region types.
     DEFAULT_ATTRS = {
         'name': lambda r: r.type.name.lower(),
@@ -166,7 +166,7 @@ class MemoryRegion(MemoryRangeBase):
         'is_cacheable': True,
         'invalidate_cache_on_run': True,
         'is_testable': True,
-        'is_external': False,        
+        'is_external': False,
         'is_ram': lambda r: r.type == MemoryType.RAM,
         'is_rom': lambda r: r.type == MemoryType.ROM,
         'is_flash': lambda r: r.type == MemoryType.FLASH,
@@ -177,12 +177,12 @@ class MemoryRegion(MemoryRangeBase):
         'is_secure': lambda r: 's' in r.access,
         'is_nonsecure': lambda r: not r.is_secure,
         }
-    
+
     def __init__(self, type=MemoryType.OTHER, start=0, end=0, length=None, **attrs):
         """! Memory region constructor.
-        
+
         Memory regions are required to have non-zero lengths, unlike memory ranges.
-        
+
         Some common optional region attributes passed as keyword arguments:
         - name: If a name is not provided, the name is set to the region type in lowercase.
         - access: composition of r, w, x, s
@@ -197,7 +197,7 @@ class MemoryRegion(MemoryRangeBase):
         self._map = None
         self._type = type
         self._attributes = attrs
-        
+
         # Assign default values to any attributes missing from kw args.
         for k, v in self.DEFAULT_ATTRS.items():
             if k not in self._attributes:
@@ -210,15 +210,15 @@ class MemoryRegion(MemoryRangeBase):
     @map.setter
     def map(self, the_map):
         self._map = the_map
-        
+
     @property
     def type(self):
         return self._type
-    
+
     @property
     def attributes(self):
         return self._attributes
-        
+
     @property
     def alias(self):
         # Resolve alias reference.
@@ -231,7 +231,7 @@ class MemoryRegion(MemoryRangeBase):
             return referent
         else:
             return alias_value
-        
+
     def __getattr__(self, name):
         try:
             v = self._attributes[name]
@@ -245,7 +245,7 @@ class MemoryRegion(MemoryRangeBase):
 
     def _get_attributes_for_clone(self):
         """@brief Return a dict containing all the attributes of this region.
-        
+
         This method must be overridden by subclasses to include in the returned dict any instance attributes
         not present in the `_attributes` attribute.
         """
@@ -255,7 +255,7 @@ class MemoryRegion(MemoryRangeBase):
         """@brief Create a duplicate this region with some of its attributes modified."""
         new_attrs = self._get_attributes_for_clone()
         new_attrs.update(modified_attrs)
-        
+
         return self.__class__(**new_attrs)
 
     def __copy__(self):
@@ -263,7 +263,7 @@ class MemoryRegion(MemoryRangeBase):
 
     # Need to redefine __hash__ since we redefine __eq__.
     __hash__ = MemoryRangeBase.__hash__
-    
+
     def __eq__(self, other):
         # Include type and attributes in equality comparison.
         return self.start == other.start and self.length == other.length \
@@ -299,7 +299,7 @@ class DefaultFlashWeights:
 
 class FlashRegion(MemoryRegion):
     """! @brief Contiguous region of flash memory.
-    
+
     Flash regions have a number of attributes in addition to those available in all region types.
     - `blocksize`: Erase sector size in bytes.
     - `sector_size`: Alias for `blocksize`.
@@ -317,7 +317,7 @@ class FlashRegion(MemoryRegion):
     - `flash`: After connection, this attribute holds the instance of `flash_class` for this region.
     - `are_erased_sectors_readable`: Specifies whether the flash controller allows reads of erased
         sectors, or will fault such reads. Default is True.
-    
+
     `sector_size` and `blocksize` are aliases of each other. If one is set via the constructor, the
     other will have the same value.
     """
@@ -347,13 +347,13 @@ class FlashRegion(MemoryRegion):
         self._algo = attrs.get('algo', None)
         self._flm = attrs.get('flm', None)
         self._flash = None
-        
+
         if ('flash_class' in attrs) and (attrs['flash_class'] is not None):
             self._flash_class = attrs['flash_class']
             assert issubclass(self._flash_class, Flash)
         else:
             self._flash_class = Flash
-        
+
         # Remove writable region attributes from attributes dict so there is only one copy.
         try:
             del self._attributes['algo']
@@ -367,39 +367,39 @@ class FlashRegion(MemoryRegion):
             del self._attributes['flm']
         except KeyError:
             pass
-    
+
     @property
     def algo(self):
         return self._algo
-    
+
     @algo.setter
     def algo(self, flash_algo):
         self._algo = flash_algo
-    
+
     @property
     def flm(self):
         return self._flm
-    
+
     @flm.setter
     def flm(self, flm_path):
         self._flm = flm_path
-    
+
     @property
     def flash_class(self):
         return self._flash_class
-    
+
     @flash_class.setter
     def flash_class(self, klass):
         self._flash_class = klass
-    
+
     @property
     def flash(self):
         return self._flash
-    
+
     @flash.setter
     def flash(self, flash_instance):
         self._flash = flash_instance
-        
+
     def is_data_erased(self, d):
         """! @brief Helper method to check if a block of data is erased.
         @param self
@@ -425,7 +425,7 @@ class FlashRegion(MemoryRegion):
 
     # Need to redefine __hash__ since we redefine __eq__.
     __hash__ = MemoryRegion.__hash__
-    
+
     def __eq__(self, other):
         # Include flash algo, class, and flm in equality test.
         return super(FlashRegion, self).__eq__(other) and self.algo == other.algo and \
@@ -451,7 +451,7 @@ class DeviceRegion(MemoryRegion):
         attrs['type'] = MemoryType.DEVICE
         super(DeviceRegion, self).__init__(start=start, end=end, length=length, **attrs)
 
-## @brief Map from memory type to class.         
+## @brief Map from memory type to class.
 MEMORY_TYPE_CLASS_MAP = {
         MemoryType.OTHER:   MemoryRegion,
         MemoryType.RAM:     RamRegion,
@@ -462,10 +462,10 @@ MEMORY_TYPE_CLASS_MAP = {
 
 class MemoryMap(collections.abc.Sequence):
     """! @brief Memory map consisting of memory regions.
-    
+
     The normal way to create a memory map is to instantiate regions directly in the call to the
     constructor.
-    
+
     @code
     map = MemoryMap(
                 FlashRegion(    start=0,
@@ -473,25 +473,25 @@ class MemoryMap(collections.abc.Sequence):
                                 blocksize=0x400,
                                 is_boot_memory=True,
                                 algo=FLASH_ALGO),
-            
+
                 RamRegion(      start=0x10000000,
                                 length=0x1000)
                 )
     @endcode
-    
+
     The memory map can also be modified by adding and removing regions at runtime. Regardless of
     the order regions are added, the list of regions contained in the memory map is always
     maintained sorted by start address.
 
     MemoryMap objects implement the collections.abc.Sequence interface.
     """
-    
+
     def __init__(self, *more_regions):
         """! @brief Constructor.
-        
+
         All parameters passed to the constructor are assumed to be MemoryRegion instances, and
         are passed to add_regions(). The resulting memory map is sorted by region start address.
-        
+
         @param self
         @param more_regions Zero or more MemoryRegion objects passed as separate parameters.
         """
@@ -501,7 +501,7 @@ class MemoryMap(collections.abc.Sequence):
     @property
     def regions(self):
         """! @brief List of all memory regions.
-        
+
         Regions in the returned list are sorted by start address.
         """
         return self._regions
@@ -513,7 +513,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def clone(self):
         """! @brief Create a duplicate of the memory map.
-        
+
         The duplicate memory map contains shallow copies of each of the regions. This is intended
         to be used so that `Target` objects in different but simultaneously live sessions have
         independant copies of the target's memory map.
@@ -522,13 +522,13 @@ class MemoryMap(collections.abc.Sequence):
 
     def add_regions(self, *more_regions):
         """! @brief Add multiple regions to the memory map.
-        
+
         There are two options for passing the list of regions to be added. The first is to pass
         each region as a separate parameter, similar to how the constructor is intended to be used.
         The second option is to pass either a list or tuple of regions.
-        
+
         The region list is kept sorted. If no regions are provided, the call is a no-op.
-        
+
         @param self
         @param more_regions Either a single tuple or list, or one or more MemoryRegion objects
             passed as separate parameters.
@@ -538,15 +538,15 @@ class MemoryMap(collections.abc.Sequence):
                 regionsToAdd = more_regions[0]
             else:
                 regionsToAdd = more_regions
-            
+
             for newRegion in regionsToAdd:
                 self.add_region(newRegion)
 
     def add_region(self, new_region):
         """! @brief Add one new region to the map.
-        
+
         The region list is resorted after adding the provided region.
-        
+
         @param self
         @param new_region An instance of MemoryRegion to add. A new instance that is a copy of this argument
             may be added to the memory map in order to guarantee unique region names.
@@ -555,11 +555,11 @@ class MemoryMap(collections.abc.Sequence):
         existing_names = [r.name for r in self._regions if r]
         if new_region.name and (new_region.name in existing_names):
             new_region = new_region.clone_with_changes(name=uniquify_name(new_region.name, existing_names))
-        
+
         new_region.map = self
         self._regions.append(new_region)
         self._regions.sort()
-    
+
     def remove_region(self, region):
         """! @brief Removes a memory region from the map.
         @param self
@@ -572,7 +572,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def get_boot_memory(self):
         """! @brief Returns the first region marked as boot memory.
-        
+
         @param self
         @return MemoryRegion or None.
         """
@@ -583,7 +583,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def get_region_for_address(self, address):
         """! @brief Returns the first region containing the given address.
-        
+
         @param self
         @param address An integer target address.
         @return MemoryRegion or None.
@@ -595,7 +595,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def is_valid_address(self, address):
         """! @brief Determines whether an address is contained by any region.
-        
+
         @param self
         @param address An integer target address.
         @return Boolean indicating whether the address was contained by a region.
@@ -604,7 +604,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def get_contained_regions(self, start, end=None, length=None, range=None):
         """! @brief Get all regions fully contained by an address range.
-        
+
         @param self
         @param start The start address or a MemoryRange object.
         @param end Optional end address.
@@ -618,7 +618,7 @@ class MemoryMap(collections.abc.Sequence):
 
     def get_intersecting_regions(self, start, end=None, length=None, range=None):
         """! @brief Get all regions intersected by an address range.
-        
+
         @param self
         @param start The start address or a MemoryRange object.
         @param end Optional end address.
@@ -629,12 +629,12 @@ class MemoryMap(collections.abc.Sequence):
         """
         start, end = check_range(start, end, length, range)
         return [r for r in self._regions if r.intersects_range(start, end)]
-    
+
     def iter_matching_regions(self, **kwargs):
         """! @brief Iterate over regions matching given criteria.
-        
+
         Useful attributes to match on include 'type', 'name', 'is_default', and others.
-        
+
         @param self
         @param kwargs Values for region attributes that must match.
         """
@@ -651,15 +651,15 @@ class MemoryMap(collections.abc.Sequence):
                     mismatch = True
             if mismatch:
                 continue
-            
+
             yield r
-    
+
     def get_first_matching_region(self, **kwargs):
         """! @brief Get the first region matching a given memory type.
-        
+
         The region of given type with the lowest start address is returned. If there are no regions
         with that type, None is returned instead.
-        
+
         @param self
         @param type One of the MemoryType enums.
         @return A MemoryRegion object or None.
@@ -667,14 +667,14 @@ class MemoryMap(collections.abc.Sequence):
         for r in self.iter_matching_regions(**kwargs):
             return r
         return None
-    
+
     def get_default_region_of_type(self, type):
         """! @brief Get the default region of a given memory type.
-        
+
         If there are multiple regions of the specified type marked as default, then the one with
         the lowest start address will be returned. None is returned if there are no default regions
         of the type.
-        
+
         @param self
         @param type One of the MemoryType enums.
         @return A MemoryRegion object or None.
@@ -687,22 +687,22 @@ class MemoryMap(collections.abc.Sequence):
     def __iter__(self):
         """! @brief Enable iteration over the memory map."""
         return iter(self._regions)
-    
+
     def __reversed__(self):
         """! @brief Reverse iteration over the memory map."""
         return reversed(self._regions)
-    
+
     def __getitem__(self, key):
         """! @brief Return a region indexed by name or number."""
         if isinstance(key, str):
             return self.get_first_matching_region(name=key)
         else:
             return self._regions[key]
-    
+
     def __len__(self):
         """! @brief Return the number of regions."""
         return len(self._regions)
-    
+
     def __contains__(self, key):
         if isinstance(key, int):
             return self.is_valid_address(key)

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -37,12 +37,12 @@ OptionChangeInfo = namedtuple('OptionChangeInfo', 'new_value old_value')
 
 class OptionsManager(Notifier):
     """! @brief Handles session option management for a session.
-    
+
     The options manager supports multiple layers of option priority. When an option's value is
     accessed, the highest priority layer that contains a value for the option is used. This design
     makes it easy to load options from multiple sources. The default value specified for an option
     in the OPTIONS_INFO dictionary provides a layer with an infinitely low priority.
-    
+
     Users can subscribe to notifications for changes to option values by calling the subscribe()
     method. The notification events are the option names themselves. The source for notifications is
     always the options manager instance. The notification data is an instance of OptionChangeInfo
@@ -55,10 +55,10 @@ class OptionsManager(Notifier):
         """
         super(OptionsManager, self).__init__()
         self._layers = []
-    
+
     def _update_layers(self, new_options, update_operation):
         """! @brief Internal method to add a new layer dictionary.
-        
+
         @param self
         @param new_options Dictionary of option values.
         @param update_operation Callable to add the layer. Must accept a single parameter, which is
@@ -74,23 +74,23 @@ class OptionsManager(Notifier):
 
     def add_front(self, new_options):
         """! @brief Add a new highest priority layer of option values.
-        
+
         @param self
         @param new_options Dictionary of option values.
         """
         self._update_layers(new_options, partial(self._layers.insert, 0))
-    
+
     def add_back(self, new_options):
         """! @brief Add a new lowest priority layer of option values.
-        
+
         @param self
         @param new_options Dictionary of option values.
         """
         self._update_layers(new_options, self._layers.append)
-    
+
     def _convert_options(self, new_options):
         """! @brief Prepare a dictionary of session options for use by the manager.
-        
+
         1. Strip dictionary entries with a value of None.
         2. Replace double-underscores ("__") with a dot (".").
         3. Convert option names to all-lowercase.
@@ -106,7 +106,7 @@ class OptionsManager(Notifier):
 
     def is_set(self, key):
         """! @brief Return whether a value is set for the specified option.
-        
+
         This method returns True as long as any layer has a value set for the option, even if the
         value is the same as the default value. If the option is not set in any layer, then False is
         returned regardless of whether the default value is None.
@@ -129,18 +129,18 @@ class OptionsManager(Notifier):
             if key in layer:
                 return layer[key]
         return self.get_default(key)
-    
+
     def set(self, key, value):
         """! @brief Set an option in the current highest priority layer."""
         self.update({key: value})
-    
+
     def update(self, new_options):
         """! @brief Set multiple options in the current highest priority layer."""
         filtered_options = self._convert_options(new_options)
         previous_values = {name: self.get(name) for name in filtered_options.keys()}
         self._layers[0].update(filtered_options)
         self._notify_changes(previous_values, filtered_options)
-    
+
     def _notify_changes(self, previous, options):
         """! @brief Send notifications that the specified options have changed."""
         for name, new_value in options.items():
@@ -151,11 +151,11 @@ class OptionsManager(Notifier):
     def __contains__(self, key):
         """! @brief Returns whether the named option has a non-default value."""
         return self.is_set(key)
-        
+
     def __getitem__(self, key):
         """! @brief Return the highest priority value for the option, or its default."""
         return self.get(key)
-    
+
     def __setitem__(self, key, value):
         """! @brief Set an option in the current highest priority layer."""
         self.set(key, value)

--- a/pyocd/core/plugin.py
+++ b/pyocd/core/plugin.py
@@ -24,50 +24,50 @@ LOG = logging.getLogger(__name__)
 
 class Plugin(object):
     """! @brief Class that describes a plugin for pyOCD.
-    
+
     Each plugin vends a subclass of Plugin that describes itself and provides meta-actions.
-    
+
     An instance is created and queried for whether the plugin can be loaded by calling
     should_load(). If this method returns True, then load() is called. The default implementation
     will always load, and does nothing when loaded.
     """
-    
+
     def should_load(self):
         """! @brief Whether the plugin should be loaded."""
         return True
-    
+
     def load(self):
         """! @brief Load the plugin and return the plugin implementation.
-        
+
         This method can perform any actions required to load the plugin beyond simply returning
         the implementation.
-        
+
         @return An object appropriate for the plugin type, which normally would be a class object.
         """
         pass
-    
+
     @property
     def options(self):
         """! @brief A list of options added by the plugin.
         @return List of @ref pyocd.core.options.OptionInfo "OptionInfo" objects.
         """
         return []
-    
+
     @property
     def version(self):
         """! @brief Current version of the plugin.
-        
+
         The default implementation returns pyOCD's version.
-        
+
         @return String with the plugin's version, such as '2.13.4'.
         """
         return pyocd_version
-    
+
     @property
     def name(self):
         """! @brief Name of the plugin."""
         raise NotImplementedError()
-    
+
     @property
     def description(self):
         """! @brief Short description of the plugin."""
@@ -75,10 +75,10 @@ class Plugin(object):
 
 def load_plugin_classes_of_type(plugin_group, plugin_dict, base_class):
     """! @brief Helper method to load plugins.
-    
+
     Plugins are expected to return an implementation class from their Plugin.load() method. This
     class must be derived from `base_class`.
-    
+
     @param plugin_group String of the plugin group, e.g. 'pyocd.probe'.
     @param plugin_dict Dictionary to fill with loaded plugin classes.
     @param base_class The required superclass for plugin implementation classes.
@@ -90,7 +90,7 @@ def load_plugin_classes_of_type(plugin_group, plugin_dict, base_class):
             LOG.warning("Plugin '%s' of type '%s' has an invalid plugin object",
                     entry_point.name, plugin_group)
             continue
-        
+
         # Ask the plugin whether it should be loaded.
         if plugin.should_load():
             # Load the plugin and stuff the implementation class it gives
@@ -100,7 +100,7 @@ def load_plugin_classes_of_type(plugin_group, plugin_dict, base_class):
                         plugin.name, plugin_group)
                 continue
             plugin_dict[plugin.name] = impl_class
-            
+
             # Add any plugin options.
             add_option_set(plugin.options)
-                
+

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -45,33 +45,33 @@ _USER_SCRIPT_NAMES = [
 
 class Session(Notifier):
     """! @brief Top-level object for a debug session.
-    
+
     This class represents a debug session with a single debug probe. It is the root of the object
     graph, where it owns the debug probe and the board objects.
-    
+
     Another important function of this class is that it contains a dictionary of session-scope
     options. These would normally be passed in from the command line. Options can also be loaded
     from a config file.
 
     Precedence for session options:
-    
+
     1. Keyword arguments to constructor.
     2. _options_ parameter to constructor.
     3. Probe-specific options from a config file.
     4. General options from a config file.
     5. _option_defaults_ parameter to constructor.
-    
+
     The session also tracks several other objects:
     - @ref pyocd.gdbserver.gdbserver.GDBServer "GDBServer" instances created for any cores.
     - @ref pyocd.probe.tcp_probe_server.DebugProbeServer "DebugProbeServer".
     - The user script proxy.
-    
+
     See the @ref pyocd.core.helpers.ConnectHelper "ConnectHelper" class for several methods that
     make it easy to create new sessions, with or without user interaction in the case of multiple
-    available debug probes. A common pattern is to combine @ref 
+    available debug probes. A common pattern is to combine @ref
     pyocd.core.helpers.ConnectHelper.session_with_chosen_probe()
     "ConnectHelper.session_with_chosen_probe()" and a **with** block.
-    
+
     A Session instance can be used as a context manager. The session will, by default, be
     automatically opened when the context is entered. And, of course, it will be closed when the
     **with** block is exited (which is harmless if the session was never opened). If you wish to
@@ -79,18 +79,18 @@ class Session(Notifier):
     exception is raised while opening a session inside a **with** statement, the session will be
     closed for you to undo any partial initialisation.
     """
-    
+
     ## @brief Weak reference to the most recently created session.
     _current_session = None
-    
+
     @classmethod
     def get_current(cls):
         """! @brief Return the most recently created Session instance or a default Session.
-        
+
         By default this method will return the most recently created Session object that is
         still alive. If no live session exists, a new default session will be created and returned.
         That at least provides access to the user's config file(s).
-        
+
         Used primarily so code that doesn't have a session reference can access session options. This
         method should only be used to access options that are unlikely to differ between sessions,
         or for debug or other purposes.
@@ -102,18 +102,18 @@ class Session(Notifier):
 
     def __init__(self, probe, auto_open=True, options=None, option_defaults=None, **kwargs):
         """! @brief Session constructor.
-        
+
         Creates a new session using the provided debug probe. Session options are merged from the
         _options_ parameter and any keyword arguments. Normally a board instance is created that can
         either be a generic board or a board associated with the debug probe.
-        
+
         Note that the 'project_dir' and 'config' options must be set in either keyword arguments or
         the _options_ parameter.
-        
+
         Passing in a _probe_ that is None is allowed. This is useful to create a session that operates
         only as a container for session options. In this case, the board instance is not created, so the
         #board attribute will be None. Such a Session cannot be opened.
-        
+
         @param self
         @param probe The @ref pyocd.probe.debug_probe. "DebugProbe" instance. May be None.
         @param auto_open Whether to automatically open the session when used as a context manager.
@@ -124,9 +124,9 @@ class Session(Notifier):
         @param kwargs Session options passed as keyword arguments.
         """
         super(Session, self).__init__()
-        
+
         Session._current_session = weakref.ref(self)
-        
+
         self._probe = probe
         self._closed = True
         self._inited = False
@@ -137,22 +137,22 @@ class Session(Notifier):
         self._options = OptionsManager()
         self._gdbservers = {}
         self._probeserver = None
-        
+
         # Set this session on the probe, if we were given a probe.
         if probe is not None:
             probe.session = self
-        
+
         # Update options.
         self._options.add_front(kwargs)
         self._options.add_back(options)
-        
+
         # Init project directory.
         if self.options.get('project_dir') is None:
             self._project_dir = os.environ.get('PYOCD_PROJECT_DIR') or os.getcwd()
         else:
             self._project_dir = os.path.abspath(os.path.expanduser(self.options.get('project_dir')))
         LOG.debug("Project directory: %s", self.project_dir)
-            
+
         # Apply common configuration settings from the config file.
         config = self._get_config()
         probesConfig = config.pop('probes', None)
@@ -164,29 +164,29 @@ class Session(Notifier):
                 if str(uid).lower() in probe.unique_id.lower():
                     LOG.info("Using config settings for probe %s" % (probe.unique_id))
                     self._options.add_back(settings)
-        
+
         # Merge in lowest priority options.
         self._options.add_back(option_defaults)
-        
+
         # Logging config.
         self._configure_logging()
-        
+
         # Bail early if we weren't provided a probe.
         if probe is None:
             self._board = None
             return
-        
+
         # Load the user script.
         self._load_user_script()
-        
+
         # Ask the probe if it has an associated board, and if not then we create a generic one.
         self._board = probe.create_associated_board() or Board(self)
-    
+
     def _get_config(self):
         # Load config file if one was provided via options, and no_config option was not set.
         if not self.options.get('no_config'):
             configPath = self.find_user_file('config_file', _CONFIG_FILE_NAMES)
-                    
+
             if configPath is not None:
                 try:
                     with open(configPath, 'r') as configFile:
@@ -202,12 +202,12 @@ class Session(Notifier):
                         return config
                 except IOError as err:
                     LOG.warning("Error attempting to access config file '%s': %s", configPath, err)
-        
+
         return {}
-            
+
     def find_user_file(self, option_name, filename_list):
         """! @brief Search the project directory for a file.
-        
+
         @retval None No matching file was found.
         @retval string An absolute path to the requested file.
         """
@@ -215,7 +215,7 @@ class Session(Notifier):
             filePath = self.options.get(option_name)
         else:
             filePath = None
-        
+
         # Look for default filenames if a path wasn't provided.
         if filePath is None:
             for filename in filename_list:
@@ -229,18 +229,18 @@ class Session(Notifier):
             filePath = os.path.expanduser(filePath)
             if not os.path.isabs(filePath):
                 filePath = os.path.join(self.project_dir, filePath)
-        
+
         return filePath
-    
+
     def _configure_logging(self):
         """! @brief Load a logging config dict or file."""
         # Get logging config that could have been loaded from the config file.
         config = self.options.get('logging')
-        
+
         # Allow logging setting to refer to another file.
         if isinstance(config, str):
             loggingConfigPath = self.find_user_file(None, [config])
-            
+
             if loggingConfigPath is not None:
                 try:
                     with open(loggingConfigPath, 'r') as configFile:
@@ -260,75 +260,75 @@ class Session(Notifier):
             # Remove an empty 'loggers' key.
             if ('loggers' in config) and (config['loggers'] is None):
                 del config['loggers']
-            
+
             try:
                 logging.config.dictConfig(config)
             except (ValueError, TypeError, AttributeError, ImportError) as err:
                 LOG.warning("Error applying logging configuration: %s", err)
-    
+
     @property
     def is_open(self):
         """! @brief Boolean of whether the session has been opened."""
         return self._inited and not self._closed
-    
+
     @property
     def probe(self):
         """! @brief The @ref pyocd.probe.debug_probe.DebugProbe "DebugProbe" instance."""
         return self._probe
-    
+
     @property
     def board(self):
         """! @brief The @ref pyocd.board.board.Board "Board" object."""
         return self._board
-    
+
     @property
     def target(self):
         """! @brief The @ref pyocd.core.target.soc_target "SoCTarget" object representing the SoC.
-        
+
         This is the @ref pyocd.core.target.soc_target "SoCTarget" instance owned by the board.
         """
         return self.board.target
-    
+
     @property
     def options(self):
         """! @brief The @ref pyocd.core.options_manager.OptionsManager "OptionsManager" object."""
         return self._options
-    
+
     @property
     def project_dir(self):
         """! @brief Path to the project directory."""
         return self._project_dir
-    
+
     @property
     def delegate(self):
         """! @brief An optional delegate object for customizing behaviour."""
         return self._delegate
-    
+
     @delegate.setter
     def delegate(self, new_delegate):
         """! @brief Setter for the `delegate` property."""
         self._delegate = new_delegate
-    
+
     @property
     def user_script_proxy(self):
         """! @brief The UserScriptDelegateProxy object for a loaded user script."""
         return self._user_script_proxy
-    
+
     @property
     def gdbservers(self):
         """! @brief Dictionary of core numbers to @ref pyocd.gdbserver.gdbserver.GDBServer "GDBServer" instances."""
         return self._gdbservers
-    
+
     @property
     def probeserver(self):
         """! @brief A @ref pyocd.probe.tcp_probe_server.DebugProbeServer "DebugProbeServer" instance."""
         return self._probeserver
-    
+
     @probeserver.setter
     def probeserver(self, server):
         """! @brief Setter for the `probeserver` property."""
         self._probeserver = server
-    
+
     @property
     def log_tracebacks(self):
         """! @brief Quick access to debug.traceback option since it is widely used."""
@@ -347,10 +347,10 @@ class Session(Notifier):
     def __exit__(self, type, value, traceback):
         self.close()
         return False
-    
+
     def _init_user_script_namespace(self, user_script_path):
         """! @brief Create the namespace dict used for user scripts.
-        
+
         This initial namespace has only those objects that are available very early in the
         session init process. For instance, the Target instance isn't available yet. The
         _update_user_script_namespace() method is used to add such objects to the namespace
@@ -392,7 +392,7 @@ class Session(Notifier):
             'options': self.options,
             'LOG': logging.getLogger('pyocd.user_script'),
             }
-    
+
     def _update_user_script_namespace(self):
         """! @brief Add objects available only after init to the user script namespace."""
         if self._user_script_namespace is not None:
@@ -403,7 +403,7 @@ class Session(Notifier):
                 'dp': self.target.dp,
                 'aps': self.target.aps,
                 })
-    
+
     def _load_user_script(self):
         scriptPath = self.find_user_file('user_script', _USER_SCRIPT_NAMES)
 
@@ -413,16 +413,16 @@ class Session(Notifier):
                 with open(scriptPath, 'r') as scriptFile:
                     LOG.debug("Loading user script: %s", scriptPath)
                     scriptSource = scriptFile.read()
-                
+
                 self._init_user_script_namespace(scriptPath)
-                
+
                 scriptCode = compile(scriptSource, scriptPath, 'exec')
                 # Executing the code will create definitions in the namespace for any
                 # functions or classes. A single namespace is shared for both globals and
                 # locals so that script-level definitions are available within the
                 # script functions.
                 exec(scriptCode, self._user_script_namespace, self._user_script_namespace)
-                
+
                 # Create the proxy for the user script. It becomes the delegate unless
                 # another delegate was already set.
                 self._user_script_proxy = UserScriptDelegateProxy(self._user_script_namespace)
@@ -433,13 +433,13 @@ class Session(Notifier):
 
     def open(self, init_board=True):
         """! @brief Open the session.
-        
+
         This method does everything necessary to begin a debug session. It first loads the user
         script, if there is one. The user script will be available via the _user_script_proxy_
         property. Then it opens the debug probe and sets the clock rate from the `frequency` user
         option. Finally, it inits the board (which will init the target, which performs the
         full target init sequence).
-        
+
         @param self
         @param init_board This parameter lets you prevent the board from being inited, which can
             be useful in board bringup situations. It's also used by pyocd commander's "no init"
@@ -448,10 +448,10 @@ class Session(Notifier):
         if not self._inited:
             assert self._probe is not None, "Cannot open a session without a probe."
             assert self._board is not None, "Must have a board to open a session."
-            
+
             # Add in the full set of objects for the user script.
             self._update_user_script_namespace()
-            
+
             self._probe.open()
             self._closed = False
             self._probe.set_clock(self.options.get('frequency'))
@@ -461,7 +461,7 @@ class Session(Notifier):
 
     def close(self):
         """! @brief Close the session.
-        
+
         Uninits the board and disconnects then closes the probe.
         """
         if self._closed:
@@ -475,7 +475,7 @@ class Session(Notifier):
                 self._inited = False
             except exceptions.Error:
                 LOG.error("exception during board uninit:", exc_info=self.log_tracebacks)
-        
+
         if self._probe.is_open:
             try:
                 self._probe.disconnect()
@@ -488,14 +488,14 @@ class Session(Notifier):
 
 class UserScriptFunctionProxy(object):
     """! @brief Proxy for user script functions.
-    
-    This proxy makes arguments to user script functions optional. 
+
+    This proxy makes arguments to user script functions optional.
     """
 
     def __init__(self, fn):
         self._fn = fn
         self._spec = getfullargspec(fn)
-    
+
     def __call__(self, **kwargs):
         args = {}
         for arg in self._spec.args:
@@ -509,7 +509,7 @@ class UserScriptDelegateProxy(object):
     def __init__(self, script_namespace):
         super(UserScriptDelegateProxy, self).__init__()
         self._script = script_namespace
-    
+
     def __getattr__(self, name):
         if name in self._script:
             fn = self._script[name]

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -28,17 +28,17 @@ LOG = logging.getLogger(__name__)
 
 class SoCTarget(Target, GraphNode):
     """! @brief Represents a microcontroller system-on-chip.
-    
+
     An instance of this class is the root of the chip-level object graph. It has child
     nodes for the DP and all cores. As a concrete subclass of Target, it provides methods
     to control the device, access memory, adjust breakpoints, and so on.
-    
+
     For single core devices, the SoCTarget has mostly equivalent functionality to
     the Target object for the core. Multicore devices work differently. This class tracks
     a "selected core", to which all actions are directed. The selected core can be changed
     at any time. You may also directly access specific cores and perform operations on them.
     """
-    
+
     VENDOR = "Generic"
 
     def __init__(self, session, memory_map=None):
@@ -61,7 +61,7 @@ class SoCTarget(Target, GraphNode):
         if self._selected_core is None:
             return None
         return self.cores[self._selected_core]
-    
+
     @selected_core.setter
     def selected_core(self, core_number):
         if core_number not in self.cores:
@@ -84,11 +84,11 @@ class SoCTarget(Target, GraphNode):
                 if self.session.options['cache.read_code_from_elf']:
                     self.cores[core_number].set_target_context(
                             ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
-    
+
     @property
     def supported_security_states(self):
         return self.selected_core.supported_security_states
-    
+
     @property
     def core_registers(self):
         return self.selected_core.core_registers
@@ -98,28 +98,28 @@ class SoCTarget(Target, GraphNode):
         core.set_target_context(CachingDebugContext(core))
         self.cores[core.core_number] = core
         self.add_child(core)
-        
+
         if self._selected_core is None:
             self._selected_core = core.core_number
 
     def create_init_sequence(self):
         # Return an empty call sequence. The subclass must override this.
         return CallSequence()
-    
+
     def init(self):
         # If we don't have a delegate installed yet but there is a session delegate, use it.
         if (self.delegate is None) and (self.session.delegate is not None):
             self.delegate = self.session.delegate
-        
+
         # Create and execute the init sequence.
         seq = self.create_init_sequence()
         self.call_delegate('will_init_target', target=self, init_sequence=seq)
         seq.invoke()
         self.call_delegate('did_init_target', target=self)
-    
+
     def post_connect_hook(self):
         """! @brief Hook function called after post_connect init task.
-        
+
         This hook lets the target subclass configure the target as necessary.
         """
         pass
@@ -218,7 +218,7 @@ class SoCTarget(Target, GraphNode):
 
     def get_state(self):
         return self.selected_core.get_state()
-        
+
     def get_security_state(self):
         return self.selected_core.get_security_state()
 
@@ -235,11 +235,11 @@ class SoCTarget(Target, GraphNode):
         if core is None:
             core = self._selected_core
         return self.cores[core].get_target_context()
-    
+
     def trace_start(self):
         self.call_delegate('trace_start', target=self, mode=0)
-    
+
     def trace_stop(self):
         self.call_delegate('trace_stop', target=self, mode=0)
-    
-        
+
+

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -34,7 +34,7 @@ class Target(MemoryInterface):
         SLEEPING = 4
         ## Core is locked up.
         LOCKUP = 5
-    
+
     class SecurityState(Enum):
         """! @brief Security states for a processor with the Security extension."""
         ## PE is in the Non-secure state.
@@ -81,7 +81,7 @@ class Target(MemoryInterface):
 
     class VectorCatch:
         """! Vector catch option masks.
-        
+
         These constants can be OR'd together to form any combination of vector catch settings.
         """
         ## Disable vector catch.
@@ -145,7 +145,7 @@ class Target(MemoryInterface):
 
     class RunType(Enum):
         """! Run type for run notifications.
-        
+
         An enum of this type is set as the data attribute on PRE_RUN and POST_RUN notifications.
         """
         ## Target is being resumed.
@@ -155,7 +155,7 @@ class Target(MemoryInterface):
 
     class HaltReason(Enum):
         """! Halt type for halt notifications.
-        
+
         An value of this type is returned from Target.get_halt_reason(). It is also used as the data
         attribute on PRE_HALT and POST_HALT notifications.
         """
@@ -186,18 +186,18 @@ class Target(MemoryInterface):
     @property
     def session(self):
         return self._session
-    
+
     @property
     def delegate(self):
         return self._delegate
-    
+
     @delegate.setter
     def delegate(self, the_delegate):
         self._delegate = the_delegate
-    
+
     def delegate_implements(self, method_name):
         return (self._delegate is not None) and (hasattr(self._delegate, method_name))
-    
+
     def call_delegate(self, method_name, *args, **kwargs):
         if self.delegate_implements(method_name):
             return getattr(self._delegate, method_name)(*args, **kwargs)
@@ -208,11 +208,11 @@ class Target(MemoryInterface):
     @property
     def svd_device(self):
         return self._svd_device
-    
+
     @property
     def supported_security_states(self):
         raise NotImplementedError()
-    
+
     @property
     def core_registers(self):
         raise NotImplementedError()
@@ -288,7 +288,7 @@ class Target(MemoryInterface):
 
     def get_state(self):
         raise NotImplementedError()
-        
+
     def get_security_state(self):
         raise NotImplementedError()
 

--- a/pyocd/core/target_delegate.py
+++ b/pyocd/core/target_delegate.py
@@ -16,14 +16,14 @@
 
 class TargetDelegateInterface(object):
     """! @brief Abstract class defining the delegate interface for targets.
-    
+
     Note that delegates don't actually have to derive from this class due to Python's
     dynamic method dispatching.
     """
 
     def __init__(self, session):
         self._session = session
-    
+
     def will_connect(self, board):
         """! @brief Pre-init hook for the board.
         @param self
@@ -31,7 +31,7 @@ class TargetDelegateInterface(object):
         @return Ignored.
         """
         pass
-    
+
     def did_connect(self, board):
         """! @brief Post-initialization hook for the board.
         @param self
@@ -49,7 +49,7 @@ class TargetDelegateInterface(object):
         @return Ignored.
         """
         pass
-    
+
     def did_init_target(self, target):
         """! @brief Post-initialization hook.
         @param self
@@ -66,7 +66,7 @@ class TargetDelegateInterface(object):
         @retval "False or None" Continue with normal behaviour.
         """
         pass
-    
+
     def did_start_debug_core(self, core):
         """! @brief Post-initialization hook.
         @param self
@@ -83,7 +83,7 @@ class TargetDelegateInterface(object):
         @retval "False or None" Continue with normal behaviour.
         """
         pass
-    
+
     def did_stop_debug_core(self, core):
         """! @brief Post-cleanup hook for the core.
         @param self
@@ -174,5 +174,5 @@ class TargetDelegateInterface(object):
         @return Ignored.
         """
         pass
-    
+
 

--- a/pyocd/coresight/component.py
+++ b/pyocd/coresight/component.py
@@ -19,7 +19,7 @@ from ..utility.graph import GraphNode
 
 class CoreSightComponent(GraphNode):
     """! @brief CoreSight component base class."""
-    
+
     @classmethod
     def factory(cls, ap, cmpid, address):
         """! @brief Common CoreSightComponent factory."""
@@ -34,30 +34,30 @@ class CoreSightComponent(GraphNode):
         self._ap = ap
         self._cmpid = cmpid
         self._address = addr if (addr is not None) else (cmpid.address if cmpid else None)
-    
+
     @property
     def ap(self):
         return self._ap
-    
+
     @property
     def cmpid(self):
         return self._cmpid
-    
+
     @cmpid.setter
     def cmpid(self, newCmpid):
         self._cmpid = newCmpid
-    
+
     @property
     def address(self):
         return self._address
-    
+
     @address.setter
     def address(self, newAddr):
         self._address = newAddr
 
 class CoreSightCoreComponent(CoreSightComponent):
     """! @brief CoreSight component for a CPU core.
-    
+
     This class serves only as a superclass for identifying core-type components.
     """
     pass

--- a/pyocd/coresight/component_ids.py
+++ b/pyocd/coresight/component_ids.py
@@ -120,19 +120,19 @@ COMPONENT_MAP = {
     (ARM_ID, CORESIGHT_CLASS, 0x927, 0x11, 0)      : CmpInfo('TPIU',            'SC300',    None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x932, 0x31, 0x0a31) : CmpInfo('MTB',             'M0+',      None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x950, 0x13, 0)      : CmpInfo('PTM',             'A9',       None                ),
-    (ARM_ID, CORESIGHT_CLASS, 0x961, 0x32, 0)      : CmpInfo('ETF',             None,       None                ), # Trace Memory Controller ETF    
-    (ARM_ID, CORESIGHT_CLASS, 0x962, 0x63, 0x0a63) : CmpInfo('STM',             None,       None                ), # System Trace Macrocell 
-    (ARM_ID, CORESIGHT_CLASS, 0x963, 0x63, 0x0a63) : CmpInfo('STM-500',         None,       None                ), # System Trace Macrocell 
+    (ARM_ID, CORESIGHT_CLASS, 0x961, 0x32, 0)      : CmpInfo('ETF',             None,       None                ), # Trace Memory Controller ETF
+    (ARM_ID, CORESIGHT_CLASS, 0x962, 0x63, 0x0a63) : CmpInfo('STM',             None,       None                ), # System Trace Macrocell
+    (ARM_ID, CORESIGHT_CLASS, 0x963, 0x63, 0x0a63) : CmpInfo('STM-500',         None,       None                ), # System Trace Macrocell
     (ARM_ID, CORESIGHT_CLASS, 0x975, 0x13, 0x4a13) : CmpInfo('ETM',             'M7',       None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a0, 0x16, 0)      : CmpInfo('PMU',             'A9',       None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a1, 0x11, 0)      : CmpInfo('TPIU',            'M4',       TPIU.factory        ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a3, 0x13, 0x0)    : CmpInfo('MTB',             'M0',       None                ),
-    (ARM_ID, CORESIGHT_CLASS, 0x9a4, 0x34, 0x0a34) : CmpInfo('GPR',             None,       GPR.factory         ), # Granular Power Requestor   
+    (ARM_ID, CORESIGHT_CLASS, 0x9a4, 0x34, 0x0a34) : CmpInfo('GPR',             None,       GPR.factory         ), # Granular Power Requestor
     (ARM_ID, CORESIGHT_CLASS, 0x9a5, 0x16, 0)      : CmpInfo('PMU',             'A5',       None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a6, 0x14, 0x1a14) : CmpInfo('CTI',             'M0+',      None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a7, 0x16, 0)      : CmpInfo('PMU',             'A7',       None                ),
     (ARM_ID, CORESIGHT_CLASS, 0x9a9, 0x11, 0)      : CmpInfo('TPIU',            'M7',       TPIU.factory        ),
-    (ARM_ID, CORESIGHT_CLASS, 0x9ba, 0x55, 0x0a55) : CmpInfo('PMC-100',         None,       None                ), # Programmable MBIST Controller  
+    (ARM_ID, CORESIGHT_CLASS, 0x9ba, 0x55, 0x0a55) : CmpInfo('PMC-100',         None,       None                ), # Programmable MBIST Controller
     (ARM_ID, CORESIGHT_CLASS, 0x9db, 0x13, 0x4a13) : CmpInfo('ETM',             'A32',      None                ), # ETMv4
     (ARM_ID, CORESIGHT_CLASS, 0x9db, 0x14, 0x1a14) : CmpInfo('CTI',             'A32',      None                ), # CTIv2
     (ARM_ID, CORESIGHT_CLASS, 0x9db, 0x16, 0x2a16) : CmpInfo('PMU',             'A32',      None                ), # PMUv3
@@ -213,7 +213,7 @@ COMPONENT_MAP = {
     (ARM_ID, GENERIC_CLASS,   0x00c, 0x00, 0)      : CmpInfo('SCS',             'v7-M',     CortexM.factory     ),
     (ARM_ID, GENERIC_CLASS,   0x00d, 0x00, 0)      : CmpInfo('SCS',             'SC000',    CortexM.factory     ),
     (ARM_ID, GENERIC_CLASS,   0x00e, 0x00, 0)      : CmpInfo('FPB',             'v7-M',     FPB.factory         ),
-    (ARM_ID, SYSTEM_CLASS,    0x101, 0x00, 0)      : CmpInfo('TSGEN',           None,       None                ), # Timestamp Generator    
+    (ARM_ID, SYSTEM_CLASS,    0x101, 0x00, 0)      : CmpInfo('TSGEN',           None,       None                ), # Timestamp Generator
     (FSL_ID, CORESIGHT_CLASS, 0x000, 0x04, 0)      : CmpInfo('MTBDWT',          None,       None                ),
     }
 

--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -56,7 +56,7 @@ class CoreArchitecture(Enum):
     ARMv7M = 2
     ARMv8M_BASE = 3
     ARMv8M_MAIN = 4
-    
+
 class CortexMExtension(Enum):
     """! @brief Extensions for the Cortex-M architecture."""
     FPU = "FPU" # Single-Precision floating point

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -32,16 +32,16 @@ LOG = logging.getLogger(__name__)
 
 class CoreSightTarget(SoCTarget):
     """! @brief Represents an SoC that uses CoreSight debug infrastructure.
-    
+
     This class adds Arm CoreSight-specific discovery and initialization code to SoCTarget.
     """
-    
+
     def __init__(self, session, memory_map=None):
         # Supply a default memory map.
         if (memory_map is None) or (memory_map.region_count == 0):
             memory_map = self._create_default_cortex_m_memory_map()
             LOG.debug("Using default Cortex-M memory map (no memory map supplied)")
-        
+
         super(CoreSightTarget, self).__init__(session, memory_map)
         self.dp = dap.DebugPort(session.probe, self)
         self._svd_load_thread = None
@@ -97,12 +97,12 @@ class CoreSightTarget(SoCTarget):
             ('create_flash',        self.create_flash),
             ('notify',              lambda : self.session.notify(Target.Event.POST_CONNECT, self))
             )
-        
+
         return seq
 
     def disconnect(self, resume=True):
         """! @brief Disconnect from the target.
-        
+
         Same as SoCTarget.disconnect(), except that it asks the DebugPort to power down.
         """
         self.session.notify(Target.Event.PRE_DISCONNECT, self)
@@ -111,10 +111,10 @@ class CoreSightTarget(SoCTarget):
             core.disconnect(resume)
         self.dp.disconnect()
         self.call_delegate('did_disconnect', target=self, resume=resume)
-            
+
     def create_discoverer(self):
         """! @brief Init task to create the discovery object.
-        
+
         Instantiates the appropriate @ref pyocd.coresight.discovery.CoreSightDiscovery
         CoreSightDiscovery subclass for the target's ADI version.
         """
@@ -122,7 +122,7 @@ class CoreSightTarget(SoCTarget):
 
     def pre_connect(self):
         """! @brief Handle some of the connect modes.
-        
+
         This init task performs a connect pre-reset or asserts reset if the connect mode is
         under-reset.
         """
@@ -133,10 +133,10 @@ class CoreSightTarget(SoCTarget):
         elif mode == 'under-reset':
             LOG.info("Asserting reset prior to connect")
             self.dp.assert_reset(True)
-    
+
     def perform_halt_on_connect(self):
         """! @brief Halt cores.
-        
+
         This init task performs a connect pre-reset or asserts reset if the connect mode is
         under-reset.
         """
@@ -154,10 +154,10 @@ class CoreSightTarget(SoCTarget):
                 except exceptions.Error as err:
                     LOG.warning("Could not halt core #%d: %s", core.core_number, err,
                         exc_info=self.session.log_tracebacks)
-    
+
     def post_connect(self):
         """! @brief Handle cleaning up some of the connect modes.
-        
+
         This init task de-asserts reset if the connect mode is under-reset.
         """
         mode = self.session.options.get('connect_mode')
@@ -173,10 +173,10 @@ class CoreSightTarget(SoCTarget):
                 except exceptions.Error as err:
                     LOG.warning("Could not halt core #%d: %s", core.core_number, err,
                         exc_info=self.session.log_tracebacks)
-    
+
     def create_flash(self):
         """! @brief Instantiates flash objects for memory regions.
-        
+
         This init task iterates over flash memory regions and for each one creates the Flash
         instance. It uses the flash_algo and flash_class properties of the region to know how
         to construct the flash object.
@@ -208,12 +208,12 @@ class CoreSightTarget(SoCTarget):
                 algo = pack_algo.get_pyocd_flash_algo(
                         page_size,
                         self.memory_map.get_default_region_of_type(MemoryType.RAM))
-                
+
                 # If we got a valid algo from the FLM, set it on the region. This will then
                 # be used below.
                 if algo is not None:
                     region.algo = algo
-            
+
             # If the constructor of the region's flash class takes the flash_algo arg, then we
             # need the region to have a flash algo dict to pass to it. Otherwise we assume the
             # algo is built-in.
@@ -227,10 +227,10 @@ class CoreSightTarget(SoCTarget):
                     continue
             else:
                 obj = klass(self)
-            
+
             # Set the region in the flash instance.
             obj.region = region
-            
+
             # Store the flash object back into the memory region.
             region.flash = obj
 
@@ -268,5 +268,5 @@ class CoreSightTarget(SoCTarget):
             self.dp.reset()
         else:
             super().reset(reset_type)
-    
-        
+
+

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -28,7 +28,7 @@ IPSR_MASK = 0x000001FF
 
 class CortexMCoreRegisterInfo(CoreRegisterInfo):
     """! @brief Core register subclass for Cortex-M registers.
-    
+
     For most registers, the index is the value written to the DCRSR register to read or write the
     core register. Other core registers not directly supported by DCRSR have special index values that
     are interpreted by the helper methods on this class and the core register read/write code in CortexM
@@ -37,7 +37,7 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
 
     ## Map of register name to info.
     _NAME_MAP = {}
-    
+
     ## Map of register index to info.
     _INDEX_MAP = {}
 
@@ -84,12 +84,12 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
 
 class CoreRegisterGroups:
     """! @brief Namespace for lists of Cortex-M core register information."""
-    
+
     _I = CortexMCoreRegisterInfo # Reduce table width.
 
     # For most registers, the index is the DCRSR register selector value. Those registers not directly
     # supported by the DCRSR have special values that are interpreted by the register read/write methods.
-    
+
     ## @brief Registers common to all M-profile cores.
     M_PROFILE_COMMON = [
         #  Name         index   bits    type            group       gdbnum  feature
@@ -241,7 +241,7 @@ class CoreRegisterGroups:
         _I('d14',       -0x5c,  64,     'ieee_double',  'double',   36,     "org.gnu.gdb.arm.vfp"),
         _I('d15',       -0x5e,  64,     'ieee_double',  'double',   37,     "org.gnu.gdb.arm.vfp"),
         ]
-        
+
     del _I # Cleanup namespace.
 
 # Build info map.

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -112,25 +112,25 @@ class ADIVersion(Enum):
 
 class DPConnector:
     """! @brief Establishes a connection to the DP for a given wire protocol.
-    
+
     This class will ask the probe to connect using a given wire protocol. Then it makes multiple
     attempts at sending the SWJ sequence to select the wire protocol and read the DP IDR register.
     """
-    
+
     def __init__(self, probe):
         self._probe = probe
         self._session = probe.session
         self._idr = None
-        
+
         # Make sure we have a session, since we get the session from the probe and probes have their session set
         # after creation.
         assert self._session is not None, "DPConnector requires the probe to have a session"
-    
+
     @property
     def idr(self):
         """! @brief DPIDR instance containing values read from the DP IDR register."""
         return self._idr
-    
+
     def _get_protocol(self, protocol):
         # Convert protocol from setting if not passed as parameter.
         if protocol is None:
@@ -139,16 +139,16 @@ class DPConnector:
             if protocol not in self._probe.supported_wire_protocols:
                 raise exceptions.DebugError("requested wire protocol %s not supported by the debug probe" % protocol.name)
         return protocol
-    
+
     def connect(self, protocol=None):
         """! @brief Establish a connection to the DP.
-        
+
         This method causes the debug probe to connect using the wire protocol.
-        
+
         @param self
         @param protocol One of the @ref pyocd.probe.debug_probe.DebugProbe.Protocol
             "DebugProbe.Protocol" enums. If not provided, will default to the `dap_protocol` setting.
-        
+
         @exception DebugError
         @exception TransferError
         """
@@ -161,7 +161,7 @@ class DPConnector:
             # If this is not None then the probe is already connected.
             current_wire_protocol = self._probe.wire_protocol
             already_connected = current_wire_protocol is not None
-        
+
             if already_connected:
                 self._check_protocol(current_wire_protocol, protocol)
             else:
@@ -171,7 +171,7 @@ class DPConnector:
             self._connect_dp(protocol)
         finally:
             self._probe.unlock()
-    
+
     def _check_protocol(self, current_wire_protocol, protocol):
         # Warn about mismatched current and requested wire protocols.
         if (protocol is not current_wire_protocol) and (protocol is not DebugProbe.Protocol.DEFAULT):
@@ -183,7 +183,7 @@ class DPConnector:
         # Debug log with the selected protocol.
         if protocol is not DebugProbe.Protocol.DEFAULT:
             LOG.debug("Using %s wire protocol", protocol.name)
-        
+
         # Connect using the selected protocol.
         self._probe.connect(protocol)
 
@@ -191,7 +191,7 @@ class DPConnector:
         if protocol is DebugProbe.Protocol.DEFAULT:
             protocol = self._probe.wire_protocol
             LOG.debug("Default wire protocol selected; using %s", protocol.name)
-        
+
     def _connect_dp(self, protocol):
         # Get SWJ settings.
         use_dormant = self._session.options.get('dap_swj_use_dormant')
@@ -200,33 +200,33 @@ class DPConnector:
 
         # Create object to send SWJ sequences.
         swj = SWJSequenceSender(self._probe, use_dormant)
-        
+
         # Multiple attempts to select protocol and read DP IDR.
         for attempt in range(4):
             try:
                 if send_swj:
                     swj.select_protocol(protocol)
-                
+
                 # Attempt to read the DP IDR register.
                 self._idr = self.read_idr()
-                
+
                 # Successful connection so exit the loop.
                 break
             except exceptions.TransferError:
                 # If not sending the SWJ sequence, just reraise; there's nothing more to do.
                 if not send_swj:
                     raise
-                
+
                 # If the read of the DP IDCODE fails, retry SWJ sequence. The DP may have been
                 # in a state where it thought the SWJ sequence was an invalid transfer. We also
                 # try enabling use of dormant state if it wasn't already enabled.
                 LOG.debug("DP IDCODE read failed; resending SWJ sequence (use dormant=%s)", use_dormant)
-                
+
                 if attempt == 1:
                     # If already using dormant mode, just raise, we don't need to retry the same mode.
                     if use_dormant:
                         raise
-                    
+
                     # After the second attempt, switch to enabling dormant mode.
                     swj.use_dormant = True
                 elif attempt == 3:
@@ -250,7 +250,7 @@ class DebugPort:
 
     ## Number of times to try to read DP registers after hw reset before attempting reconnect.
     _RESET_RECOVERY_ATTEMPTS_BEFORE_RECONNECT = 1
-    
+
     def __init__(self, probe, target):
         """! @brief Constructor.
         @param self The DebugPort object.
@@ -275,7 +275,7 @@ class DebugPort:
         self._have_probe_capabilities = False
         self._did_check_version = False
         self._log_dp_info = True
-        
+
         # DPv3 attributes
         self._is_dpv3 = False
         self._addr_size = None
@@ -283,79 +283,79 @@ class DebugPort:
         self._errmode = None
         self._base_addr = None
         self._apacc_mem_interface = None
-        
+
         # Subscribe to reset events.
         self._session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
 
     @property
     def probe(self):
         return self._probe
-    
+
     @property
     def session(self):
         return self._session
-    
+
     @property
     def adi_version(self):
         return ADIVersion.ADIv6 if self._is_dpv3 else ADIVersion.ADIv5
-    
+
     @property
     def base_address(self):
         """! @brief Base address of the first component for an ADIv6 system."""
         return self._base_addr
-    
+
     @property
     def apacc_memory_interface(self):
         """! @brief Memory interface for performing APACC transactions."""
         if self._apacc_mem_interface is None:
             self._apacc_mem_interface = APAccessMemoryInterface(self)
         return self._apacc_mem_interface
-    
+
     @property
     def next_access_number(self):
         self._access_number += 1
         return self._access_number
-    
+
     def lock(self):
         """! @brief Lock the DP from access by other threads."""
         self.probe.lock()
-    
+
     def unlock(self):
         """! @brief Unlock the DP."""
         self.probe.unlock()
 
     def connect(self, protocol=None):
         """! @brief Connect to the target.
-        
+
         This method causes the debug probe to connect using the selected wire protocol. The probe
         must have already been opened prior to this call.
-        
+
         Unlike create_connect_sequence(), this method is intended to be used when manually constructing a
         DebugPort instance. It simply calls create_connect_sequence() and invokes the returned call sequence.
-        
+
         @param self
         @param protocol One of the @ref pyocd.probe.debug_probe.DebugProbe.Protocol
             "DebugProbe.Protocol" enums. If not provided, will default to the `protocol` setting.
         """
         self._protocol = protocol
         self.create_connect_sequence().invoke()
-    
+
     def disconnect(self):
         """! @brief Disconnect from target.
-        
+
         DP debug is powered down. See power_down_debug().
         """
         self.power_down_debug()
 
     def create_connect_sequence(self):
         """! @brief Returns call sequence to connect to the target.
-        
+
         Returns a @ref pyocd.utility.sequence.CallSequence CallSequence that will connect to the
         DP, power up debug and the system, check the DP version to identify whether the target uses
         ADI v5 or v6, then clears sticky errors.
-        
+
         The probe must have already been opened prior to this method being called.
-        
+
         @param self
         @return @ref pyocd.utility.sequence.CallSequence CallSequence
         """
@@ -399,22 +399,22 @@ class DebugPort:
         LOG.log(logging.INFO if self._log_dp_info else logging.DEBUG,
             "DP IDR = 0x%08x (v%d%s rev%d)", self.dpidr.idr, self.dpidr.version,
             " MINDP" if self.dpidr.mindp else "", self.dpidr.revision)
-        
+
     def _check_version(self):
         self._is_dpv3 = (self.dpidr.version == 3)
         if self._is_dpv3:
             # Check that the probe will be able to access ADIv6 APs.
             if self._probe_managed_ap_select and not self._probe_supports_apv2_addresses:
                 raise exceptions.ProbeError("connected to ADIv6 target with probe that does not support APv2 addresses")
-            
+
             idr1 = self.read_reg(DP_IDR1)
-            
+
             self._addr_size = idr1 & DPIDR1_ASIZE_MASK
             self._addr_mask = (1 << self._addr_size) - 1
             self._errmode_supported = (idr1 & DPIDR1_ERRMODE_MASK) != 0
-            
+
             LOG.debug("DP IDR1 = 0x%08x (addr size=%d, errmode=%d)", idr1, self._addr_size, self._errmode_supported)
-            
+
             # Read base system address.
             baseptr0 = self.read_reg(DP_BASEPTR0)
             valid = (baseptr0 & BASEPTR0_VALID_MASK) != 0
@@ -426,7 +426,7 @@ class DebugPort:
 
                 base &= self._addr_mask
                 self._base_addr = base
-                
+
                 LOG.debug("DP BASEPTR = 0x%08x", self._base_addr)
             else:
                 LOG.warning("DPv3 has no valid base address")
@@ -448,10 +448,10 @@ class DebugPort:
 
     def power_up_debug(self):
         """! @brief Assert DP power requests.
-        
+
         Request both debug and system power be enabled, and wait until the request is acked.
         There is a timeout for the request.
-        
+
         @return Boolean indicating whether the power up request succeeded.
         """
         # Send power up request for system and debug.
@@ -464,22 +464,22 @@ class DebugPort:
                     break
             else:
                 return False
-        
+
         return True
 
     def power_down_debug(self):
         """! @brief Deassert DP power requests.
-        
+
         ADIv6 says that we must not clear CSYSPWRUPREQ and CDBGPWRUPREQ at the same time.
         ADIv5 says CSYSPWRUPREQ must not be set to 1 while CDBGPWRUPREQ is set to 0. So we
         start with deasserting system power, then debug power. Each deassertion has its own
         timeout.
-        
+
         @return Boolean indicating whether the power down request succeeded.
         """
         # Power down system first.
         self.write_reg(DP_CTRL_STAT, CDBGPWRUPREQ | MASKLANE | TRNNORMAL)
-        
+
         with Timeout(DP_POWER_REQUEST_TIMEOUT) as time_out:
             while time_out.check():
                 r = self.read_reg(DP_CTRL_STAT)
@@ -490,7 +490,7 @@ class DebugPort:
 
         # Now power down debug.
         self.write_reg(DP_CTRL_STAT,  MASKLANE | TRNNORMAL)
-        
+
         with Timeout(DP_POWER_REQUEST_TIMEOUT) as time_out:
             while time_out.check():
                 r = self.read_reg(DP_CTRL_STAT)
@@ -498,21 +498,21 @@ class DebugPort:
                     break
             else:
                 return False
-        
+
         return True
 
     def _invalidate_cache(self):
         """! @brief Invalidate cached DP registers."""
         self._cached_dp_select = None
-    
+
     def _reset_did_occur(self, notification):
         """! @brief Handles reset notifications to invalidate register cache.
-        
+
         The cache is cleared on all resets just to be safe. On most devices, warm resets do not reset
         debug logic, but it does happen on some devices.
         """
         self._invalidate_cache()
-    
+
     def post_reset_recovery(self):
         """! @brief Wait for the target to recover from reset, with auto-reconnect if needed."""
         # Check if we can access DP registers. If this times out, then reconnect the DP and retry.
@@ -549,15 +549,15 @@ class DebugPort:
 
     def reset(self, *, send_notifications=True):
         """! @brief Hardware reset.
-        
+
         Pre- and post-reset notifications are sent.
-        
+
         This method can be called before the DebugPort is connected.
 
         @param self This object.
         @param send_notifications Optional keyword-only parameter used by higher-level reset methods so they can
             manage the sending of reset notifications themselves, in order to provide more context in the notification.
-        
+
         @todo Should automatic recovery from a disconnected DAP be provided for these low-level hardware resets
             like is done for CortexM.reset()?
         """
@@ -572,12 +572,12 @@ class DebugPort:
 
     def assert_reset(self, asserted, *, send_notifications=True):
         """! @brief Assert or deassert the hardware reset signal.
-        
+
         A pre-reset notification is sent before asserting reset, whereas a post-reset notification is sent
         after deasserting reset.
-        
+
         This method can be called before the DebugPort is connected.
-        
+
         @param self This object.
         @param asserted True if nRESET is to be driven low; False will drive nRESET high.
         @param send_notifications Optional keyword-only parameter used by higher-level reset methods so they can
@@ -596,7 +596,7 @@ class DebugPort:
 
     def is_reset_asserted(self):
         """! @brief Returns the current state of the nRESET signal.
-        
+
         This method can be called before the DebugPort is initalized.
 
         @retval True Reset is asserted; nRESET is low.
@@ -613,7 +613,7 @@ class DebugPort:
 
     def _write_dp_select(self, mask, value):
         """! @brief Modify part of the DP SELECT register and write if cache is stale.
-        
+
         The DP lock must already be acquired before calling this method.
         """
         # Compute the new SELECT value and see if we need to write it.
@@ -623,22 +623,22 @@ class DebugPort:
             select = (self._cached_dp_select & ~mask) | value
             if select == self._cached_dp_select:
                 return
-        
+
         # Update the SELECT register and cache.
         self.write_dp(DP_SELECT, select)
         self._cached_dp_select = select
-    
+
     def _set_dpbanksel(self, addr, is_write):
         """! @brief Updates the DPBANKSEL field of the SELECT register as required.
-        
+
         Several DP registers (most, actually) ignore DPBANKSEL. If one of those is being
         accessed, any value of DPBANKSEL can be used. Otherwise SELECT is updated if necessary
         and a lock acquired so another thread doesn't change DPBANKSEL until thsi transaction is
         complete.
-        
+
         This method also handles the case where the debug probe manages DPBANKSEL on its own,
         such as with STLink.
-        
+
         @return Whether the access needs a lock on DP SELECT.
         @exception exceptions.ProbeError Raised when a banked register is being accessed but the
             probe doesn't support DPBANKSEL.
@@ -650,11 +650,11 @@ class DebugPort:
             registers_ignoring_dpbanksel = (DP_SELECT, DP_RDBUFF)
         else:
             registers_ignoring_dpbanksel = (DP_ABORT, DP_SELECT, DP_RDBUFF)
-        
+
         if (addr & DPADDR_MASK) not in registers_ignoring_dpbanksel:
             # Get the DP bank.
             dpbanksel = (addr & DPADDR_DPBANKSEL_MASK) >> DPADDR_DPBANKSEL_SHIFT
-            
+
             # Check if the probe handles this for us.
             if self._probe_managed_dpbanksel:
                 # If there is a nonzero DPBANKSEL and the probe doesn't support this,
@@ -663,7 +663,7 @@ class DebugPort:
                     raise exceptions.ProbeError("probe does not support banked DP registers")
                 else:
                     return False
-            
+
             # Update the selected DP bank.
             self.lock()
             self._write_dp_select(SELECT_DPBANKSEL_MASK, dpbanksel)
@@ -675,7 +675,7 @@ class DebugPort:
         if (addr & DPADDR_MASK) % 4 != 0:
             raise ValueError("DP address must be word aligned")
         num = self.next_access_number
-        
+
         # Update DPBANKSEL if required.
         did_lock = self._set_dpbanksel(addr, False)
 
@@ -715,7 +715,7 @@ class DebugPort:
         if (addr & DPADDR_MASK) % 4 != 0:
             raise ValueError("DP address must be word aligned")
         num = self.next_access_number
-        
+
         # Update DPBANKSEL if required.
         did_lock = self._set_dpbanksel(addr, True)
 
@@ -731,10 +731,10 @@ class DebugPort:
                 self.unlock()
 
         return True
-    
+
     def _select_ap(self, addr):
         """! @brief Write DP_SELECT to choose the given AP.
-        
+
         Handles the case where the debug probe manages selecting an AP itself, in which case we
         never write SELECT directly.
 
@@ -743,7 +743,7 @@ class DebugPort:
         # If the probe handles selecting the AP for us, there's nothing to do here.
         if self._probe_managed_ap_select:
             return False
-        
+
         # Write DP SELECT to select the probe.
         self.lock()
         if self.adi_version == ADIVersion.ADIv5:
@@ -831,7 +831,7 @@ class DebugPort:
         assert isinstance(addr, int)
         num = self.next_access_number
         did_lock = False
-        
+
         try:
             did_lock = self._select_ap(addr)
             TRACE.debug("read_ap_multiple:%06d (addr=0x%08x, count=%i)", num, addr, count)
@@ -885,20 +885,20 @@ class DebugPort:
 
 class APAccessMemoryInterface(memory_interface.MemoryInterface):
     """! @brief Memory interface for performing simple APACC transactions.
-    
+
     This class allows the caller to generate Debug APB transactions from a DPv3. It simply
     adapts the MemoryInterface to APACC transactions.
-    
+
     By default, it passes memory transaction addresses unmodified to the DP. But an instance can be
     constructed by passing an APAddress object to the constructor that offsets transaction addresses
     so they are relative to the APAddress base.
-    
+
     Only 32-bit transfers are supported.
     """
-    
+
     def __init__(self, dp, ap_address=None):
         """! @brief Constructor.
-        
+
         @param self
         @param dp The DebugPort object.
         @param ap_address Optional instance of APAddress. If provided, all memory transaction
@@ -910,11 +910,11 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
             self._offset = ap_address.address
         else:
             self._offset = 0
-    
+
     @property
     def dp(self):
         return self._dp
-    
+
     @property
     def short_description(self):
         if self._ap_address is None:
@@ -924,20 +924,20 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
 
     def write_memory(self, addr, data, transfer_size=32):
         """! @brief Write a single memory location.
-        
+
         By default the transfer size is a word."""
         if transfer_size != 32:
             raise exceptions.DebugError("unsupported transfer size")
-        
+
         return self._dp.write_ap(self._offset + addr, data)
-        
+
     def read_memory(self, addr, transfer_size=32, now=True):
         """! @brief Read a memory location.
-        
+
         By default, a word will be read."""
         if transfer_size != 32:
             raise exceptions.DebugError("unsupported transfer size")
-        
+
         return self._dp.read_ap(self._offset + addr, now)
 
     def write_memory_block32(self, addr, data):

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -31,15 +31,15 @@ class CoreSightDiscovery(object):
     def __init__(self, target):
         """! @brief Constructor."""
         self._target = target
-    
+
     @property
     def target(self):
         return self._target
-    
+
     @property
     def dp(self):
         return self.target.dp
-    
+
     @property
     def session(self):
         return self.target.session
@@ -67,7 +67,7 @@ class CoreSightDiscovery(object):
         self._apply_to_all_components(self._create_component,
             filter=lambda c: c.factory is not None
                 and c.factory not in (cortex_m.CortexM.factory, cortex_m_v8m.CortexM_v8M.factory))
-    
+
     def _apply_to_all_components(self, action, filter=None):
         # Iterate over every top-level ROM table.
         for ap in [x for x in self.dp.aps.values() if x.rom_table]:
@@ -75,10 +75,10 @@ class CoreSightDiscovery(object):
 
 class ADIv5Discovery(CoreSightDiscovery):
     """! @brief Component discovery process for ADIv5.
-    
+
     Component discovery for ADIv5 proceeds as follows. Each of the steps is labeled with the name
     of the init task for that step.
-    
+
     1. `find_aps`: Perform an AP scan. Probe each AP at APSEL=0..255. By default the scan stops on
         the first invalid APSEL, as determined by testing the IDR value (0 is invalid). This can be
         overridden by a session option.
@@ -104,11 +104,11 @@ class ADIv5Discovery(CoreSightDiscovery):
 
     def _find_aps(self):
         """! @brief Find valid APs using the ADIv5 method.
-        
+
         Scans for valid APs starting at APSEL=0. The default behaviour is to stop after reading
         0 for the AP's IDR twice in succession. If the `scan_all_aps` session option is set to True,
         then the scan will instead probe every APSEL from 0-255.
-        
+
         If there is already a list of valid APs defined for the @ref pyocd.coresight.dap.DebugPort
         DebugPort (the `valid_aps` attribute), then scanning is not performed. This is to allow a
         predetermined list of valid APSELs to be used in place of a scan. A few MCUs will lock up
@@ -119,7 +119,7 @@ class ADIv5Discovery(CoreSightDiscovery):
         # skipping the AP scan by providing a predetermined list of valid APSELs.
         if self.dp.valid_aps is not None:
             return
-        
+
         ap_list = []
         apsel = 0
         invalid_count = 0
@@ -138,13 +138,13 @@ class ADIv5Discovery(CoreSightDiscovery):
                     exc_info=self.session.log_tracebacks)
                 break
             apsel += 1
-        
+
         # Update the AP list once we know it's complete.
         self.dp.valid_aps = ap_list
 
     def _create_aps(self):
         """! @brief Init task that returns a call sequence to create APs.
-        
+
         For each AP in the #valid_aps list, an AccessPort object is created. The new objects
         are added to the #aps dict, keyed by their AP number.
         """
@@ -154,7 +154,7 @@ class ADIv5Discovery(CoreSightDiscovery):
                 ('create_ap.{}'.format(apsel), lambda apsel=apsel: self._create_1_ap(apsel))
                 )
         return seq
-    
+
     def _create_1_ap(self, apsel):
         """! @brief Init task to create a single AP object."""
         try:
@@ -164,7 +164,7 @@ class ADIv5Discovery(CoreSightDiscovery):
         except exceptions.Error as e:
             LOG.error("Exception reading AP#%d IDR: %s", apsel, e,
                 exc_info=self.session.log_tracebacks)
-    
+
     def _find_components(self):
         """! @brief Init task that generates a call sequence to ask each AP to find its components."""
         seq = CallSequence()
@@ -176,10 +176,10 @@ class ADIv5Discovery(CoreSightDiscovery):
 
 class ADIv6Discovery(CoreSightDiscovery):
     """! @brief Component discovery process for ADIv6.
-    
+
     The process for discovering components in ADIv6 proceeds as follows. Each of the steps is
     labeled with the name of the init task for that step.
-    
+
     1. `find_root_components`: Examine the component pointed to by the DP BASEPTR register(s). If
         it's a ROM table, read it and examine components pointed to by the entries. This creates the
         AP instances.
@@ -188,7 +188,7 @@ class ADIv6Discovery(CoreSightDiscovery):
     3. `create_cores`: Create any discovered core (CPU) components. The cores are created first to
         ensure that other components have a core to which they may be connected.
     4. `create_components`: Create remaining discovered components.
-    
+
     Note that nested APs are not supported.
     """
 
@@ -210,23 +210,23 @@ class ADIv6Discovery(CoreSightDiscovery):
         # There's not much we can do if we don't have a base address.
         if self.dp.base_address is None:
             return
-        
+
         # Create a temporary memory interface.
         mem_interface = self.dp.apacc_memory_interface
-        
+
         # Examine the base component.
         cmpid = CoreSightComponentID(None, mem_interface, self.dp.base_address)
         cmpid.read_id_registers()
         LOG.debug("Base component: %s", cmpid)
-        
+
         if cmpid.is_rom_table:
             self._top_rom_table = ROMTable.create(mem_interface, cmpid)
             self._top_rom_table.init()
-            
+
             # Create components defined in the DP ROM table.
             self._top_rom_table.for_each(self._create_1_ap,
                     filter=lambda c: c.factory == AccessPort.create)
-            
+
             # Create non-AP components in the DP ROM table.
             self._top_rom_table.for_each(self._create_root_component,
                     filter=lambda c: (c.factory is not None) and (c.factory != AccessPort.create))
@@ -234,7 +234,7 @@ class ADIv6Discovery(CoreSightDiscovery):
             self._create_1_ap(cmpid)
         else:
             self._create_root_component(cmpid)
-    
+
     def _create_1_ap(self, cmpid):
         """! @brief Init task to create a single AP object."""
         try:
@@ -244,10 +244,10 @@ class ADIv6Discovery(CoreSightDiscovery):
         except exceptions.Error as e:
             LOG.error("Exception reading AP@0x%08x IDR: %s", cmpid.address, e,
                     exc_info=self.session.log_tracebacks)
-    
+
     def _create_root_component(self, cmpid):
         """! @brief Init task to create a component attached directly to the DP.
-        
+
         The newly created component is attached directly to the target instance (i.e.,
         CoreSightTarget or subclass) in the object graph.
         """
@@ -255,7 +255,7 @@ class ADIv6Discovery(CoreSightDiscovery):
             # Create a memory interface for this component.
             ap_address = APv2Address(cmpid.address)
             memif = APAccessMemoryInterface(self.dp, ap_address)
-            
+
             # Instantiate the component and attach to the target.
             component = cmpid.factory(memif, cmpid, cmpid.address)
             self.target.add_child(component)
@@ -263,7 +263,7 @@ class ADIv6Discovery(CoreSightDiscovery):
         except exceptions.Error as e:
             LOG.error("Exception creating root component at address 0x%08x: %s", cmpid.address, e,
                     exc_info=self.session.log_tracebacks)
-    
+
     def _find_components_on_aps(self):
         """! @brief Init task that generates a call sequence to ask each AP to find its components."""
         seq = CallSequence()

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -36,7 +36,7 @@ class Watchpoint(HardwareBreakpoint):
 
 class DWT(CoreSightComponent):
     """! @brief Data Watchpoint and Trace version 1.0"""
-    
+
     # DWT registers
     #
     # The addresses are offsets from the base address.
@@ -52,7 +52,7 @@ class DWT(CoreSightComponent):
     DWT_MASK_OFFSET = 4
     DWT_FUNCTION_OFFSET = 8
     DWT_COMP_BLOCK_SIZE = 0x10
-    
+
     DWT_CTRL_NUM_COMP_MASK = (0xF << 28)
     DWT_CTRL_NUM_COMP_SHIFT = 28
     DWT_CTRL_CYCEVTENA_MASK = (1 << 22)
@@ -90,14 +90,14 @@ class DWT(CoreSightComponent):
         self.watchpoints = []
         self.watchpoint_used = 0
         self.dwt_configured = False
-    
+
     @property
     def watchpoint_count(self):
         return len(self.watchpoints)
 
     def init(self):
         """! @brief Inits the DWT.
-        
+
         Reads the number of hardware watchpoints available on the core and makes sure that they
         are all disabled and ready for future use.
         """
@@ -106,7 +106,7 @@ class DWT(CoreSightComponent):
         if (demcr & DEMCR_TRCENA) == 0:
             demcr |= DEMCR_TRCENA
             self.ap.write_memory(DEMCR, demcr)
-        
+
         dwt_ctrl = self.ap.read_memory(self.address + self.DWT_CTRL)
         watchpoint_count = (dwt_ctrl & self.DWT_CTRL_NUM_COMP_MASK) >> self.DWT_CTRL_NUM_COMP_SHIFT
         LOG.info("%d hardware watchpoints", watchpoint_count)
@@ -114,7 +114,7 @@ class DWT(CoreSightComponent):
             comparatorAddress = self.address + self.DWT_COMP_BASE + self.DWT_COMP_BLOCK_SIZE * i
             self.watchpoints.append(Watchpoint(comparatorAddress, self))
             self.ap.write_memory(comparatorAddress + self.DWT_FUNCTION_OFFSET, 0)
-        
+
         # Enable cycle counter.
         self.ap.write32(self.address + self.DWT_CTRL, self.DWT_CTRL_CYCCNTENA_MASK)
         self.dwt_configured = True
@@ -171,34 +171,34 @@ class DWT(CoreSightComponent):
         watch.func = 0
         self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, 0)
         self.watchpoint_used -= 1
-    
+
     def remove_all_watchpoints(self):
         for watch in self.watchpoints:
             if watch.func != 0:
                 self.remove_watchpoint(watch.addr, watch.size, self.WATCH_TYPE_TO_FUNCT[watch.func])
-    
+
     def get_watchpoints(self):
         return [watch for watch in self.watchpoints if watch.func != 0]
-    
+
     @property
     def cycle_count(self):
         return self.ap.read32(self.address + self.DWT_CYCCNT)
-    
+
     @cycle_count.setter
     def cycle_count(self, value):
         self.ap.write32(self.address + self.DWT_CYCCNT, value)
 
 class DWTv2(DWT):
     """! @brief Data Watchpoint and Trace version 2.x
-    
+
     This version is present in v8-M platforms.
-    
+
     - DWT 2.0 appears in v8.0-M
     - DWT 2.1 appears in v8.1-M and adds the VMASKn registers.
     """
-    
+
     DWT_ACTION_DEBUG_EVENT = 0x00000010
-    
+
     ## Map from watchpoint type to FUNCTIONn.MATCH field value.
     WATCH_TYPE_TO_FUNCT = {
                             Target.WatchpointType.READ: 0b0110,
@@ -208,14 +208,14 @@ class DWTv2(DWT):
                             0b0101: Target.WatchpointType.WRITE,
                             0b0100: Target.WatchpointType.READ_WRITE,
                             }
-    
+
     ## Map from data access size to pre-shifted DATAVSIZE field value.
     DATAVSIZE_MAP = {
                         1: (0 << 10),
                         2: (1 << 10),
                         4: (2 << 10),
                     }
-    
+
     def set_watchpoint(self, addr, size, type):
         """! @brief Set a hardware watchpoint."""
         if self.dwt_configured is False:
@@ -228,7 +228,7 @@ class DWTv2(DWT):
         if type not in self.WATCH_TYPE_TO_FUNCT:
             LOG.error("Invalid watchpoint type %i", type)
             return False
-        
+
         # Only support sizes that can be handled with a single comparator.
         if size not in (1, 2, 4):
             LOG.error("Invalid watchpoint size %d", size)

--- a/pyocd/coresight/fpb.py
+++ b/pyocd/coresight/fpb.py
@@ -29,7 +29,7 @@ class HardwareBreakpoint(Breakpoint):
 
 class FPB(BreakpointProvider, CoreSightComponent):
     """! @brief Flash Patch and Breakpoint unit"""
-    
+
     # FPB registers
     #
     # The addresses are offsets from the base address.
@@ -38,7 +38,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
     FP_CTRL_REV_MASK = 0xf0000000
     FP_CTRL_REV_SHIFT = 28
     FP_COMP0 = 0x00000008
-    
+
     def __init__(self, ap, cmpid=None, addr=None):
         CoreSightComponent.__init__(self, ap, cmpid, addr)
         BreakpointProvider.__init__(self)
@@ -55,7 +55,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
 
     def init(self):
         """! @brief Inits the FPB.
-        
+
         Reads the number of hardware breakpoints available on the core and disable the FPB
         (Flash Patch and Breakpoint Unit), which will be enabled when the first breakpoint is set.
         setup FPB (breakpoint)
@@ -97,7 +97,7 @@ class FPB(BreakpointProvider, CoreSightComponent):
 
     def can_support_address(self, addr):
         """! @brief Test whether an address is supported by the FPB.
-        
+
         For FPBv1, hardware breakpoints are only supported in the range 0x00000000 - 0x1fffffff.
         This was fixed for FPBv2, which supports hardware breakpoints at any address.
         """

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -27,7 +27,7 @@ DEAD_VALUE = 0
 
 class GenericMemAPTarget(Target, CoreSightCoreComponent):
     """! @brief This target represents ARM debug Access Port without a CPU
-    
+
     It may be used to access the address space of the target via Access Ports
     without real ARM CPU core behind it. For instance Cypress PSoC64 devices have
     three APs implemented in the hardware:
@@ -35,11 +35,11 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
     * AP #1 -> Cortex-M0+ AP
     * AP #2 -> Cortex-M4F AP
     Depending on the protection state, AP #1 and AP #2 can be permanently disabled.
-    This class allows to communicate with Secure FW running on the target via AP #0. 
-    
+    This class allows to communicate with Secure FW running on the target via AP #0.
+
     Most of the methods in this class (except memory access methods) are empty/dummy.
     """
-    
+
     def __init__(self, session, ap, memory_map=None, core_num=0, cmpid=None, address=None):
         Target.__init__(self, session, memory_map)
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)

--- a/pyocd/coresight/gpr.py
+++ b/pyocd/coresight/gpr.py
@@ -21,15 +21,15 @@ ACK_TIMEOUT = 5.0
 
 class GPR(CoreSightComponent):
     """! @brief Granular Power Requestor.
-    
+
     Currently only supports enabling power domains.
     """
-    
+
     CPWRUPREQ = 0x0
     CPWRUPACK = 0x0
-    
+
     CPWRUPM_COUNT_MASK = 0x3f
-    
+
     @classmethod
     def factory(cls, ap, cmpid, address):
         # Attempt to return the same instance that was created during ROM table scanning.
@@ -37,7 +37,7 @@ class GPR(CoreSightComponent):
             rom_gpr = cmpid.parent_rom_table.gpr
             if rom_gpr is not None and rom_gpr.address == address:
                 return rom_gpr
-        
+
         # No luck, create a new instance.
         gpr = cls(ap, cmpid, address)
         return gpr
@@ -49,7 +49,7 @@ class GPR(CoreSightComponent):
     def init(self):
         """! @brief Inits the GPR."""
         self.domain_count = self.cmpid.devid[2] & self.CPWRUPM_COUNT_MASK
-    
+
     def _power_up(self, mask):
         """! @brief Enable power to a power domaind by mask.
         @param self
@@ -59,7 +59,7 @@ class GPR(CoreSightComponent):
         """
         # Enable power up request bits.
         self.ap.write32(self.address + self.CPWRUPREQ, mask)
-        
+
         # Wait for ack bits to set.
         with Timeout(ACK_TIMEOUT) as t_o:
             while t_o.check():
@@ -67,7 +67,7 @@ class GPR(CoreSightComponent):
                 if (value & mask) == mask:
                     return True
             return False
-    
+
     def power_up_all(self):
         """! @brief Enable power to all available power domains.
         @param self
@@ -76,7 +76,7 @@ class GPR(CoreSightComponent):
         """
         mask = (1 << self.domain_count) - 1
         return self._power_up(mask)
-    
+
     def power_up_one(self, domain_id):
         """! @brief Power up a single power domain by domain ID.
         @param self
@@ -86,9 +86,9 @@ class GPR(CoreSightComponent):
         """
         mask = 1 << domain_id
         return self._power_up(mask)
-    
+
     def __repr__(self):
         return "<GPR @ %x: count=%d>" % (id(self), self.domain_count)
-        
+
 
 

--- a/pyocd/coresight/itm.py
+++ b/pyocd/coresight/itm.py
@@ -54,7 +54,7 @@ class ITM(CoreSightComponent):
     TCR_TRACEBUSID_MASK = (0x7f << 16)
     TCR_TRACEBUSID_SHIFT = 16
     TCR_BUSY_MASK = (1 << 23)
-    
+
     LAR = 0x00000fb0
     LAR_KEY = 0xC5ACCE55
     LSR = 0x00000fb4
@@ -79,10 +79,10 @@ class ITM(CoreSightComponent):
             val = self.ap.read32(self.address + ITM.LSR)
             if val & ITM.LSR_SLK_MASK:
                 raise exceptions.DebugError("Failed to unlock ITM")
-        
+
         # Disable the ITM until enabled.
         self.disable()
-    
+
     @property
     def is_enabled(self):
         return self._is_enabled
@@ -99,9 +99,9 @@ class ITM(CoreSightComponent):
 
     def set_enabled_ports(self, enabled_ports):
         self.ap.write32(self.address + ITM.TERn, enabled_ports)
-    
+
     def disable(self):
         self.ap.write32(self.address + ITM.TERn, 0)
         self.ap.write32(self.address + ITM.TCR, 0)
         self._is_enabled = False
-        
+

--- a/pyocd/coresight/sdc600.py
+++ b/pyocd/coresight/sdc600.py
@@ -40,7 +40,7 @@ class LinkClosedException(ComPortError):
     """! @brief Received an unexpected or out of order flag byte."""
     def __init__(self, phase):
         self._phase = phase
-    
+
     @property
     def phase(self):
         """! @brief The link phase that was closed from the other side."""
@@ -49,17 +49,17 @@ class LinkClosedException(ComPortError):
 class SDC600(CoreSightComponent):
     """! @brief SDC-600 component.
     """
-    
+
     ## Default timeout for an operation or packet transfer.
     TRANSFER_TIMEOUT = 30.0
-    
+
     class LinkPhase(Enum):
         """! @brief COM Port link phases."""
         ## Hardware-defined link phase.
         PHASE1 = 1
         ## Software-defined link phase.
         PHASE2 = 2
-    
+
     class Register:
         """! @brief Namespace for SDC-600 register offset constants."""
         # Register offsets.
@@ -87,7 +87,7 @@ class SDC600(CoreSightComponent):
         FIDxXR_xXSZ32_SHIFT = (10)
         FIDxXR_xXFD_MASK    = (0x000f0000)
         FIDxXR_xXFD_SHIFT   = (16)
-        
+
         # SR bit definitions.
         SR_TXS_MASK         = (0x000000ff)
         SR_TXS_SHIFT        = (0)
@@ -105,7 +105,7 @@ class SDC600(CoreSightComponent):
         SR_RXLE_SHIFT       = (30)
         SR_PEN_MASK         = (0x80000000)
         SR_PEN_SHIFT        = (31)
-    
+
     class Flag:
         """! @brief Namespace with SDC-600 flag byte constants."""
         IDR     = 0xA0
@@ -120,11 +120,11 @@ class SDC600(CoreSightComponent):
         END     = 0xAD
         ESC     = 0xAE
         NULL    = 0xAF
-        
+
         # All bytes with 0b101 in bits [7:5] are flag bytes.
         MASK = 0xE0
         IDENTIFIER = 0b10100000
-        
+
         ## Map from flag value to name.
         NAME = {
             IDR     : "IDR",
@@ -140,11 +140,11 @@ class SDC600(CoreSightComponent):
             ESC     : "ESC",
             NULL    : "NULL",
             }
-    
+
     ## NULL bytes must be written to the upper bytes, and will be present in the upper bytes
     # when read.
     NULL_FILL = 0xAFAFAF00
-    
+
     def __init__(self, ap, cmpid=None, addr=None):
         super(SDC600, self).__init__(ap, cmpid, addr)
         self._tx_width = 0
@@ -153,37 +153,37 @@ class SDC600(CoreSightComponent):
 
     def init(self):
         """! @brief Inits the component.
-        
+
         Reads the RX and TX widths and whether the SDC-600 is enabled. All error flags are cleared.
         """
         fidtx = self.ap.read32(self.Register.FIDTXR)
         LOG.debug("fidtx=0x%08x", fidtx)
         fidrx = self.ap.read32(self.Register.FIDRXR)
         LOG.debug("fidrx=0x%08x", fidrx)
-        
+
         self._tx_width = (fidtx & self.Register.FIDxXR_xXW_MASK) >> self.Register.FIDxXR_xXW_SHIFT
-        
+
         self._rx_width = (fidrx & self.Register.FIDxXR_xXW_MASK) >> self.Register.FIDxXR_xXW_SHIFT
-        
+
         status = self.ap.read32(self.Register.SR)
         LOG.debug("status=0x%08x", status)
         self._is_enabled = (status & self.Register.SR_PEN_MASK) != 0
-        
+
         # Clear any error flags.
         error_flags = status & (self.Register.SR_TXOE_MASK | self.Register.SR_TXLE_MASK)
         if error_flags:
             self.ap.write32(self.Register.SR, error_flags)
-    
+
     @property
     def is_enabled(self):
         """! @brief Whether the SDC-600 is enabled."""
         return self._is_enabled
-    
+
     @property
     def is_reboot_request_enabled(self):
         """! @brief Whether the Reboot Request feature is enabled in the SDC-600."""
         return (self.ap.read32(self.Register.SR) & self.Register.SR_RRDIS_MASK) == 0
-    
+
     @property
     def current_link_phase(self):
         """! @brief Currently established link phase.
@@ -193,10 +193,10 @@ class SDC600(CoreSightComponent):
 
     def _read1(self, to_):
         """! @brief Read a single byte.
-        
+
         If a NULL byte is received, it is ignored and another byte is read. No other flag bytes
         are processed.
-        
+
         @exception TimeoutError
         """
         while True:
@@ -213,9 +213,9 @@ class SDC600(CoreSightComponent):
             # Ignore NULL flag bytes.
             if value == self.Flag.NULL:
                 continue
-            
+
             return value
-        
+
     def _write1(self, value, to_):
         """! @brief Write one or more bytes.
         @exception TimeoutError
@@ -289,10 +289,10 @@ class SDC600(CoreSightComponent):
             if (value & self.Flag.MASK) == self.Flag.IDENTIFIER:
                 # Insert escape flag.
                 result.append(self.Flag.ESC)
-                
+
                 # Invert high bit.
                 value ^= 0x80
-            
+
             result.append(value)
         return result
 
@@ -306,17 +306,17 @@ class SDC600(CoreSightComponent):
         i = 0
         while i < len(data):
             value = data[i]
-            
+
             # Check for escaped bytes.
             if value == self.Flag.ESC:
                 # Skip over escape.
                 i += 1
-                
+
                 # Get escaped byte and invert high bit to destuff it.
                 value = data[i] ^ 0x80
-            
+
             result.append(value)
-            
+
             i += 1
         return result
 
@@ -329,7 +329,7 @@ class SDC600(CoreSightComponent):
         result = []
         while to_.check():
             value = self._read1(to_)
-            
+
             # Check for the packet end marker flag.
             if value == self.Flag.END:
                 break
@@ -341,25 +341,25 @@ class SDC600(CoreSightComponent):
             result.append(value)
         else:
             raise exceptions.TimeoutError("timeout while reading from SDC-600")
-        
+
         return self._destuff(result)
 
     def receive_packet(self, timeout=TRANSFER_TIMEOUT):
         """! @brief Read a data packet.
-        
+
         Reads a packet (PDU) from the target and removes byte stuffing. The timeout for reading the
         entire packet can be set via the _timeout_ parameter.
-        
+
         As data is read from the target, special flags for link errors or to close either phase of
         the link are handled and an appropriate exception is raised.
-        
+
         The connection must be in link phase 2.
-        
+
         @param self
         @param timeout Optional timeout for reading the entire packet. If reading times out, a
             TimeoutError exception is raised.
         @return List of integer byte values of the de-escaped packet contents.
-        
+
         @exception UnexpectedFlagError
         @exception LinkClosedException
         @exception TimeoutError
@@ -368,21 +368,21 @@ class SDC600(CoreSightComponent):
         with Timeout(timeout) as to_:
             self._expect_flag(self.Flag.START, to_)
             return self._read_packet_data_to_end(to_)
-    
+
     def send_packet(self, data, timeout=TRANSFER_TIMEOUT):
         """! @brief Send a data packet.
-        
+
         Sends the provided data to the target as a single packet (PDU), escaping bytes as necessary.
         No data is read while the packet is sent, so if the target closes the connection it will
         not be detected.
-        
+
         The connection must be in link phase 2.
-        
+
         @param self
         @param data List of integer byte values to send. Must not be pre-escaped.
         @param timeout Optional timeout for reading the entire packet. If reading times out, a
             TimeoutError exception is raised.
-        
+
         @exception UnexpectedFlagError
         @exception TimeoutError
         """
@@ -392,7 +392,7 @@ class SDC600(CoreSightComponent):
             for value in self._stuff(data):
                 self._write1(value, to_)
             self._write1(self.Flag.END, to_)
-    
+
     def open_link(self, phase, timeout=TRANSFER_TIMEOUT):
         """! @brief Send the LPH1RA or LPH2RA flag.
         @exception UnexpectedFlagError
@@ -405,11 +405,11 @@ class SDC600(CoreSightComponent):
 
                 # Close link phase 1 first, to put it in a known state.
                 self.close_link(self.LinkPhase.PHASE1)
-        
+
                 LOG.debug("sending LPH1RA")
                 self._write1(self.Flag.LPH1RA, to_)
                 self._expect_flag(self.Flag.LPH1RA, to_)
-                
+
                 self._current_link_phase = self.LinkPhase.PHASE1
             elif phase == self.LinkPhase.PHASE2:
                 assert self._current_link_phase == self.LinkPhase.PHASE1
@@ -417,17 +417,17 @@ class SDC600(CoreSightComponent):
                 LOG.debug("sending LPH2RA")
                 self._write1(self.Flag.LPH2RA, to_)
                 self._expect_flag(self.Flag.LPH2RA, to_)
-                
+
                 self._current_link_phase = self.LinkPhase.PHASE2
             else:
                 raise ValueError("unrecognized phase value")
 
     def close_link(self, phase, timeout=TRANSFER_TIMEOUT):
         """! @brief Send the LPH1RL or LPH2RL flag.
-        
+
         Link phase 1 can be closed from any state. Link phase 2 can only be closed when the
         connection is already in that phase.
-        
+
         @exception UnexpectedFlagError
         @exception TimeoutError
         """
@@ -437,7 +437,7 @@ class SDC600(CoreSightComponent):
                 LOG.debug("sending LPH1RL")
                 self._write1(self.Flag.LPH1RL, to_)
                 self._expect_flag(self.Flag.LPH1RL, to_)
-            
+
                 self._current_link_phase = None
             elif phase == self.LinkPhase.PHASE2:
                 assert self._current_link_phase == self.LinkPhase.PHASE2
@@ -445,7 +445,7 @@ class SDC600(CoreSightComponent):
                 LOG.debug("sending LPH2RL")
                 self._write1(self.Flag.LPH2RL, to_)
                 self._expect_flag(self.Flag.LPH2RL, to_)
-            
+
                 self._current_link_phase = self.LinkPhase.PHASE1
             else:
                 raise ValueError("unrecognized phase value")
@@ -464,15 +464,15 @@ class SDC600(CoreSightComponent):
             self._write1(self.Flag.IDR, to_)
             self._expect_flag(self.Flag.IDA, to_)
             return self._read_packet_data_to_end(to_)
-    
+
     def send_reboot_request(self, timeout=TRANSFER_TIMEOUT):
         """! @brief Send remote reboot request."""
         with Timeout(timeout) as to_:
             self._write1(self.Flag.LPH2RR, to_)
-    
+
     def __repr__(self):
         return "<SDC-600@{:x}: en={} txw={} rxw={} phase={}>".format(id(self),
             self._is_enabled, self._tx_width, self._rx_width, self._current_link_phase)
-        
+
 
 

--- a/pyocd/coresight/tpiu.py
+++ b/pyocd/coresight/tpiu.py
@@ -39,7 +39,7 @@ class TPIU(CoreSightComponent):
         """! @brief Standard CoreSight component constructor."""
         super(TPIU, self).__init__(ap, cmpid, addr)
         self._has_swo_uart = False
-    
+
     @property
     def has_swo_uart(self):
         """! @brief Whether SWO UART mode is supported by the TPIU."""
@@ -47,19 +47,19 @@ class TPIU(CoreSightComponent):
 
     def init(self):
         """! @brief Reads TPIU capabilities.
-        
+
         Currently this method simply checks whether the TPIU supports SWO in asynchronous
         UART mode. The result of this check is available via the has_swo_uart property.
         """
         devid = self.ap.read32(self.address + TPIU.DEVID)
         self._has_swo_uart = (devid & TPIU.DEVID_NRZ_MASK) != 0
-        
+
     def set_swo_clock(self, swo_clock, system_clock):
         """! @brief Prepare TPIU for transmitting SWO at a given baud rate.
-        
+
         Configures the TPIU for SWO UART mode, then sets the SWO clock frequency based on
         the provided system clock.
-        
+
         @param self
         @param swo_clock Desired SWO baud rate in Hertz.
         @param system_clock The frequency of the SWO clock source in Hertz. This is almost always
@@ -70,11 +70,11 @@ class TPIU(CoreSightComponent):
         # First check whether SWO UART is supported.
         if not self.has_swo_uart:
             return False
-            
+
         # Go ahead and configure for SWO.
         self.ap.write32(self.address + TPIU.SPPR, TPIU.SPPR_TXMODE_NRZ) # Select SWO UART mode.
         self.ap.write32(self.address + TPIU.FFCR, 0) # Disable formatter.
-    
+
         # Compute the divider.
         div = (system_clock // swo_clock) - 1
         actual = system_clock // (div + 1)

--- a/pyocd/debug/breakpoints/manager.py
+++ b/pyocd/debug/breakpoints/manager.py
@@ -72,7 +72,7 @@ class BreakpointManager(object):
 
     def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
         """! @brief Set a hardware or software breakpoint at a specific location in memory.
-        
+
         @retval True Breakpoint was set.
         @retval False Breakpoint could not be set.
         """
@@ -105,7 +105,7 @@ class BreakpointManager(object):
 
     def _check_added_breakpoint(self, bp):
         """! @brief Check whether a new breakpoint is likely to actually be added when we flush.
-        
+
         First, software breakpoints are assumed to always be addable. For hardware breakpoints,
         the current free hardware breakpoint count is updated based on the current set of to-be
         added and removed breakpoints. If there are enough free hardware breakpoints to meet the
@@ -115,11 +115,11 @@ class BreakpointManager(object):
         if self._fpb is None:
             region = self._core.memory_map.get_region_for_address(bp.addr)
             return region is not None and region.is_writable
-        
+
         likely_bp_type = self._select_breakpoint_type(bp, False)
         if likely_bp_type == Target.BreakpointType.SW:
             return True
-        
+
         # Count updated hw breakpoints.
         free_hw_bp_count = self._fpb.available_breakpoints
         added, removed = self._get_updated_breakpoints()
@@ -130,7 +130,7 @@ class BreakpointManager(object):
             likely_bp_type = self._select_breakpoint_type(bp, False)
             if likely_bp_type == Target.BreakpointType.HW:
                 free_hw_bp_count -= 1
-        
+
         return free_hw_bp_count > self.MIN_HW_BREAKPOINTS
 
     def remove_breakpoint(self, addr):

--- a/pyocd/debug/context.py
+++ b/pyocd/debug/context.py
@@ -21,30 +21,30 @@ from ..coresight.cortex_m_core_registers import CortexMCoreRegisterInfo
 
 class DebugContext(MemoryInterface):
     """! @brief Viewport for inspecting the system being debugged.
-    
+
     A debug context is used to access target registers and memory. It enables these accesses to be
     redirected to different locations. For instance, if you want to read registers from a call frame
     that is not the topmost, then a context would redirect those reads to locations on the stack.
-    
+
     A context always has both a parent context and a specific core associated with it, neither of
     which can be changed after the context is created. The parent context is passed into the
     constructor. For the top-level debug context, the parent *is* the core. For other contexts that
     have a context as their parent, the core is set to the topmost parent's core.
-    
+
     The DebugContext class itself is meant to be used as a base class. It's primary purpose is to
     provide the default implementation of methods to forward calls up to the parent and eventually
     to the core.
     """
-    
+
     def __init__(self, parent):
         """! @brief Debug context constructor.
-        
+
         @param self
         @param parent The parent of this context. Can be either a core (CoreSightCoreComponent) or
             another DebugContext instance.
         """
         self._parent = parent
-        
+
         if isinstance(self._parent, CoreSightCoreComponent):
             self._core = parent
         else:
@@ -57,7 +57,7 @@ class DebugContext(MemoryInterface):
     @property
     def core(self):
         return self._core
-    
+
     @property
     def session(self):
         return self.core.session
@@ -82,12 +82,12 @@ class DebugContext(MemoryInterface):
 
     def read_core_register(self, reg):
         """! @brief Read one core register.
-        
+
         @param self The debug context.
         @param reg Either the register's name in lowercase or an integer register index.
         @return The current value of the register. Most core registers return an integer value,
             while the floating point single and double precision register return a float value.
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             read the register.
@@ -98,12 +98,12 @@ class DebugContext(MemoryInterface):
 
     def read_core_register_raw(self, reg):
         """! @brief Read a core register without type conversion.
-        
+
         @param self The debug context.
         @param reg Either the register's name in lowercase or an integer register index.
         @return The current integer value of the register. Even float register values are returned
             as integers (thus the "raw").
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             read the register.
@@ -113,13 +113,13 @@ class DebugContext(MemoryInterface):
 
     def read_core_registers_raw(self, reg_list):
         """! @brief Read one or more core registers.
-        
+
         @param self The debug context.
         @param reg_list List of registers to read. Each element in the list can be either the
             register's name in lowercase or the integer register index.
         @return List of integer values of the registers requested to be read. The result list will
             be the same length as _reg_list_.
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             read one or more registers.
@@ -128,11 +128,11 @@ class DebugContext(MemoryInterface):
 
     def write_core_register(self, reg, data):
         """! @brief Write a CPU register.
-        
+
         @param self The debug context.
         @param reg The name of the register to write.
         @param data New value of the register. Float registers accept float values.
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             write the register.
@@ -142,11 +142,11 @@ class DebugContext(MemoryInterface):
 
     def write_core_register_raw(self, reg, data):
         """! @brief Write a CPU register without type conversion.
-        
+
         @param self The debug context.
         @param reg The name of the register to write.
         @param data New value of the register. Must be an integer, even for float registers.
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             write the register.
@@ -161,7 +161,7 @@ class DebugContext(MemoryInterface):
             register's name in lowercase or the integer register index.
         @param data_list List of values for the registers in the corresponding positions of
             _reg_list_. All values must be integers, even for float registers.
-        
+
         @exception KeyError Invalid or unsupported register was requested.
         @exception @ref pyocd.core.exceptions.CoreRegisterAccessError "CoreRegisterAccessError" Failed to
             write one or more registers.

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -51,7 +51,7 @@ class ElfSymbolDecoder(object):
             return sorted(self.symbol_tree[addr])[0].data
         except IndexError:
             return None
-    
+
     def get_symbol_for_name(self, name):
         try:
             return self.symbol_dict[name]
@@ -80,7 +80,7 @@ class ElfSymbolDecoder(object):
 
             # Add to symbol dict.
             self.symbol_dict[symbol.name] = syminfo
-            
+
             # Add to symbol tree.
             self.symbol_tree.addi(sym_value, sym_value+sym_size, syminfo)
 

--- a/pyocd/debug/elf/elf.py
+++ b/pyocd/debug/elf/elf.py
@@ -23,18 +23,18 @@ from .decoder import (ElfSymbolDecoder, DwarfAddressDecoder)
 
 class ELFSection(MemoryRange):
     """! @brief Memory range for a section of an ELF file.
-    
+
     Objects of this class represent sections of an ELF file. See the ELFBinaryFile class documentation
     for details of how sections are selected and how to get instances of this class.
-    
+
     If a region in the target's memory map can be found that contains the section, it will be
     accessible via the instance's _region_ attribute. Otherwise _region_ will be `None`. A maximum of
     one associated memory region is supported, even if the section spans multiple regions.
-    
+
     The contents of the ELF section can be read via the `data` property as a `bytearray`. The data is
     read from the file only once and cached.
     """
-    
+
     def __init__(self, elf, sect):
         self._elf = elf
         self._section = sect
@@ -52,7 +52,7 @@ class ELFSection(MemoryRange):
     @property
     def name(self):
         return self._name
-        
+
     @property
     def type(self):
         return self._section['sh_type']
@@ -80,7 +80,7 @@ class ELFSection(MemoryRange):
         if flagsDesc[-1] == '|':
             flagsDesc = flagsDesc[:-1]
         return flagsDesc
-    
+
     def __eq__(self, other):
         # Include section name in equality test.
         return super(ELFSection, self).__eq__(other) and self.name == other.name
@@ -91,23 +91,23 @@ class ELFSection(MemoryRange):
 
 class ELFBinaryFile(object):
     """! @brief An ELF binary executable file.
-    
+
     Examines the ELF and provides several lists of useful data: section objects, and both used
     and unused ranges of memory.
-    
+
     An ELFSection object is created for each of the sections of the file that are loadable code or
     data, or otherwise occupy memory. These are normally the .text, .rodata, .data, and .bss
     sections. More specifically, the list of sections contains any section with a type of
     `SHT_PROGBITS` or `SHT_NOBITS`. Also, at least one of the `SHF_WRITE`, `SHF_ALLOC`, or
     `SHF_EXECINSTR` flags must be set.
-    
+
     The set of sections is compared with the target's memory map to produce a lists of the used
     (occupied) and unused (unoccupied) ranges of memory. Note that if the executable uses ranges
     of memory not mapped with a section of the ELF file, those ranges will not be considered in
     the used/unused lists. Also, only ranges completely contained within a region of the memory
     map are considered.
     """
-    
+
     def __init__(self, elf, memory_map=None):
         self._owns_file = False
         if isinstance(elf, str):

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -74,11 +74,11 @@ MAX_STRING_LENGTH = 2048
 
 class SemihostIOHandler(object):
     """! @brief Interface for semihosting file I/O handlers.
-    
+
     This class is also used as the default I/O handler if none is provided to SemihostAgent.
     In this case, all file I/O requests are rejected.
     """
-    
+
     def __init__(self):
         self.agent = None
         self._errno = 0
@@ -92,12 +92,12 @@ class SemihostIOHandler(object):
 
     def _std_open(self, fnptr, fnlen, mode):
         """! @brief Helper for standard I/O open requests.
-        
+
         In the ARM semihosting spec, standard I/O files are opened using a filename of ":tt"
         with the open mode specifying which standard I/O file to open. This method takes care
         of these special open requests, and is intended to be used by concrete I/O handler
         subclasses.
-        
+
         @return A 2-tuple of the file descriptor and filename. The filename is returned so it
           only has to be read from target memory once if the request is not for standard I/O.
           The returned file descriptor may be one of 0, 1, or 2 for the standard I/O files,
@@ -154,12 +154,12 @@ class SemihostIOHandler(object):
 
 class InternalSemihostIOHandler(SemihostIOHandler):
     """! @brief Implements semihosting requests directly in the Python process.
-    
+
     This class maintains its own list of pseudo-file descriptors for files opened by the
     debug target. By default, this class uses the system stdin, stdout, and stderr file objects
     for file desscriptors 1, 2, and 3.
     """
-    
+
     def __init__(self):
         super(InternalSemihostIOHandler, self).__init__()
         self.next_fd = STDERR_FD + 1
@@ -287,7 +287,7 @@ class InternalSemihostIOHandler(SemihostIOHandler):
 
 class ConsoleIOHandler(SemihostIOHandler):
     """! @brief Simple IO handler for console."""
-    
+
     def __init__(self, stdin_file, stdout_file=None):
         super(ConsoleIOHandler, self).__init__()
         self._stdin_file = stdin_file
@@ -321,31 +321,31 @@ class ConsoleIOHandler(SemihostIOHandler):
 
 class SemihostAgent(object):
     """! @brief Handler for ARM semihosting requests.
-    
+
     Semihosting requests are made by the target by executing a 'bkpt #0xab' instruction. The
     requested operation is specified by R0 and any arguments by R1. Many requests use a block
     of word-sized arguments pointed to by R1. The return value is passed back to the target
     in R0.
-    
+
     This class does not handle any file-related requests by itself. It uses I/O handler objects
     passed in to the constructor. The requests handled directly by this class are #TARGET_SYS_CLOCK
     and #TARGET_SYS_TIME.
-    
+
     There are two types of I/O handlers used by this class. The main I/O handler, set
     with the constructor's @i io_handler parameter, is used for most file operations.
     You may optionally pass another I/O handler for the @i console constructor parameter. The
     console handler is used solely for standard I/O and debug console I/O requests. If no console
     handler is provided, the main handler is used instead. TARGET_SYS_OPEN requests are not
     passed to the console handler in any event, they are always passed to the main handler.
-    
+
     If no main I/O handler is provided, the class will use SemihostIOHandler, which causes all
     file I/O requests to be rejected as an error.
-    
+
     The SemihostAgent assumes standard I/O file descriptor numbers are #STDIN_FD, #STDOUT_FD,
     and #STDERR_FD. When it receives a read or write request for one of these descriptors, it
     passes the request to the console handler. This means the main handler must return these
     numbers for standard I/O open requests (those with a file name of ":tt").
-    
+
     Not all semihosting requests are supported. Those that are not implemented are:
     - TARGET_SYS_TMPNAM
     - TARGET_SYS_SYSTEM
@@ -397,16 +397,16 @@ class SemihostAgent(object):
 
     def check_and_handle_semihost_request(self):
         """! @brief Handle a semihosting request.
-        
+
         This method should be called after the target has halted, to check if the halt was
         due to a semihosting request. It first checks to see if the target halted because
         of a breakpoint. If so, it reads the instruction at PC to make sure it is a 'bkpt #0xAB'
         instruction. If so, the target is making a semihosting request. If not, nothing more is done.
-        
+
         After the request is handled, the PC is advanced to the next instruction after the 'bkpt'.
         A boolean is return indicating whether a semihosting request was handled. If True, the
         caller should resume the target immediately.
-        
+
         @retval True A semihosting request was handled.
         @retval False The target halted for a reason other than semihosting, i.e. a user-installed
           debugging breakpoint.
@@ -458,7 +458,7 @@ class SemihostAgent(object):
 
     def cleanup(self):
         """! @brief Clean up any resources allocated by semihost requests.
-        
+
         @note May be called more than once.
         """
         self.io_handler.cleanup()

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -38,7 +38,7 @@ class SVDFile(object):
             from ...core.session import Session
             LOG.warning("unable to open builtin SVD file: %s", err, exc_info=Session.get_current().log_tracebacks)
             return None
-    
+
     def __init__(self, filename=None):
         self.filename = filename
         self.device = None

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -38,7 +38,7 @@ def ranges(i: List[int]) -> List[Tuple[int, int]]:
     """!
     Accepts a sorted list of byte addresses. Breaks the addresses into contiguous ranges.
     Yields 2-tuples of the start and end address for each contiguous range.
-    
+
     For instance, the input [0, 1, 2, 3, 32, 33, 34, 35] will yield the following 2-tuples:
     (0, 3) and (32, 35).
     """
@@ -48,12 +48,12 @@ def ranges(i: List[int]) -> List[Tuple[int, int]]:
 
 class FileProgrammer(object):
     """! @brief Class to manage programming a file in any supported format with many options.
-    
+
     Most specifically, this class implements the behaviour provided by the command-line flash
     programming tool. The code in this class simply extracts data from the given file, potentially
     respecting format-specific options such as the base address for binary files. Then the heavy
     lifting of flash programming is handled by FlashLoader, and beneath that, FlashBuilder.
-    
+
     Support file formats are:
     - Binary (.bin)
     - Intel Hex (.hex)
@@ -68,7 +68,7 @@ class FileProgrammer(object):
             keep_unwritten: Optional[bool] = None
         ):
         """! @brief Constructor.
-        
+
         @param self
         @param session The session object.
         @param progress A progress report handler as a callable that takes a percentage completed.
@@ -94,64 +94,64 @@ class FileProgrammer(object):
         self._keep_unwritten = keep_unwritten
         self._progress = progress
         self._loader = None
-        
+
         self._format_handlers: Dict[str, Callable[..., None]] = {
             'axf': self._program_elf,
             'bin': self._program_bin,
             'elf': self._program_elf,
             'hex': self._program_hex,
             }
-    
+
     def program(self, file_or_path: Union[str, IO[bytes]], file_format: Optional[str] = None, **kwargs: Any):
         """! @brief Program a file into flash.
-        
+
         @param self
         @param file_or_path Either a string that is a path to a file, or a file-like object.
         @param file_format Optional file format name, one of "bin", "hex", "elf", "axf". If not provided,
             the file's extension will be used. If a file object is passed for _file_or_path_ then
             this parameter must be used to set the format.
         @param kwargs Optional keyword arguments for format-specific parameters.
-        
+
         The only current format-specific keyword parameters are for the binary format:
         - `base_address`: Memory address at which to program the binary data. If not set, the base
             of the boot memory will be used.
         - `skip`: Number of bytes to skip at the start of the binary file. Does not affect the
             base address.
-        
+
         @exception FileNotFoundError Provided file_or_path string does not reference a file.
         @exception ValueError Invalid argument value, for instance providing a file object but
             not setting file_format.
         """
         is_path = isinstance(file_or_path, str)
-        
+
         # Check for valid path first.
         if is_path and not os.path.isfile(file_or_path): # type: ignore (type checker doesn't use is_path)
             raise FileNotFoundError(errno.ENOENT, "No such file: '{}'".format(file_or_path))
-        
+
         # If no format provided, use the file's extension.
         if not file_format:
             if is_path:
                 # Extract the extension from the path.
                 file_format = os.path.splitext(file_or_path)[1][1:] # type: ignore (type checker doesn't use is_path)
-                
+
                 # Explicitly check for no extension.
                 if file_format == '':
                     raise ValueError("file path '{}' does not have an extension and "
                                         "no format is set".format(file_or_path))
             else:
                 raise ValueError("file object provided but no format is set")
-        
+
         # Check the format is one we understand.
         if file_format is None or file_format not in self._format_handlers:
             raise ValueError("unknown file format '%s'" % file_format)
-            
+
         self._loader = FlashLoader(self._session,
                                     progress=self._progress,
                                     chip_erase=self._chip_erase,
                                     smart_flash=self._smart_flash,
                                     trust_crc=self._trust_crc,
                                     keep_unwritten=self._keep_unwritten)
-        
+
         # file_obj = None
         # Open the file if a path was provided.
         if is_path:
@@ -185,13 +185,13 @@ class FileProgrammer(object):
                 raise exceptions.TargetSupportError("No boot memory is defined for this device")
             address = boot_memory.start
         assert isinstance(address, int)
-        
+
         skip_offset = kwargs.get('skip', 0)
         if not isinstance(skip_offset, int):
             raise TypeError("skip argument must be an integer")
         file_obj.seek(skip_offset, os.SEEK_SET)
         data = list(bytearray(file_obj.read()))
-        
+
         self._loader.add_data(address, data)
 
     def _program_hex(self, file_obj: IO[bytes], **kwargs: Any) -> None:
@@ -208,7 +208,7 @@ class FileProgrammer(object):
             data = list(hexfile.tobinarray(start=start, size=size))
             # Ignore invalid addresses for HEX files only
             # Binary files (obviously) don't contain addresses
-            # For ELF files, any metadata that's not part of the application code 
+            # For ELF files, any metadata that's not part of the application code
             # will be held in a section that doesn't have the SHF_WRITE flag set
             try:
                 self._loader.add_data(start, data)
@@ -223,7 +223,7 @@ class FileProgrammer(object):
             addr = segment['p_paddr']
             if segment.header.p_type == 'PT_LOAD' and segment.header.p_filesz != 0:
                 data = bytearray(segment.data())
-                LOG.debug("Writing segment LMA:0x%08x, VMA:0x%08x, size %d", addr, 
+                LOG.debug("Writing segment LMA:0x%08x, VMA:0x%08x, size %d", addr,
                           segment['p_vaddr'], segment.header.p_filesz)
                 try:
                     self._loader.add_data(addr, data)

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -31,12 +31,12 @@ class ThreadsCommand(CommandBase):
             'usage': "{flush,enable,disable,status}",
             'help': "Control thread awareness.",
             }
-    
+
     def parse(self, args):
         self.action = args[0]
         if self.action not in ('flush', 'enable', 'disable', 'status'):
             raise exceptions.CommandError("invalid action")
-    
+
     def execute(self):
         # Get the gdbserver for the selected core.
         core_number = self.context.selected_core.core_number
@@ -73,21 +73,21 @@ class ArmSemihostingCommand(CommandBase):
             'extra_help': "Provided for compatibility with OpenOCD. The same functionality can be achieved "
                             "by setting the 'enable_semihosting' session option.",
             }
-    
+
     def parse(self, args):
         if args[0] != 'semihosting':
             raise exceptions.CommandError("invalid action")
         if args[1] not in ('enable', 'disable'):
             raise exceptions.CommandError("invalid action")
         self.action = args[1]
-    
+
     def execute(self):
         enable = (self.action == 'enable')
         self.context.session.options['enable_semihosting'] = enable
 
 class GdbserverMonitorInitCommand(CommandBase):
     """@brief 'init' command for OpenOCD compatibility.
-    
+
     Many default gdbserver configurations send an 'init' monitor command.
     """
     INFO = {
@@ -98,6 +98,6 @@ class GdbserverMonitorInitCommand(CommandBase):
             'usage': "init",
             'help': "Ignored; for OpenOCD compatibility.",
             }
-    
+
     def execute(self):
         pass

--- a/pyocd/gdbserver/packet_io.py
+++ b/pyocd/gdbserver/packet_io.py
@@ -40,13 +40,13 @@ class ConnectionClosedException(Exception):
 
 class GDBServerPacketIOThread(threading.Thread):
     """! @brief Packet I/O thread.
-    
+
     This class is a thread used by the GDBServer class to perform all RSP packet I/O. It
     handles verifying checksums, acking, and receiving Ctrl-C interrupts. There is a queue
     for received packets. The interface to this queue is the receive() method. The send()
     method writes outgoing packets to the socket immediately.
     """
-    
+
     def __init__(self, abstract_socket):
         super(GDBServerPacketIOThread, self).__init__()
         self.name = "gdb-packet-thread-port%d" % abstract_socket.port

--- a/pyocd/probe/aggregator.py
+++ b/pyocd/probe/aggregator.py
@@ -48,31 +48,31 @@ class DebugProbeAggregator(object):
     @staticmethod
     def get_all_connected_probes(unique_id=None):
         klasses, unique_id, is_explicit = DebugProbeAggregator._get_probe_classes(unique_id)
-        
+
         probes = []
-        
+
         # First look for a match against the full ID, as this can be more efficient for certain probes.
         if unique_id is not None:
             for cls in klasses:
                 probe = cls.get_probe_with_id(unique_id, is_explicit)
                 if probe is not None:
                     return [probe]
-        
+
         # No full match, so ask probe classes for probes.
         for cls in klasses:
             probes += cls.get_all_connected_probes(unique_id, is_explicit)
-        
+
         # Filter by unique ID.
         if unique_id is not None:
             unique_id = unique_id.lower()
             probes = [probe for probe in probes if (unique_id in probe.unique_id.lower())]
-        
+
         return probes
-    
+
     @classmethod
     def get_probe_with_id(cls, unique_id):
         klasses, unique_id, is_explicit = DebugProbeAggregator._get_probe_classes(unique_id)
-        
+
         for cls in klasses:
             probe = cls.get_probe_with_id(unique_id, is_explicit)
             if probe is not None:

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -20,33 +20,33 @@ import threading
 
 class DebugProbe(object):
     """! @brief Abstract debug probe class.
-    
+
     Subclasses of this abstract class are drivers for different debug probe interfaces, either hardware such as a
     USB based probe, or software such as connecting with a simulator.
-    
+
     The constructor is private. To create an instance, use either of get_all_connected_probes() or get_probe_with_id().
     Normally, the @ref pyocd.probe.aggregator.DebugProbeAggregator "DebugProbeAggregator" class is used instead of
     directly calling methods on a specific probe class.
-    
+
     Use an instance as follows:
-    
+
     1. Call open().
     2. Optionally inspect the `supported_wire_protocols` property and select a protocol to use.
     3. Call connect(), passing the chosen wire protocol.
     4. Use by instance by calling other methods.
     5. Call disconnect().
     6. Call close().
-    
+
     Most methods are required to be overridden by a subclass, with a few exceptions.
-    
+
     These methods are completely optional:
-    
+
     - create_associated_board()
     - flush()
     - get_memory_interface_for_ap()
-    
+
     These methods must be implemented depending on the probe capabilities, as returned from the `capabilities` property.
-    
+
     - swj_sequence(): Capability.SWJ_SEQUENCE; if not provided it is assumed the probe automatically enables SWD or JTAG
         on the target based on the protocol passed into connect().
     - swd_sequence(): Capability.SWD_SEQUENCE
@@ -59,14 +59,14 @@ class DebugProbe(object):
         DEFAULT = 0
         SWD = 1
         JTAG = 2
-    
+
     ## Map from wire protocol setting name to debug probe constant.
     PROTOCOL_NAME_MAP = {
             'swd': Protocol.SWD,
             'jtag': Protocol.JTAG,
             'default': Protocol.DEFAULT,
         }
-    
+
     class Capability(Enum):
         """! @brief Probe capabilities."""
         ## @brief Whether the probe supports the swj_sequence() API.
@@ -74,7 +74,7 @@ class DebugProbe(object):
         # If this property is True, then the swj_sequence() method is used to move between protocols.
         # If False, it is assumed the probe firmware automatically manages the protocol switch.
         SWJ_SEQUENCE = 0
-        
+
         ## @brief Whether the probe supports receiving SWO data.
         SWO = 1
 
@@ -83,20 +83,20 @@ class DebugProbe(object):
         # Currently only used to verify that the probe supports banked DP registers when the #MANAGED_DPBANKSEL
         # capability is present.
         BANKED_DP_REGISTERS = 2
-        
+
         ## @brief Whether the probe can access APv2 registers.
         #
         # This capability is currently only used to verify that a probe with the #MANAGED_AP_SELECTION capability
         # can support the wider AP addresses used in version 2 APs. For probes without #MANAGED_AP_SELECTION,
         # DP_SELECT is written directly by the DAP layer when selecting an AP.
         APv2_ADDRESSES = 3
-        
+
         ## @brief Whether the probe automatically handles AP selection in the DP.
         #
         # If this capability is not present, the DebugPort object will perform the AP selection
         # by DP register writes.
         MANAGED_AP_SELECTION = 4
-        
+
         ## @brief whether the probe automatically handles access of banked DAP registers.
         MANAGED_DPBANKSEL = 5
 
@@ -105,15 +105,15 @@ class DebugProbe(object):
 
         ## @brief Whether the probe supports the jtag_sequence() API.
         JTAG_SEQUENCE = 7
-    
+
     @classmethod
     def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
         """! @brief Returns a list of DebugProbe instances.
-        
+
         To filter the list of returned probes, the `unique_id` parameter may be set to a string with a full or
         partial unique ID (canonically the serial number). Alternatively, the probe class may simply return all
         available probes and let the caller handle filtering.
-        
+
         @param cls The class instance.
         @param unique_id String. Optional partial unique ID value used to filter available probes. May be used by the
             probe to optimize retrieving the probe list; there is no requirement to filter the results.
@@ -124,13 +124,13 @@ class DebugProbe(object):
         @return List of DebugProbe instances.
         """
         raise NotImplementedError()
-    
+
     @classmethod
     def get_probe_with_id(cls, unique_id, is_explicit=False):
         """! @brief Returns a DebugProbe instance for a probe with the given unique ID.
-        
+
         If no probe is connected with a fully matching unique ID, then None will be returned.
-        
+
         @param cls The class instance.
         @param unique_id Unique ID string to match against probes' full unique ID. No partial matches are allowed.
         @param is_explicit Boolean. Whether the probe type was explicitly specified in the unique ID.
@@ -147,30 +147,30 @@ class DebugProbe(object):
     def session(self):
         """! @brief Session associated with this probe."""
         return self._session
-    
+
     @session.setter
     def session(self, the_session):
         self._session = the_session
-    
+
     @property
     def description(self):
         """! @brief Combined description of the debug probe and/or associated board."""
         return self.vendor_name + " " + self.product_name
-    
+
     @property
     def vendor_name(self):
         """! @brief Name of the debug probe's manufacturer."""
         raise NotImplementedError()
-    
+
     @property
     def product_name(self):
         """! @brief Name of the debug probe."""
         raise NotImplementedError()
-    
+
     @property
     def supported_wire_protocols(self):
         """! @brief List of DebugProbe.Protocol supported by the probe.
-        
+
         Only one of the values returned from this property may be passed to connect().
         """
         raise NotImplementedError()
@@ -178,7 +178,7 @@ class DebugProbe(object):
     @property
     def unique_id(self):
         """! @brief The unique ID of this device.
-        
+
         This property will be valid before open() is called. This value can be passed to
         get_probe_with_id().
         """
@@ -187,37 +187,37 @@ class DebugProbe(object):
     @property
     def wire_protocol(self):
         """! @brief Currently selected wire protocol.
-        
+
         If the probe is not open and connected, i.e., open() and connect() have not been called,
         then this property will be None. If a value other than None is returned, then the probe
         has been connected successfully.
         """
         raise NotImplementedError()
-    
+
     @property
     def is_open(self):
         """! @brief Whether the probe is currently open.
-        
+
         To open the probe, call the open() method.
         """
         raise NotImplementedError()
-    
+
     @property
     def capabilities(self):
         """! @brief A set of DebugProbe.Capability enums indicating the probe's features.
-        
+
         This value should not be trusted until after the probe is opened.
         """
         raise NotImplementedError()
 
     def create_associated_board(self):
         """! @brief Create a board instance representing the board of which the probe is a component.
-        
+
         If the probe is part of a board, then this method will create a Board instance that
         represents the associated board. Usually, for an on-board debug probe, this would be the
         Board that the probe physically is part of, and will also set the target type. If the probe
         does not have an associated board, then this method returns None.
-        
+
         @param self
         @param session Session to pass to the board upon construction.
         """
@@ -226,24 +226,24 @@ class DebugProbe(object):
     def open(self):
         """! @brief Open the USB interface to the probe for sending commands."""
         raise NotImplementedError()
-    
+
     def close(self):
         """! @brief Close the probe's USB interface."""
         raise NotImplementedError()
-    
+
     def lock(self):
         """! @brief Lock the probe from access by other threads.
-        
+
         This lock is recursive, so locking multiple times from a single thread is acceptable as long
         as the thread unlocks the same number of times.
-        
+
         This method does not return until the calling thread has ownership of the lock.
         """
         self._lock.acquire()
-    
+
     def unlock(self):
         """! @brief Unlock the probe.
-        
+
         Only when the thread unlocks the probe the same number of times it has called lock() will
         the lock actually be released and other threads allowed access.
         """
@@ -262,7 +262,7 @@ class DebugProbe(object):
 
     def swj_sequence(self, length, bits):
         """! @brief Transfer some number of bits on SWDIO/TMS.
-        
+
         @param self
         @param length Number of bits to transfer. Must be less than or equal to 256.
         @param bits Integer of the bit values to send on SWDIO/TMS. The LSB is transmitted first.
@@ -271,16 +271,16 @@ class DebugProbe(object):
 
     def swd_sequence(self, sequences):
         """! @brief Send a sequences of bits on the SWDIO signal.
-        
+
         Each sequence in the _sequences_ parameter is a tuple with 1 or 2 members in this order:
         - 0: int: number of TCK cycles from 1-64
         - 1: int: the SWDIO bit values to transfer. The presence of this tuple member indicates the sequence is
             an output sequence; the absence means that the specified number of TCK cycles of SWDIO data will be
             read and returned.
-        
+
         @param self
         @param sequences A sequence of sequence description tuples as described above.
-        
+
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
         """
@@ -288,14 +288,14 @@ class DebugProbe(object):
 
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):
         """! @brief Send JTAG sequence.
-        
+
         @param self
         @param cycles Number of TCK cycles, from 1-64.
         @param tms Fixed TMS value. Either 0 or 1.
         @param read_tdo Boolean indicating whether TDO should be read.
         @param tdi Integer with the TDI bit values to be transferred each TCK cycle. The LSB is
             sent first.
-        
+
         @return Either an integer with TDI bit values, or None, if _read_tdo_ was false.
         """
         raise NotImplementedError()
@@ -313,15 +313,15 @@ class DebugProbe(object):
 
     def assert_reset(self, asserted):
         """! @brief Assert or de-assert target's nRESET signal.
-        
+
         Because nRESET is negative logic and usually open drain, passing True will drive it low, and
         passing False will stop driving so nRESET will be pulled up.
         """
         raise NotImplementedError()
-    
+
     def is_reset_asserted(self):
         """! @brief Returns True if nRESET is asserted or False if de-asserted.
-        
+
         If the debug probe cannot actively read the reset signal, the value returned will be the
         last value passed to assert_reset().
         """
@@ -329,7 +329,7 @@ class DebugProbe(object):
 
     def flush(self):
         """! @brief Write out all unsent commands.
-        
+
         This API may be a no-op for certain debug probe types.
         """
         pass
@@ -341,7 +341,7 @@ class DebugProbe(object):
 
     def read_dp(self, addr, now=True):
         """! @brief Read a DP register.
-        
+
         @param self
         @param addr Integer register address being one of (0x0, 0x4, 0x8, 0xC).
         @param now Boolean specifying whether the read is synchronous (True) or asynchronous.
@@ -352,7 +352,7 @@ class DebugProbe(object):
 
     def write_dp(self, addr, data):
         """! @brief Write a DP register.
-        
+
         @param self
         @param addr Integer register address being one of (0x0, 0x4, 0x8, 0xC).
         @param data Integer register value.
@@ -374,21 +374,21 @@ class DebugProbe(object):
     def write_ap_multiple(self, addr, values):
         """! @brief Write one AP register multiple times."""
         raise NotImplementedError()
-    
+
     def get_memory_interface_for_ap(self, ap_address):
         """! @brief Returns a @ref pyocd.core.memory_interface.MemoryInterface "MemoryInterface" for
             the specified AP.
-        
+
         Some debug probe types have accelerated memory read and write commands. This method is used
         to get a concrete @ref pyocd.core.memory_interface.MemoryInterface "MemoryInterface"
         instance that is specific to the AP identified by the _ap_address_ parameter. If the probe
         does not provide an accelerated memory interface, None will be returned.
-        
+
         @param self The debug probe.
         @param ap_address An instance of @ref pyocd.coresight.ap.APAddress "APAddress".
         """
         return None
-    
+
     ##@}
 
     ## @name SWO
@@ -396,7 +396,7 @@ class DebugProbe(object):
 
     def swo_start(self, baudrate):
         """! @brief Start receiving SWO data at the given baudrate.
-        
+
         Once SWO reception has started, the swo_read() method must be called at regular intervals
         to receive SWO data. If this is not done, the probe's internal SWO data buffer may overflow
         and data will be lost.
@@ -409,15 +409,15 @@ class DebugProbe(object):
 
     def swo_read(self):
         """! @brief Read buffered SWO data from the target.
-        
+
         @eturn Bytearray of the received data. May be 0 bytes in length if no SWO data is buffered
             at the probe.
         """
         raise NotImplementedError()
 
     ##@}
-    
+
     def __repr__(self):
         return "<{}@{:x} {}>".format(self.__class__.__name__, id(self), self.description)
-  
+
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -140,7 +140,7 @@ class DAPTransferResponse:
     ACK_MASK = 0x07 # Bits [2:0]
     PROTOCOL_ERROR_MASK = 0x08 # Bit [3]
     VALUE_MISMATCH_MASK = 0x08 # Bit [4]
-    
+
     # Values for ACK bitfield.
     ACK_OK = 1
     ACK_WAIT = 2
@@ -166,7 +166,7 @@ class CMSISDAPProtocol(object):
             - A string-type info was requested, but the returned value length is greater than the response packet size minus response header and terminating null byte on the string.
         """
         assert type(id_) is DAPAccessIntf.ID
-            
+
         cmd = []
         cmd.append(Command.DAP_INFO)
         cmd.append(id_.value)
@@ -348,7 +348,7 @@ class CMSISDAPProtocol(object):
     def swd_configure(self, turnaround=1, always_send_data_phase=False):
         assert 1 <= turnaround <= 4
         conf = (turnaround - 1) | (int(always_send_data_phase) << 2)
-    
+
         cmd = []
         cmd.append(Command.DAP_SWD_CONFIGURE)
         cmd.append(conf)
@@ -367,13 +367,13 @@ class CMSISDAPProtocol(object):
 
     def swd_sequence(self, sequences):
         """! @brief Send the DAP_SWD_Sequence command.
-        
+
         Each sequence in the _sequences_ parameter is a tuple with 1 or 2 members:
         - 0: int: number of TCK cycles from 1-64
         - 1: int: the SWDIO bit values to transfer. The presence of this tuple member indicates the sequence is
             an output sequence; the absence means that the specified number of TCK cycles of SWDIO data will be
             read and returned.
-        
+
         The DAP_SWD_Sequence command expects this data for each sequence:
         - 0: sequence info byte
             - bit [7]: mode, 0=output, 1=input
@@ -381,10 +381,10 @@ class CMSISDAPProtocol(object):
             - bits [5:0]: number of TCK cycles from 1-64, with 64 encoded as 0
         - 1: (only present if element 0 bit 7 == 0, for output mode) bytes of data to send, one bit per TCK cycle,
             transmitted LSB first.
-        
+
         @param self
         @param sequences A sequence of sequence description tuples as described above.
-        
+
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
         """
@@ -397,7 +397,7 @@ class CMSISDAPProtocol(object):
             is_output = len(seq) == 2
             info = (0x00 if is_output else 0x80) | (0 if (tck_count == 64) else tck_count)
             cmd.append(info)
-            
+
             # Append SWDIO output data.
             if is_output:
                 bits = seq[1]
@@ -456,7 +456,7 @@ class CMSISDAPProtocol(object):
         info = (((0 if (cycles == 64) else cycles) & 0x3f)
                 | ((tms & 1) << 6)
                 | (int(read_tdo) << 7))
-        
+
         cmd = []
         cmd.append(Command.DAP_JTAG_SEQUENCE)
         cmd.append(1)
@@ -481,7 +481,7 @@ class CMSISDAPProtocol(object):
         # Default to a single device with an IRLEN of 4.
         if devices_irlen is None:
             devices_irlen = [4]
-        
+
         cmd = []
         cmd.append(Command.DAP_JTAG_CONFIGURE)
         cmd.append(len(devices_irlen))

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -102,7 +102,7 @@ class DAPAccessIntf(object):
     @property
     def protocol_version(self):
         """! @brief CMSIS-DAP protocol version.
-        
+
         The version is represented as 3-tuple with elements, in order, of major version,
         minor version, and patch version.
 
@@ -117,7 +117,7 @@ class DAPAccessIntf(object):
     @property
     def product_name(self):
         raise NotImplementedError()
-    
+
     @property
     def vidpid(self):
         """! @brief A tuple of USB VID and PID, in that order."""
@@ -126,7 +126,7 @@ class DAPAccessIntf(object):
     @property
     def has_swd_sequence(self):
         """! @brief Boolean indicating whether the DAP_SWD_Sequence command is supported.
-        
+
         This property is only valid after the probe is opened. Until then, the value will be None.
         """
         raise NotImplementedError()
@@ -162,17 +162,17 @@ class DAPAccessIntf(object):
 
     def configure_swd(self, turnaround=1, always_send_data_phase=False):
         """! @brief Modify SWD configuration.
-        
+
         @param self
         @param turnaround Number of turnaround phase clocks, from 1-4.
         @param always_send_data_phase Whether the data phase should always be transmitted on writes,
             even on a FAULT response. This is required for sticky overrun support.
         """
         raise NotImplementedError()
-    
+
     def configure_jtag(self, devices_irlen=None):
         """! @brief Modify JTAG configuration.
-        
+
         @param self
         @param devices_irlen Sequence of IR lengths for each device, thus also specifying the
             number of devices. If not passed, this will default to a single device with IRLen=4.
@@ -181,7 +181,7 @@ class DAPAccessIntf(object):
 
     def swj_sequence(self, length, bits):
         """! @brief Send sequence to activate JTAG or SWD on the target.
-        
+
         @param self
         @param length Number of bits to transfer on TCK/TMS.
         @param bits Integer with the bit values, sent LSB first.
@@ -190,32 +190,32 @@ class DAPAccessIntf(object):
 
     def swd_sequence(self, sequences):
         """! @brief Send a sequences of bits on the SWDIO signal.
-        
+
         This method sends the DAP_SWD_Sequence CMSIS-DAP command.
-        
+
         Each sequence in the _sequences_ parameter is a tuple with 1 or 2 members:
         - 0: int: number of TCK cycles from 1-64
         - 1: int: the SWDIO bit values to transfer. The presence of this tuple member indicates the sequence is
             an output sequence; the absence means that the specified number of TCK cycles of SWDIO data will be
             read and returned.
-        
+
         @param self
         @param sequences A sequence of sequence description tuples as described above.
-        
+
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
         """
 
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):
         """! @brief Send JTAG sequence.
-        
+
         @param self
         @param cycles Number of TCK cycles, from 1-64.
         @param tms Fixed TMS value. Either 0 or 1.
         @param read_tdo Boolean indicating whether TDO should be read.
         @param tdi Integer with the TDI bit values to be transferred each TCK cycle. The LSB is
             sent first.
-        
+
         @return Either an integer with TDI bit values, or None, if _read_tdo_ was false.
         """
         raise NotImplementedError()
@@ -242,7 +242,7 @@ class DAPAccessIntf(object):
     def assert_reset(self, asserted):
         """! @brief Assert or de-assert target reset line"""
         raise NotImplementedError()
-    
+
     def is_reset_asserted(self):
         """! @brief Returns True if the target reset line is asserted or False if de-asserted"""
         raise NotImplementedError()
@@ -258,7 +258,7 @@ class DAPAccessIntf(object):
     def vendor(self, index, data=None):
         """! @brief Send a vendor specific command"""
         raise NotImplementedError()
-    
+
     def has_swo(self):
         """! @brief Returns bool indicating whether the link supports SWO."""
         raise NotImplementedError()
@@ -278,11 +278,11 @@ class DAPAccessIntf(object):
 
     def swo_read(self, count=None):
         """! @brief Read buffered SWO data from the target.
-        
+
         The count parameter is optional. If
         provided, it is the number of bytes to read, which must be less than the packet size.
         If count is not provided, the packet size will be used instead.
-        
+
         Returns a 3-tuple containing the status mask at index 0, the number of buffered
         SWO data bytes at index 1, and a list of the received data bytes at index 2."""
         raise NotImplementedError()

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -65,16 +65,16 @@ def _get_interfaces():
     """! @brief Get the connected USB devices"""
     # Get CMSIS-DAPv1 interfaces.
     v1_interfaces = INTERFACE[USB_BACKEND].get_all_connected_interfaces()
-    
+
     # Get CMSIS-DAPv2 interfaces.
     v2_interfaces = INTERFACE[USB_BACKEND_V2].get_all_connected_interfaces()
-    
+
     # Prefer v2 over v1 if a device provides both.
     devices_in_both = [v1 for v1 in v1_interfaces for v2 in v2_interfaces
                         if _get_unique_id(v1) == _get_unique_id(v2)]
     for dev in devices_in_both:
         v1_interfaces.remove(dev)
-        
+
     # Return the combined list.
     return v1_interfaces + v2_interfaces
 
@@ -323,11 +323,11 @@ class _Command(object):
         The ACK bits [2:0] and the protocol error bit are checked. If any error is indicated,
         the appropriate exception is raised. An exception is also raised for unrecognised ACK
         values.
-        
+
         @param self
         @param response The "Transfer Response" byte from a DAP_Transfer or DAP_TransferBlock
             command.
-        
+
         @exception DAPAccessIntf.TransferFaultError Raised for the ACK_FAULT response.
         @exception DAPAccessIntf.TransferTimeoutError Raised for ACK_WAIT response.
         @exception DAPAccessIntf.TransferError Raised for other, less common errors, including No
@@ -346,7 +346,7 @@ class _Command(object):
                 raise DAPAccessIntf.TransferError("Unexpected ACK value (%d) returned by probe" % ack)
         elif (response & DAPTransferResponse.PROTOCOL_ERROR_MASK) != 0:
             raise DAPAccessIntf.TransferError("SWD protocol error")
-    
+
     def _decode_transfer_data(self, data):
         """! @brief Take a byte array and extract the data from it
 
@@ -456,7 +456,7 @@ class _Command(object):
 
 class DAPAccessCMSISDAP(DAPAccessIntf):
     """! @brief An implementation of the DAPAccessIntf layer for DAPLink boards
-    
+
     @internal
     All methods that use the CMSISDAPProtocol instance must be locked and must flush the command queue
     prior to using methods of that object. Otherwise the command responses may be processed out of order.
@@ -548,7 +548,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             self._vendor_name = ""
             self._product_name = ""
             self._vidpid = (0, 0)
-            
+
         self._lock = threading.RLock()
         self._interface = interface
         self._deferred_transfer = False
@@ -572,11 +572,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             by the debug probe.
         """
         return self._cmsis_dap_version
-    
+
     @property
     def firmware_version(self) -> Optional[str]:
         """! @brief A string of the product firmware version, or None.
-        
+
         Only probes supporting CMSIS-DAP protocol v2.1 or later can return their firmware version.
         """
         return self._fw_version
@@ -588,7 +588,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     @property
     def product_name(self):
         return self._product_name
-    
+
     @property
     def vidpid(self):
         """! @brief A tuple of USB VID and PID, in that order."""
@@ -597,11 +597,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     @property
     def has_swd_sequence(self):
         return self._cmsis_dap_version >= CMSISDAPVersion.V1_2_0
-    
+
     def lock(self):
         """! @brief Lock the interface."""
         self._lock.acquire()
-    
+
     def unlock(self):
         """! @brief Unlock the interface."""
         self._lock.release()
@@ -644,7 +644,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             # One of the protocol version fields had a non-numeric character, indicating it is not a valid
             # CMSIS-DAP version number. Default to the lowest version.
             self._cmsis_dap_version = CMSISDAPVersion.V1_0_0
-        
+
         # Validate the version against known CMSIS-DAP minor versions. This will also catch the beta release
         # versions of CMSIS-DAP, 0.01 and 0.02, and raise them to 1.0.0.
         if self._cmsis_dap_version[:2] not in CMSISDAPVersion.minor_versions():
@@ -672,7 +672,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         if (self._cmsis_dap_version >= CMSISDAPVersion.V2_1_0) or (self._cmsis_dap_version >= CMSISDAPVersion.V1_3_0
                 and self._cmsis_dap_version < CMSISDAPVersion.V2_0_0):
             self._fw_version = self._protocol.dap_info(self.ID.PRODUCT_FW_VERSION)
-        
+
         # Log probe's firmware version.
         if self._fw_version:
             LOG.debug("CMSIS-DAP probe %s: firmware version %s, protocol version %i.%i.%i",
@@ -709,7 +709,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             self._protocol.set_swj_pins(0, Pin.nRESET)
         else:
             self._protocol.set_swj_pins(Pin.nRESET, Pin.nRESET)
-    
+
     @locked
     def is_reset_asserted(self):
         self.flush()
@@ -775,7 +775,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         self._protocol.set_swj_clock(self._frequency)
         # configure transfer
         self._protocol.transfer_configure()
-        
+
         # configure the selected protocol with defaults.
         if self._dap_port == DAPAccessIntf.PORT.SWD:
             self.configure_swd()
@@ -786,7 +786,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def configure_swd(self, turnaround=1, always_send_data_phase=False):
         self.flush()
         self._protocol.swd_configure(turnaround, always_send_data_phase)
-    
+
     @locked
     def configure_jtag(self, devices_irlen=None):
         self.flush()
@@ -811,10 +811,10 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     def disconnect(self):
         self.flush()
         self._protocol.disconnect()
-    
+
     def has_swo(self):
         return self._has_swo_uart
-    
+
     @locked
     def swo_configure(self, enabled, rate):
         self.flush()
@@ -822,7 +822,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         # Don't send any commands if the SWO commands aren't supported.
         if not self._has_swo_uart:
             return False
-        
+
         # Before we attempt any configuration, we must explicitly disable SWO
         # (if SWO is enabled, setting any other configuration fails).
         self._swo_disable()
@@ -834,7 +834,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                     transport = DAPSWOTransport.DAP_SWO_EP
                 else:
                     transport = DAPSWOTransport.DAP_SWO_DATA
-                
+
                 if self._protocol.swo_transport(transport) != 0:
                     self._swo_disable()
                     return False
@@ -851,7 +851,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             LOG.debug("Exception while configuring SWO: %s", e)
             self._swo_disable()
             return False
-    
+
     # Doesn't need @locked because it is only called from swo_configure().
     def _swo_disable(self):
         try:
@@ -861,7 +861,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
             LOG.debug("Exception while disabling SWO: %s", e)
         finally:
             self._swo_status = SWOStatus.DISABLED
-    
+
     @locked
     def swo_control(self, start):
         self.flush()
@@ -869,7 +869,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         # Don't send any commands if the SWO commands aren't supported.
         if not self._has_swo_uart:
             return False
-        
+
         if start:
             self._protocol.swo_control(DAPSWOControl.START)
             if self._interface.has_swo_ep:
@@ -881,11 +881,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                 self._interface.stop_swo()
             self._swo_status = SWOStatus.CONFIGURED
         return True
-    
+
     @locked
     def get_swo_status(self):
         return self._protocol.swo_status()
-    
+
     def swo_read(self, count=None):
         # The separate SWO EP can be read without locking.
         if self._interface.has_swo_ep:

--- a/pyocd/probe/pydapaccess/dap_settings.py
+++ b/pyocd/probe/pydapaccess/dap_settings.py
@@ -15,5 +15,5 @@
 # limitations under the License.
 
 class DAPSettings():
-	
+
 	limit_packets = False

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -76,10 +76,10 @@ def is_known_cmsis_dap_vid_pid(vid, pid):
 
 def filter_device_by_class(vid, pid, device_class):
     """! @brief Test whether the device should be ignored by comparing bDeviceClass.
-    
+
     This function checks the device's bDeviceClass to determine whether it is likely to be
     a CMSIS-DAP device. It uses the vid and pid for device-specific quirks.
-    
+
     @retval True Skip the device.
     @retval False The device is valid.
     """
@@ -94,12 +94,12 @@ def filter_device_by_class(vid, pid, device_class):
 
 def filter_device_by_usage_page(vid, pid, usage_page):
     """! @brief Test whether the device should be ignored by comparing the HID usage page.
-    
+
     This function performs device-specific tests to determine whether the device is a CMSIS-DAP
     interface. The only current test is for the NXP LPC-Link2, which has extra HID interfaces with
     usage pages other than 0xff00. No generic tests are done regardless of VID/PID, because it is
     not clear whether all CMSIS-DAP devices have the usage page set to the same value.
-    
+
     @retval True Skip the device.
     @retval False The device is valid.
     """
@@ -114,12 +114,12 @@ def check_ep(interface, ep_index, ep_dir, ep_type):
 
 def generate_device_unique_id(vid: int, pid: int, *locations: List[Union[int, str]]) -> str:
     """! @brief Generate a semi-stable unique ID from USB device properties.
-    
+
     This function is intended to be used in cases where a device does not provide a serial number
     string. pyocd still needs a valid unique ID so the device can be selected from amongst multiple
     connected devices. The algorithm used here generates an ID that is stable for a given device as
     long as it is connected to the same USB port.
-    
+
     @param vid Vendor ID.
     @param pid Product ID.
     @param locations Additional parameters are expected to be int or string values that represent

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -56,7 +56,7 @@ class HidApiUSB(Interface):
     @staticmethod
     def get_all_connected_interfaces():
         """! @brief Returns all the connected devices with CMSIS-DAP in the name.
-        
+
         returns an array of HidApiUSB (Interface) objects
         """
 
@@ -73,10 +73,10 @@ class HidApiUSB(Interface):
                 if "CMSIS-DAP" not in device_path:
                     # Skip non cmsis-dap devices
                     continue
-            
+
             vid = deviceInfo['vendor_id']
             pid = deviceInfo['product_id']
-            
+
             # Perform device-specific filtering.
             if filter_device_by_usage_page(vid, pid, deviceInfo['usage_page']):
                 continue

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -25,7 +25,7 @@ class Interface(object):
         self.serial_number = ""
         self.packet_count = 1
         self.packet_size = 64
-    
+
     @property
     def has_swo_ep(self):
         return False

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -48,7 +48,7 @@ class PyUSB(Interface):
     """
 
     isAvailable = IS_AVAILABLE
-    
+
     did_show_no_libusb_warning = False
 
     def __init__(self):
@@ -237,28 +237,28 @@ class PyUSB(Interface):
 
 class MatchCmsisDapv1Interface(object):
     """! @brief Match class for finding CMSIS-DAPv1 interface.
-    
+
     This match class performs several tests on the provided USB interface descriptor, to
     determine whether it is a CMSIS-DAPv1 interface. These requirements must be met by the
     interface:
-    
+
     1. If there is more than one HID interface on the device, the interface must have an interface
         name string containing "CMSIS-DAP".
     2. bInterfaceClass must be 0x03 (HID).
     3. bInterfaceSubClass must be 0.
     4. Must have interrupt in endpoint, with an optional interrupt out endpoint, in that order.
     """
-    
+
     def __init__(self, hid_interface_count):
         """! @brief Constructor."""
         self._hid_count = hid_interface_count
-        
+
     def __call__(self, interface):
         """! @brief Return True if this is a CMSIS-DAPv1 interface."""
         try:
             if self._hid_count > 1:
                 interface_name = usb.util.get_string(interface.device, interface.iInterface)
-        
+
                 # This tells us whether the interface is CMSIS-DAP, but not whether it's v1 or v2.
                 if (interface_name is None) or ("CMSIS-DAP" not in interface_name):
                     return False
@@ -291,7 +291,7 @@ class MatchCmsisDapv1Interface(object):
             ]
             if endpoint_attrs not in ENDPOINT_ATTRS_ALLOWED:
                 return False
-        
+
             # All checks passed, this is a CMSIS-DAPv2 interface!
             return True
 
@@ -315,20 +315,20 @@ class FindDap(object):
         # Check if the device class is a valid one for CMSIS-DAP.
         if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False
-        
+
         try:
             # First attempt to get the active config. This produces a more direct error
             # when you don't have device permissions on Linux
             config = dev.get_active_configuration()
-            
+
             # Now read the product name string.
             device_string = dev.product
             if (device_string is None) or ("CMSIS-DAP" not in device_string):
                 return False
-            
+
             # Get count of HID interfaces.
             hid_interface_count = len(list(usb.util.find_descriptor(config, find_all=True, bInterfaceClass=USB_CLASS_HID)))
-            
+
             # Find the CMSIS-DAPv1 interface.
             matcher = MatchCmsisDapv1Interface(hid_interface_count)
             cmsis_dap_interface = usb.util.find_descriptor(config, custom_match=matcher)

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -70,7 +70,7 @@ class PyUSBv2(Interface):
         self.read_sem = threading.Semaphore(0)
         self.packet_size = 512
         self.is_swo_running = False
-    
+
     @property
     def has_swo_ep(self):
         return self.ep_swo is not None
@@ -135,7 +135,7 @@ class PyUSBv2(Interface):
         self.thread = threading.Thread(target=self.rx_task, name=thread_name)
         self.thread.daemon = True
         self.thread.start()
-    
+
     def start_swo(self):
         self.swo_stop_event = threading.Event()
         thread_name = "SWO receive (%s)" % self.serial_number
@@ -143,7 +143,7 @@ class PyUSBv2(Interface):
         self.swo_thread.daemon = True
         self.swo_thread.start()
         self.is_swo_running = True
-    
+
     def stop_swo(self):
         self.swo_stop_event.set()
         self.swo_thread.join()
@@ -224,7 +224,7 @@ class PyUSBv2(Interface):
             if self.swo_data[0] is None:
                 raise DAPAccessIntf.DeviceError("Device %s SWO thread exited unexpectedly" % self.serial_number)
             data += self.swo_data.pop(0)
-        
+
         return data
 
     def close(self):
@@ -251,11 +251,11 @@ class PyUSBv2(Interface):
 
 def _match_cmsis_dap_v2_interface(interface):
     """! @brief Returns true for a CMSIS-DAP v2 interface.
-    
+
     This match function performs several tests on the provided USB interface descriptor, to
     determine whether it is a CMSIS-DAPv2 interface. These requirements must be met by the
     interface:
-    
+
     1. Have an interface name string containing "CMSIS-DAP".
     2. bInterfaceClass must be 0xff.
     3. bInterfaceSubClass must be 0.
@@ -264,7 +264,7 @@ def _match_cmsis_dap_v2_interface(interface):
     """
     try:
         interface_name = usb.util.get_string(interface.device, interface.iInterface)
-        
+
         # This tells us whether the interface is CMSIS-DAP, but not whether it's v1 or v2.
         if (interface_name is None) or ("CMSIS-DAP" not in interface_name):
             return False
@@ -277,20 +277,20 @@ def _match_cmsis_dap_v2_interface(interface):
         # Must have either 2 or 3 endpoints.
         if interface.bNumEndpoints not in (2, 3):
             return False
-        
+
         # Endpoint 0 must be bulk out.
         if not check_ep(interface, 0, usb.util.ENDPOINT_OUT, usb.util.ENDPOINT_TYPE_BULK):
             return False
-        
+
         # Endpoint 1 must be bulk in.
         if not check_ep(interface, 1, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
             return False
-        
+
         # Endpoint 2 is optional. If present it must be bulk in.
         if (interface.bNumEndpoints == 3) \
             and not check_ep(interface, 2, usb.util.ENDPOINT_IN, usb.util.ENDPOINT_TYPE_BULK):
             return False
-        
+
         # All checks passed, this is a CMSIS-DAPv2 interface!
         return True
 
@@ -314,7 +314,7 @@ class HasCmsisDapv2Interface(object):
         # Check if the device class is a valid one for CMSIS-DAP.
         if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False
-        
+
         try:
             config = dev.get_active_configuration()
             cmsis_dap_interface = usb.util.find_descriptor(config, custom_match=_match_cmsis_dap_v2_interface)

--- a/pyocd/probe/shared_probe_proxy.py
+++ b/pyocd/probe/shared_probe_proxy.py
@@ -24,12 +24,12 @@ LOG = logging.getLogger(__name__)
 
 class SharedDebugProbeProxy(object):
     """! @brief Proxy for a DebugProbe that allows it to be shared by multiple clients.
-    
+
     The main purpose of this class is to keep track of the number of times the probe has been
     opened and connected, and to perform checks to ensure that probes don't interfere with each
     other. Most probe APIs are simply passed to the underlying probe object.
     """
-    
+
     def __init__(self, probe):
         self._session = None
         self._probe = probe
@@ -40,21 +40,21 @@ class SharedDebugProbeProxy(object):
     def session(self):
         """! @brief Session associated with this probe."""
         return self._session
-    
+
     @session.setter
     def session(self, the_session):
         self._session = the_session
         self._probe.session = the_session
-    
+
     @property
     def probe(self):
         return self._probe
-    
+
     def open(self):
         if self._open_count == 0:
             self._probe.open()
         self._open_count += 1
-    
+
     def close(self):
         if self._open_count == 1:
             self._probe.close()
@@ -75,7 +75,7 @@ class SharedDebugProbeProxy(object):
 
     def swj_sequence(self, length, bits):
         self._probe.swj_sequence(length, bits)
-    
+
     def __getattr__(self, name):
         """! @brief Redirect to underlying probe object methods."""
         if hasattr(self._probe, name):

--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -15,11 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class Commands:    
+class Commands:
     """!
     @brief STLink V2 and V3 commands.
     """
-    
+
     # Common commands.
     GET_VERSION = 0xf1
     JTAG_COMMAND = 0xf2
@@ -71,7 +71,7 @@ class Commands:
     SET_COM_FREQ = 0x61 # V3 only, replaces SWD/JTAG_SET_FREQ
     GET_COM_FREQ = 0x62 # V3 only
     SWITCH_STLINK_FREQ = 0x63 # V3 only
-    
+
     # Parameters for JTAG_ENTER2.
     JTAG_ENTER_SWD = 0xa3
     JTAG_ENTER_JTAG_NO_CORE_RESET = 0xa3
@@ -80,15 +80,15 @@ class Commands:
     JTAG_DRIVE_NRST_LOW = 0x00
     JTAG_DRIVE_NRST_HIGH = 0x01
     JTAG_DRIVE_NRST_PULSE = 0x02
-    
+
     # Parameters for JTAG_INIT_AP and JTAG_CLOSE_AP_DBG.
     JTAG_AP_NO_CORE = 0x00
     JTAG_AP_CORTEXM_CORE = 0x01
-    
+
     # Parameters for SET_COM_FREQ and GET_COM_FREQ.
     JTAG_STLINK_SWD_COM = 0x00
     JTAG_STLINK_JTAG_COM = 0x01
-    
+
 class Status:
     """!
     @brief STLink status codes and messages.
@@ -123,7 +123,7 @@ class Status:
     SWV_NOT_AVAILABLE = 0x20
     JTAG_FREQ_NOT_SUPPORTED = 0x41
     JTAG_UNKNOWN_CMD = 0x42
-    
+
     ## Map from status code to error message.
     MESSAGES = {
         JTAG_UNKNOWN_ERROR : "Unknown error",
@@ -155,7 +155,7 @@ class Status:
         JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
         JTAG_UNKNOWN_CMD : "Unknown command",
     }
-    
+
     @staticmethod
     def get_error_message(status):
         return "STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error"))

--- a/pyocd/probe/swj.py
+++ b/pyocd/probe/swj.py
@@ -23,10 +23,10 @@ LOG = logging.getLogger(__name__)
 
 class SWJSequenceSender(object):
     """! @brief Class to send canned SWJ sequences.
-    
+
     The primary usage of this class is for sending the SWJ sequences to switch between JTAG and SWD protocols
     in the Arm ADI SWJ-DP. The select_protocol() method is used for this purpose.
-    
+
     In addition, there are methods available to send fragments of the various selection sequences. These can be
     used to put a target is whatever state is required.
     """
@@ -34,25 +34,25 @@ class SWJSequenceSender(object):
     def __init__(self, probe, use_dormant):
         self._probe = probe
         self._use_dormant = use_dormant
-    
+
     @property
     def use_dormant(self):
         return self._use_dormant
-    
+
     @use_dormant.setter
     def use_dormant(self, flag):
         self._use_dormant = flag
 
     def select_protocol(self, protocol):
         """! @brief Send SWJ sequence to select chosen wire protocol.
-        
+
         The `use_dormant` property determines whether dormant mode will be used for the protocol selection, or
         if the deprecated ADIv5.0 SWJ sequences will be used.
-        
+
         @param self This object.
         @param protocol One of the @ref pyocd.probe.debug_probe.DebugProbe.Protocol DebugProbe.Protocol enums, except
             that `DEFAULT` is not acceptable and will cause a ValueError exception to be raised.
-        
+
         @exception ValueError Request to select the `DEFAULT` protocol.
         """
         # Not all probes support sending SWJ sequences.
@@ -65,129 +65,129 @@ class SWJSequenceSender(object):
             raise ValueError("cannot send SWJ sequence for default protocol")
         else:
             assert False, "unhandled protocol %s in SWJSequenceSender" % protocol
-    
+
     def jtag_enter_test_logic_reset(self):
         """! @brief Execute at least >5 TCK cycles with TMS high to enter the Test-Logic-Reset state.
-        
+
         The line_reset() method can be used instead of this method, but takes a little longer to send.
         """
         self._probe.swj_sequence(8, 0xff)
-    
+
     def line_reset(self):
         """! @brief Execute a line reset for both SWD and JTAG.
-        
+
         For JTAG, >=5 TCK cycles with TMS high enters the Test-Logic-Reset state.<br/>
         For SWD, >=50 cycles with SWDIO high performs a line reset.
         """
         self._probe.swj_sequence(51, 0xffffffffffffff)
-    
+
     def selection_alert(self):
         """! @brief Send the dormant selection alert sequence.
-        
+
         The 128-bit selection alert is prefixed with 8 cycles of SWDIOTMS high.
         """
         self._probe.swj_sequence(136, 0x19bc0ea2e3ddafe986852d956209f392ff)
-    
+
     def jtag_activation_code(self):
         """! @brief 4-bit SWDIOTMS cycles low + 8-bit JTAG activation code."""
         self._probe.swj_sequence(12, 0x00a0)
-    
+
     def swd_activation_code(self):
         """! @brief 4-bit SWDIOTMS cycles low + 8-bit SWD activation code."""
         self._probe.swj_sequence(12, 0x01a0)
-    
+
     def idle_cycles(self, cycles):
         """! @brief Send SWD idle cycles with SWDIOTMS low."""
         self._probe.swj_sequence(cycles, 0)
-    
+
     def jtag_to_dormant(self):
         """! @brief Send the JTAG to DS select sequence.
-        
+
         Sends the recommended 31-bit JTAG-to-DS select sequence of 0x33bbbbba (LSB-first) on SWDIOTMS. See ADIv6
         section B5.3.2.
-        
+
         @note This should be prefixed with at least 5 cycles to put the JTAG TAP in Test-Logic-Reset; see
         jtag_enter_test_logic_reset().
         """
         self._probe.swj_sequence(39, 0x33bbbbba)
-    
+
     def swd_to_dormant(self):
         """! @brief Send the SWD to DS sequence.
-        
+
         Sends the 16-bit SWD-to-DS select sequence of 0xe3bc (LSB-first) on SWDIOTMS. See ADIv6 section B5.3.3.
-        
+
         @note An SWD line reset should prefix this sequence. See line_reset().
         """
         self._probe.swj_sequence(16, 0xe3bc)
-    
+
     def dormant_to_swd(self):
         """! @brief Perform the dormant mode to SWD transition sequence."""
-        
+
         # 8 SWDIOTMS cycles high + 128-bit selection alert sequence.
         self.selection_alert()
-        
+
         # 4-bit SWDIOTMS cycles low + 8-bit SWD activation code.
         self.swd_activation_code()
-        
+
         # SWD line reset (>50 SWDIOTMS cycles high).
         self.line_reset()
-        
+
         # >=2 SWDIOTMS cycles low.
         self.idle_cycles(2)
-    
+
     def dormant_to_jtag(self):
         """! @brief Perform the dormant mode to JTAG transition sequence."""
-        
+
         # 8 SWDIOTMS cycles high + 128-bit selection alert sequence.
         self.selection_alert()
-        
+
         self.jtag_activation_code()
-        
+
         self.jtag_enter_test_logic_reset()
 
     def switch_to_swd(self):
         """! @brief Send SWJ sequence to select SWD."""
-        
+
         # Ensure current debug interface is in reset state. A full line reset is used here instead
         # of the shorter JTAG TLR to support the case where the device is already in SWD mode.
         self.line_reset()
-        
+
         if self._use_dormant:
             LOG.debug("Sending SWJ sequence to select SWD; using dormant state")
-            
+
             # Switch from JTAG to dormant, then dormant to SWD.
             self.jtag_to_dormant()
             self.dormant_to_swd()
         else:
             LOG.debug("Sending deprecated SWJ sequence to select SWD")
-            
+
             # Execute SWJ-DP Switch Sequence JTAG to SWD (0xE79E)
             # Change if SWJ-DP uses deprecated switch code (0xEDB6)
             self._probe.swj_sequence(16, 0xe79e)
-            
+
             # Enter SWD Line Reset State
             self.line_reset()                   # > 50 cycles SWDIO/TMS High
             self._probe.swj_sequence(8,  0x00)  # At least 2 idle cycles (SWDIO/TMS Low)
-    
+
     def switch_to_jtag(self):
         """! @brief Send SWJ sequence to select JTAG."""
-        
+
         # Ensure current debug interface is in reset state, for either SWD or JTAG.
         self.line_reset()
-        
+
         if self._use_dormant:
             LOG.debug("Sending SWJ sequence to select JTAG ; using dormant state")
-            
+
             # Switch from SWD to dormant, then dormant to JTAG.
             self.swd_to_dormant()
             self.dormant_to_jtag()
         else:
             LOG.debug("Sending deprecated SWJ sequence to select JTAG")
-            
+
             # Execute SWJ-DP Switch Sequence SWD to JTAG (0xE73C)
             # Change if SWJ-DP uses deprecated switch code (0xAEAE)
             self._probe.swj_sequence(16, 0xe73c)
-            
+
             # Ensure JTAG interface is reset
             self.jtag_enter_test_logic_reset()
-    
+

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -32,9 +32,9 @@ TRACE.setLevel(logging.CRITICAL)
 
 class TCPClientProbe(DebugProbe):
     """! @brief Probe class that connects to a debug probe server."""
-    
+
     DEFAULT_PORT = 5555
-    
+
     PROTOCOL_VERSION = 1
 
     class StatusCode:
@@ -45,7 +45,7 @@ class TCPClientProbe(DebugProbe):
         TRANSFER_ERROR = 10
         TRANSFER_TIMEOUT = 11
         TRANSFER_FAULT = 12
-    
+
     ## Map from status code to exception class.
     STATUS_CODE_CLASS_MAP = {
         StatusCode.GENERAL_ERROR: exceptions.Error,
@@ -55,7 +55,7 @@ class TCPClientProbe(DebugProbe):
         StatusCode.TRANSFER_TIMEOUT: exceptions.TransferTimeoutError,
         StatusCode.TRANSFER_FAULT: exceptions.TransferFaultError,
         }
-    
+
     @classmethod
     def _extract_address(cls, unique_id):
         parts = unique_id.split(':', 1)
@@ -64,14 +64,14 @@ class TCPClientProbe(DebugProbe):
         else:
             port = int(parts[1])
         return parts[0], port
-    
+
     @classmethod
     def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
         if is_explicit and unique_id is not None:
             return [cls(unique_id)]
         else:
             return []
-    
+
     @classmethod
     def get_probe_with_id(cls, unique_id, is_explicit=False):
         return cls(unique_id) if is_explicit else None
@@ -86,15 +86,15 @@ class TCPClientProbe(DebugProbe):
         self._request_id = 0
         self._lock_count = 0
         self._lock_count_lock = threading.RLock()
-    
+
     @property
     def vendor_name(self):
         return self._read_property('vendor_name', "vendor")
-    
+
     @property
     def product_name(self):
         return self._read_property('product_name', "product")
-    
+
     @property
     def supported_wire_protocols(self):
         return self._read_property('supported_wire_protocols')
@@ -106,27 +106,27 @@ class TCPClientProbe(DebugProbe):
     @property
     def wire_protocol(self):
         return self._read_property('wire_protocol')
-    
+
     @property
     def is_open(self):
         return self._is_open
-    
+
     @property
     def capabilities(self):
         return self._read_property('capabilities')
-    
+
     @property
     def request_id(self):
         """! @brief Generate a new request ID."""
         rid = self._request_id
         self._request_id += 1
         return rid
-    
+
     def _perform_request(self, request, *args):
         """! Execute a request-reply transaction with the server.
 
         Request:
-        
+
         ````
         {
           "id": <int>,
@@ -136,7 +136,7 @@ class TCPClientProbe(DebugProbe):
         ````
 
         Response:
-        
+
         ````
         {
           "id": <int>,
@@ -156,19 +156,19 @@ class TCPClientProbe(DebugProbe):
                 rq["arguments"] = args
             formatted_request = json.dumps(rq)
             TRACE.debug("Request: %s", formatted_request)
-        
+
             # Send request to server.
             self._socket.write(formatted_request.encode('utf-8') + b"\n")
-        
+
             # Read response.
             response_data = self._socket.readline().decode('utf-8').strip()
             decoded_response = json.loads(response_data)
             TRACE.debug("decoded_response = %s", decoded_response)
-        
+
             # Check for required keys.
             if ('id' not in decoded_response) or ('status' not in decoded_response):
                 raise exceptions.ProbeError("malformed response from server; missing required field")
-        
+
             # Check response status.
             status = decoded_response['status']
             if status != 0:
@@ -176,18 +176,18 @@ class TCPClientProbe(DebugProbe):
                 error = decoded_response.get('error', "(missing error message key)")
                 LOG.debug("error received from server for command %s (status code %i): %s",
                         request, status, error)
-            
+
                 # Create an appropriate local exception based on the status code.
                 exc = self._create_exception_from_status_code(status,
                         "error received from server for command %s (status code %i): %s"
                         % (request, status, error))
                 raise exc
-        
+
             # Get response value. If not present then there was no return value from the command
             result = decoded_response.get('result', None)
-        
+
             return result
-    
+
     def _create_exception_from_status_code(self, status, message):
         """! @brief Convert a status code into an exception instance."""
         # Other status codes can use the map.
@@ -212,25 +212,25 @@ class TCPClientProbe(DebugProbe):
             self._socket.connect()
             self._is_open = True
             self._socket.set_timeout(0.1)
-        
+
         # Send hello message.
         self._perform_request('hello', self.PROTOCOL_VERSION)
-        
+
         self._perform_request('open')
-    
+
     def close(self):
         if self._is_open:
             self._perform_request('close')
             self._socket.close()
             self._is_open = False
-    
+
     def lock(self):
         # The lock count is then used to only send the remote lock request once.
         with self._lock_count_lock:
             if self._lock_count == 0:
                 self._perform_request('lock')
             self._lock_count += 1
-    
+
     def unlock(self):
         # The remote unlock request is only sent when the outermost nested locking is unlocked.
         with self._lock_count_lock:
@@ -265,7 +265,7 @@ class TCPClientProbe(DebugProbe):
 
     def assert_reset(self, asserted):
         self._perform_request('assert_reset', asserted)
-    
+
     def is_reset_asserted(self):
         return self._perform_request('is_reset_asserted')
 
@@ -279,11 +279,11 @@ class TCPClientProbe(DebugProbe):
 
     def read_dp(self, addr, now=True):
         result = self._perform_request('read_dp', addr)
-        
+
         def read_dp_cb():
             # TODO need to raise any exception from here
             return result
-        
+
         return result if now else read_dp_cb
 
     def write_dp(self, addr, data):
@@ -291,11 +291,11 @@ class TCPClientProbe(DebugProbe):
 
     def read_ap(self, addr, now=True):
         result = self._perform_request('read_ap', addr)
-        
+
         def read_ap_cb():
             # TODO need to raise any exception from here
             return result
-        
+
         return result if now else read_ap_cb
 
     def write_ap(self, addr, data):
@@ -303,23 +303,23 @@ class TCPClientProbe(DebugProbe):
 
     def read_ap_multiple(self, addr, count=1, now=True):
         results = self._perform_request('read_ap_multiple', addr, count)
-        
+
         def read_ap_multiple_cb():
             # TODO need to raise any exception from here
             return results
-        
+
         return results if now else read_ap_multiple_cb
 
     def write_ap_multiple(self, addr, values):
         self._perform_request('write_ap_multiple', addr, values)
-    
+
     def get_memory_interface_for_ap(self, ap_address):
         handle = self._perform_request('get_memory_interface_for_ap',
                 ap_address.ap_version.value, ap_address.nominal_address)
         if handle is None:
             return None
         return RemoteMemoryInterface(self, handle)
-    
+
     ##@}
 
     ## @name SWO
@@ -338,10 +338,10 @@ class TCPClientProbe(DebugProbe):
         return self._perform_request('swo_read')
 
     ##@}
-    
+
 class RemoteMemoryInterface(MemoryInterface):
     """! @brief Local proxy for a remote memory interface."""
-    
+
     def __init__(self, remote_probe, handle):
         self._remote_probe = remote_probe
         self._handle = handle
@@ -349,11 +349,11 @@ class RemoteMemoryInterface(MemoryInterface):
     def write_memory(self, addr, data, transfer_size=32):
         assert transfer_size in (8, 16, 32)
         self._remote_probe._perform_request('write_mem', self._handle, addr, data, transfer_size)
-        
+
     def read_memory(self, addr, transfer_size=32, now=True):
         assert transfer_size in (8, 16, 32)
         result = self._remote_probe._perform_request('read_mem', self._handle, addr, transfer_size)
-        
+
         def read_callback():
             return result
         return result if now else read_callback
@@ -372,14 +372,14 @@ class RemoteMemoryInterface(MemoryInterface):
 
 class TCPClientProbePlugin(Plugin):
     """! @brief Plugin class for TCPClientProbePlugin."""
-    
+
     def load(self):
         return TCPClientProbe
-    
+
     @property
     def name(self):
         return "remote"
-    
+
     @property
     def description(self):
         return "Client for the pyOCD debug probe server"

--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -69,7 +69,7 @@ class TargetList(object):
 
 class ArgonThreadContext(DebugContext):
     """! @brief Thread context for Argon."""
-    
+
     # SP is handled specially, so it is not in these dicts.
 
     CORE_REGISTER_OFFSETS = {
@@ -190,7 +190,7 @@ class ArgonThreadContext(DebugContext):
                 # vector catch, so retrieve LR stored by OS on last
                 # thread switch.
                 hasExtendedFrame = self._thread.has_extended_frame
-            
+
             if hasExtendedFrame:
                 table = self.FPU_EXTENDED_REGISTER_OFFSETS
                 hwStacked = 0x68
@@ -449,30 +449,30 @@ class ArgonTraceEvent(events.TraceEvent):
     kArTraceThreadSwitch = 1 # 2 value: 0=previous thread's new state, 1=new thread id
     kArTraceThreadCreated = 2 # 1 value
     kArTraceThreadDeleted = 3 # 1 value
-    
+
     def __init__(self, eventID, threadID, name, state, ts=0):
         super(ArgonTraceEvent, self).__init__("argon", ts)
         self._event_id = eventID
         self._thread_id = threadID
         self._thread_name = name
         self._prev_thread_state = state
-    
+
     @property
     def event_id(self):
         return self._event_id
-    
+
     @property
     def thread_id(self):
         return self._thread_id
-    
+
     @property
     def thread_name(self):
         return self._thread_name
-    
+
     @property
     def prev_thread_state(self):
         return self._prev_thread_state
-    
+
     def __str__(self):
         if self.event_id == ArgonTraceEvent.kArTraceThreadSwitch:
             stateName = ArgonThread.STATE_NAMES.get(self.prev_thread_state, "<invalid state>")
@@ -487,7 +487,7 @@ class ArgonTraceEvent(events.TraceEvent):
 
 class ArgonTraceEventFilter(TraceEventFilter):
     """! @brief Trace event filter to identify Argon kernel trace events sent via ITM.
-    
+
     As Argon kernel trace events are identified, the ITM trace events are replaced with instances
     of ArgonTraceEvent.
     """
@@ -496,7 +496,7 @@ class ArgonTraceEventFilter(TraceEventFilter):
         self._threads = threads
         self._is_thread_event_pending = False
         self._pending_event = None
-        
+
     def filter(self, event):
         if isinstance(event, events.TraceITMEvent):
             if event.port == 31:
@@ -511,25 +511,25 @@ class ArgonTraceEventFilter(TraceEventFilter):
                 threadID = event.data
                 name = self._threads.get(threadID, "<unknown thread>")
                 state = self._pending_event.data & 0x00ffffff
-                
+
                 # Create the Argon event.
                 event = ArgonTraceEvent(eventID, threadID, name, state, self._pending_event.timestamp)
 
                 self._is_thread_event_pending = False
                 self._pending_event = None
 
-        return event        
+        return event
 
 class ArgonPlugin(Plugin):
     """! @brief Plugin class for the Argon RTOS."""
-    
+
     def load(self):
         return ArgonThreadProvider
-    
+
     @property
     def name(self):
         return "argon"
-    
+
     @property
     def description(self):
         return "Argon RTOS"

--- a/pyocd/rtos/common.py
+++ b/pyocd/rtos/common.py
@@ -65,7 +65,7 @@ class HandlerModeThread(TargetThread):
     """! @brief Class representing the handler mode."""
 
     UNIQUE_ID = 2
-    
+
     def __init__(self, targetContext, provider):
         super(HandlerModeThread, self).__init__()
         self._target_context = targetContext

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -67,7 +67,7 @@ class TargetList(object):
 
 class FreeRTOSThreadContext(DebugContext):
     """! @brief Thread context for FreeRTOS."""
-    
+
     # SP/PSP are handled specially, so it is not in these dicts.
 
     COMMON_REGISTER_OFFSETS = {
@@ -535,14 +535,14 @@ class FreeRTOSThreadProvider(ThreadProvider):
 
 class FreeRTOSPlugin(Plugin):
     """! @brief Plugin class for FreeRTOS."""
-    
+
     def load(self):
         return FreeRTOSThreadProvider
-    
+
     @property
     def name(self):
         return "freertos"
-    
+
     @property
     def description(self):
         return "FreeRTOS"

--- a/pyocd/rtos/rtx5.py
+++ b/pyocd/rtos/rtx5.py
@@ -48,7 +48,7 @@ class TargetList(object):
 
 class RTXThreadContext(DebugContext):
     """! @brief Thread context for RTX5."""
-    
+
     # SP/PSP are handled specially, so it is not in these dicts.
 
     # Offsets are relative to stored SP in a task switch block, for the
@@ -234,7 +234,7 @@ class RTXTargetThread(TargetThread):
          0x83: "Waiting[MsgGet]",
          0x93: "Waiting[MsgPut]",
     }
-    
+
     def __init__(self, targetContext, provider, base):
         super(RTXTargetThread, self).__init__()
         self._target_context = targetContext
@@ -247,13 +247,13 @@ class RTXTargetThread(TargetThread):
         try:
             name_ptr = self._target_context.read32(self._base + RTXTargetThread.NAME_OFFSET)
             self._name = read_c_string(self._target_context, name_ptr)
-            
+
             self.update_state()
         except exceptions.TransferError as exc:
             LOG.debug("Transfer error while reading thread %x name: %s", self._base, exc)
             self._name = "?"
         LOG.debug('RTXTargetThread 0x%x' % base)
-    
+
     def update_state(self):
         try:
             state = self._target_context.read8(self._base + RTXTargetThread.STATE_OFFSET)
@@ -353,7 +353,7 @@ class RTX5ThreadProvider(ThreadProvider):
 
     def _build_thread_list(self):
         newThreads = {}
-        
+
         def create_or_update(thread):
             # Check for and reuse existing thread.
             if thread in self._threads:
@@ -390,7 +390,7 @@ class RTX5ThreadProvider(ThreadProvider):
         # Create fake handler mode thread.
         if self._target_context.read_core_register('ipsr') > 0:
             newThreads[HandlerModeThread.UNIQUE_ID] = HandlerModeThread(self._target_context, self)
-        
+
         self._threads = newThreads
 
     def get_thread(self, threadId):
@@ -448,14 +448,14 @@ class RTX5ThreadProvider(ThreadProvider):
 
 class RTX5Plugin(Plugin):
     """! @brief Plugin class for the RTX5 RTOS."""
-    
+
     def load(self):
         return RTX5ThreadProvider
-    
+
     @property
     def name(self):
         return "rtx5"
-    
+
     @property
     def description(self):
         return "RTX5"

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -47,7 +47,7 @@ class TargetList(object):
 
 class ZephyrThreadContext(DebugContext):
     """! @brief Thread context for Zephyr."""
-    
+
     STACK_FRAME_OFFSETS = {
                  0: 0, # r0
                  1: 4, # r1
@@ -417,14 +417,14 @@ class ZephyrThreadProvider(ThreadProvider):
 
 class ZephyrPlugin(Plugin):
     """! @brief Plugin class for the Zephyr RTOS."""
-    
+
     def load(self):
         return ZephyrThreadProvider
-    
+
     @property
     def name(self):
         return "zephyr"
-    
+
     @property
     def description(self):
         return "Zephyr"

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -36,7 +36,7 @@ class SubcommandBase:
 
     class CommonOptions:
         """! @brief Namespace with parsers for repeated option groups."""
-        
+
         # Define logging related options.
         LOGGING = argparse.ArgumentParser(description='logging', add_help=False)
         LOGGING_GROUP = LOGGING.add_argument_group("logging")
@@ -48,7 +48,7 @@ class SubcommandBase:
             help="Set log level of loggers whose name matches any of the comma-separated list of glob-style "
             "patterns. Log level must be one of (critical, error, warning, info, debug). Can be "
             "specified multiple times. Example: -L*.trace,pyocd.core.*=debug")
-    
+
         # Define config related options for all subcommands.
         CONFIG = argparse.ArgumentParser(description='common', add_help=False)
         CONFIG_GROUP = CONFIG.add_argument_group("configuration")
@@ -66,11 +66,11 @@ class SubcommandBase:
             help="(Deprecated) Send setting to DAPAccess layer.")
         CONFIG_GROUP.add_argument("--pack", metavar="PATH", action="append",
             help="Path to the .pack file for a CMSIS Device Family Pack.")
-    
+
         # Define common options for all subcommands, including logging options.
         COMMON = argparse.ArgumentParser(description='common',
             parents=[LOGGING, CONFIG], add_help=False)
-    
+
         # Common connection related options.
         CONNECT = argparse.ArgumentParser(description='common', add_help=False)
         CONNECT_GROUP = CONNECT.add_argument_group("connection")
@@ -89,7 +89,7 @@ class SubcommandBase:
             help="Do not wait for a probe to be connected if none are available.")
         CONNECT_GROUP.add_argument("-M", "--connect", dest="connect_mode", metavar="MODE",
             help="Select connect mode from one of (halt, pre-reset, under-reset, attach).")
-    
+
     @classmethod
     def add_subcommands(cls, parser: argparse.ArgumentParser) -> None:
         """! @brief Add declared subcommands to the given parser."""
@@ -98,7 +98,7 @@ class SubcommandBase:
             for subcmd_class in cls.SUBCOMMANDS:
                 parsers = subcmd_class.get_args()
                 subcmd_class.parser = parsers[-1]
-                
+
                 subparser = subparsers.add_parser(
                                 subcmd_class.NAMES[0],
                                 aliases=subcmd_class.NAMES[1:],
@@ -120,15 +120,15 @@ class SubcommandBase:
     def customize_subparser(cls, subparser: argparse.ArgumentParser) -> None:
         """! @brief Optionally modify a subparser after it is created."""
         pass
-    
+
     def __init__(self, args: argparse.Namespace):
         """! @brief Constructor.
-        
+
         @param self This object.
         @param args Namespace of parsed argument values.
         """
         self._args = args
-    
+
     def invoke(self) -> int:
         """! @brief Run the subcommand.
         @return Process status code for the command.
@@ -166,5 +166,5 @@ class SubcommandBase:
         pt.hrules = prettytable.HEADER
         pt.vrules = prettytable.NONE
         return pt
-    
+
 

--- a/pyocd/subcommands/commander_cmd.py
+++ b/pyocd/subcommands/commander_cmd.py
@@ -27,7 +27,7 @@ from ..utility.cmdline import (
 
 class CommanderSubcommand(SubcommandBase):
     """! @brief `pyocd commander` subcommand."""
-    
+
     NAMES = ['commander', 'cmd']
     HELP = "Interactive command console."
     DEFAULT_LOG_LEVEL = logging.WARNING
@@ -46,9 +46,9 @@ class CommanderSubcommand(SubcommandBase):
             help="Optionally specify ELF file being debugged.")
         commander_options.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
             help="Run commands.")
-        
+
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, commander_parser]
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'commander' subcommand."""
         # Flatten commands list then extract primary command and its arguments.

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 class EraseSubcommand(SubcommandBase):
     """! @brief `pyocd erase` subcommand."""
-    
+
     NAMES = ['erase']
     HELP = "Erase entire device flash or specified sectors."
     EPILOG = ("If no position arguments are listed, then no action will be taken unless the --chip or "
@@ -43,7 +43,7 @@ class EraseSubcommand(SubcommandBase):
             "0x800-0x2000 (erase sectors starting at 0x800 up to but not including 0x2000) "
             "0+8192 (erase 8 kB starting at address 0)")
     DEFAULT_LOG_LEVEL = logging.WARNING
-    
+
     @classmethod
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
@@ -59,13 +59,13 @@ class EraseSubcommand(SubcommandBase):
 
         erase_parser.add_argument("addresses", metavar="<sector-address>", action='append', nargs='*',
             help="List of sector addresses or ranges to erase.")
-        
+
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, erase_parser]
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'erase' subcommand."""
         self._increase_logging(["pyocd.flash.eraser"])
-        
+
         # Display a nice, helpful error describing why nothing was done and how to correct it.
         if (self._args.erase_mode is None) or not self._args.addresses:
             LOG.error("No erase operation specified. Please specify one of '--chip', '--sector', "
@@ -73,7 +73,7 @@ class EraseSubcommand(SubcommandBase):
                         "of sector addresses to erase must be provided. "
                         "See 'pyocd erase --help' for more.")
             return 1
-        
+
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
                             config_file=self._args.config,
@@ -92,7 +92,7 @@ class EraseSubcommand(SubcommandBase):
         with session:
             mode = self._args.erase_mode or FlashEraser.Mode.SECTOR
             eraser = FlashEraser(session, mode)
-            
+
             addresses = flatten_args(self._args.addresses)
             eraser.erase(addresses)
 

--- a/pyocd/subcommands/gdbserver_cmd.py
+++ b/pyocd/subcommands/gdbserver_cmd.py
@@ -38,10 +38,10 @@ LOG = logging.getLogger(__name__)
 
 class GdbserverSubcommand(SubcommandBase):
     """! @brief `pyocd gdbserver` subcommand."""
-    
+
     NAMES = ['gdbserver', 'gdb']
     HELP = "Run the gdb remote server(s)."
-    
+
     ## @brief Valid erase mode options.
     ERASE_OPTIONS = [
         'auto',
@@ -89,14 +89,14 @@ class GdbserverSubcommand(SubcommandBase):
             help="Allow single stepping to step into interrupts.")
         gdbserver_options.add_argument("-c", "--command", dest="commands", metavar="CMD", action='append', nargs='+',
             help="Run command (OpenOCD compatibility).")
-        
+
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, gdbserver_parser]
-    
+
     def __init__(self, args: argparse.Namespace):
         """! @brief Constructor."""
         super().__init__(args)
         self._echo_msg = None
-        
+
     def _process_commands(self, commands: Optional[List[str]]):
         """! @brief Handle OpenOCD commands for compatibility."""
         if commands is None:
@@ -127,7 +127,7 @@ class GdbserverSubcommand(SubcommandBase):
         if self._echo_msg is not None:
             print(self._echo_msg, file=sys.stderr)
             sys.stderr.flush()
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'gdbserver' subcommand."""
         self._process_commands(self._args.commands)
@@ -148,7 +148,7 @@ class GdbserverSubcommand(SubcommandBase):
                 'serve_local_only' : self._args.serve_local_only,
                 'vector_catch' : self._args.vector_catch,
                 })
-            
+
             # Split list of cores to serve.
             if self._args.core is not None:
                 try:
@@ -158,7 +158,7 @@ class GdbserverSubcommand(SubcommandBase):
                     return 1
             else:
                 core_list = None
-            
+
             # Get the probe.
             probe = ConnectHelper.choose_probe(
                         blocking=(not self._args.no_wait),
@@ -168,10 +168,10 @@ class GdbserverSubcommand(SubcommandBase):
             if probe is None:
                 LOG.error("No probe selected.")
                 return 1
-            
+
             # Create a proxy so the probe can be shared between the session and probe server.
             probe_proxy = SharedDebugProbeProxy(probe)
-            
+
             # Create the session.
             session = Session(probe_proxy,
                 project_dir=self._args.project_dir,
@@ -198,21 +198,21 @@ class GdbserverSubcommand(SubcommandBase):
                         "s" if len(bad_cores) > 1 else "",
                         ", ".join(str(x) for x in bad_cores))
                     return 1
-                
+
                 # Set ELF if provided.
                 if self._args.elf:
                     session.board.target.elf = os.path.expanduser(self._args.elf)
-                    
+
                 # Run the probe server is requested.
                 if self._args.enable_probe_server:
                     probe_server = DebugProbeServer(session, session.probe,
                             self._args.probe_server_port, self._args.serve_local_only)
                     session.probeserver = probe_server
                     probe_server.start()
-                    
+
                 # Start up the gdbservers.
                 for core_number, core in session.board.target.cores.items():
-                    # Don't create a server for CPU-less memory Access Port. 
+                    # Don't create a server for CPU-less memory Access Port.
                     if isinstance(session.board.target.cores[core_number], GenericMemAPTarget):
                         continue
                     # Don't create a server if this core is not listed by the user.

--- a/pyocd/subcommands/json_cmd.py
+++ b/pyocd/subcommands/json_cmd.py
@@ -30,7 +30,7 @@ LOG = logging.getLogger(__name__)
 
 class JsonSubcommand(SubcommandBase):
     """! @brief `pyocd json` subcommand."""
-    
+
     NAMES = ['json']
     HELP = "Output information as JSON."
     DEFAULT_LOG_LEVEL = logging.FATAL + 1
@@ -51,26 +51,26 @@ class JsonSubcommand(SubcommandBase):
             help="List available features and options.")
 
         return [cls.CommonOptions.CONFIG, json_parser]
-    
+
     @classmethod
     def customize_subparser(cls, subparser: argparse.ArgumentParser) -> None:
         """! @brief Optionally modify a subparser after it is created."""
         subparser.set_defaults(verbose=0, quiet=0)
-    
+
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
-        
+
         # Disable all logging.
         logging.disable(logging.CRITICAL)
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'json' subcommand."""
         all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.features)
-        
+
         # Default to listing probes.
         if not any(all_outputs):
             self._args.probes = True
-        
+
         # Check for more than one output option being selected.
         if sum(int(x) for x in all_outputs) > 1:
             # Because we're outputting JSON we can't just log the error, but must report the error
@@ -84,7 +84,7 @@ class JsonSubcommand(SubcommandBase):
 
             print(json.dumps(obj, indent=4))
             return 0
-        
+
         # Create a session with no device so we load any config.
         session = Session(None,
                             project_dir=self._args.project_dir,
@@ -93,7 +93,7 @@ class JsonSubcommand(SubcommandBase):
                             pack=self._args.pack,
                             **convert_session_options(self._args.options)
                             )
-        
+
         if self._args.targets or self._args.boards:
             # Create targets from provided CMSIS pack.
             if session.options['pack'] is not None:

--- a/pyocd/subcommands/list_cmd.py
+++ b/pyocd/subcommands/list_cmd.py
@@ -29,10 +29,10 @@ LOG = logging.getLogger(__name__)
 
 class ListSubcommand(SubcommandBase):
     """! @brief `pyocd list` subcommand."""
-    
+
     NAMES = ['list']
     HELP = "List information about probes, targets, or boards."
-    
+
     ## @brief Map to convert plugin groups to user friendly names.
     PLUGIN_GROUP_NAMES = {
         'pyocd.probe': "Debug Probe",
@@ -43,7 +43,7 @@ class ListSubcommand(SubcommandBase):
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
         list_parser = argparse.ArgumentParser(description=cls.HELP, add_help=False)
-        
+
         list_output = list_parser.add_argument_group("list output")
         list_output.add_argument('-p', '--probes', action='store_true',
             help="List available probes.")
@@ -53,7 +53,7 @@ class ListSubcommand(SubcommandBase):
             help="List all known boards.")
         list_output.add_argument('--plugins', action='store_true',
             help="List available plugins.")
-            
+
         list_options = list_parser.add_argument_group('list options')
         list_options.add_argument('-n', '--name',
             help="Restrict listing to items matching the given name substring. Applies to targets and boards.")
@@ -63,23 +63,23 @@ class ListSubcommand(SubcommandBase):
             help="Restrict listing to targets from the specified source. Applies to targets.")
         list_options.add_argument('-H', '--no-header', action='store_true',
             help="Don't print a table header.")
-        
+
         return [cls.CommonOptions.COMMON, list_parser]
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'list' subcommand."""
         all_outputs = (self._args.probes, self._args.targets, self._args.boards, self._args.plugins)
-        
+
         # Default to listing probes.
         if not any(all_outputs):
             self._args.probes = True
-        
+
         # Check for more than one output option being selected.
         if sum(int(x) for x in all_outputs) > 1:
             LOG.error("Only one of the output options '--probes', '--targets', '--boards', "
                       "or '--plugins' may be selected at a time.")
             return 1
-        
+
         # Create a session with no device so we load any config.
         session = Session(None,
                             project_dir=self._args.project_dir,
@@ -88,7 +88,7 @@ class ListSubcommand(SubcommandBase):
                             pack=self._args.pack,
                             **convert_session_options(self._args.options)
                             )
-        
+
         if self._args.probes:
             ConnectHelper.list_connected_probes()
         elif self._args.targets:

--- a/pyocd/subcommands/load_cmd.py
+++ b/pyocd/subcommands/load_cmd.py
@@ -31,12 +31,12 @@ LOG = logging.getLogger(__name__)
 
 class LoadSubcommand(SubcommandBase):
     """! @brief `pyocd load` and `flash` subcommand."""
-    
+
     NAMES = ['load', 'flash']
     HELP = "Load one or more images into target device memory."
     EPILOG = "Supported file formats are: binary, Intel hex, and ELF32."
     DEFAULT_LOG_LEVEL = logging.WARNING
-    
+
     ## @brief Valid erase mode options.
     ERASE_OPTIONS = [
         'auto',
@@ -66,18 +66,18 @@ class LoadSubcommand(SubcommandBase):
         parser.add_argument("file", metavar="<file-path>", nargs="+",
             help="File to write to memory. Binary files can have an optional base address appended to the file "
                  "name as '@<address>', for instance 'app.bin@0x20000'.")
-        
+
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, parser]
-    
+
     def invoke(self) -> int:
         """! @brief Handle 'load' subcommand."""
         self._increase_logging(["pyocd.flash.loader", __name__])
-        
+
         # Validate arguments.
         if (self._args.base_address is not None) and (len(self._args.file) > 1):
             raise ValueError("--base-address cannot be set when loading more than one file; "
                     "use a base address suffix instead")
-        
+
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
                             config_file=self._args.config,
@@ -104,11 +104,11 @@ class LoadSubcommand(SubcommandBase):
                     base_address = int_base_0(suffix)
                 else:
                     base_address = self._args.base_address
-                
+
                 # Resolve our path.
                 file_path = Path(filename).expanduser().resolve()
                 filename = str(file_path)
-                
+
                 if base_address is None:
                     LOG.info("Loading %s", filename)
                 else:

--- a/pyocd/subcommands/reset_cmd.py
+++ b/pyocd/subcommands/reset_cmd.py
@@ -32,11 +32,11 @@ LOG = logging.getLogger(__name__)
 
 class ResetSubcommand(SubcommandBase):
     """! @brief `pyocd reset` subcommand."""
-    
+
     NAMES = ['reset']
     HELP = "Reset a target device."
     DEFAULT_LOG_LEVEL = logging.WARNING
-    
+
     @classmethod
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
@@ -51,9 +51,9 @@ class ResetSubcommand(SubcommandBase):
                  "Default is core 0.")
         reset_options.add_argument("-l", "--halt", action="store_true",
             help="Halt the core on the first instruction after reset. Defaults to disabled.")
-        
+
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, reset_parser]
-    
+
     def invoke(self) -> None:
         """! @brief Handle 'reset' subcommand."""
         # Verify selected reset type.
@@ -62,7 +62,7 @@ class ResetSubcommand(SubcommandBase):
         except ValueError:
             LOG.error("Invalid reset method: %s", self._args.reset_type)
             return
-        
+
         session = ConnectHelper.session_with_chosen_probe(
                             project_dir=self._args.project_dir,
                             config_file=self._args.config,
@@ -82,10 +82,10 @@ class ResetSubcommand(SubcommandBase):
             # Handle hw reset specially using the probe, so we don't need a valid connection
             # and can skip discovery. If we're halting we need a connection even if performing a hardware reset.
             is_hw_reset = (the_reset_type == Target.ResetType.HW) and not self._args.halt
-            
+
             # Only init the board if performing a sw reset.
             session.open(init_board=(not is_hw_reset))
-            
+
             LOG.info("Performing '%s' reset...", self._args.reset_type)
             if is_hw_reset:
                 session.probe.reset()

--- a/pyocd/subcommands/server_cmd.py
+++ b/pyocd/subcommands/server_cmd.py
@@ -29,10 +29,10 @@ LOG = logging.getLogger(__name__)
 
 class ServerSubcommand(SubcommandBase):
     """! @brief `pyocd server` subcommand."""
-    
+
     NAMES = ['server']
     HELP = "Run debug probe server."
-    
+
     @classmethod
     def get_args(cls) -> List[argparse.ArgumentParser]:
         """! @brief Add this subcommand to the subparsers object."""
@@ -63,9 +63,9 @@ class ServerSubcommand(SubcommandBase):
             "'<probe-type>:' where <probe-type> is the name of a probe plugin.")
         server_options.add_argument("-W", "--no-wait", action="store_true",
             help="Do not wait for a probe to be connected if none are available.")
-        
+
         return [cls.CommonOptions.LOGGING, server_parser]
-    
+
     def invoke(self) -> None:
         """! @brief Handle 'server' subcommand."""
         # Create a session to load config, particularly logging config. Even though we do have a
@@ -75,22 +75,22 @@ class ServerSubcommand(SubcommandBase):
         session = Session(probe=None,
                 serve_local_only=self._args.serve_local_only,
                 options=session_options)
-        
+
         # The ultimate intent is to serve all available probes by default. For now we just serve
         # a single probe.
         probe = ConnectHelper.choose_probe(unique_id=self._args.unique_id)
         if probe is None:
             return
-        
+
         # Assign the session to the probe.
         probe.session = session
-        
+
         # Create the server instance.
         server = DebugProbeServer(session, probe, self._args.port_number, self._args.serve_local_only)
         session.probeserver = server
         LOG.debug("Starting debug probe server")
         server.start()
-        
+
         # Loop as long as the probe is running. The server thread is a daemon, so the main thread
         # must continue to exist.
         try:

--- a/pyocd/target/builtin/cypress/target_CY8C64xx.py
+++ b/pyocd/target/builtin/cypress/target_CY8C64xx.py
@@ -107,8 +107,8 @@ class cy8c64xx_s25hx512t(PSoC64):
 
     def __init__(self, session, ap_num):
         super(cy8c64xx_s25hx512t, self).__init__(session, CortexM_PSoC64_BLE2, self.MEMORY_MAP, ap_num)
-        
-        
+
+
 class cy8c64xx_nosmif(PSoC64):
     from .flash_algos.flash_algo_CY8C64xx import flash_algo as flash_algo_main
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work
@@ -158,8 +158,8 @@ class cy8c64xx_cm0_s25hx512t(cy8c64xx_s25hx512t):
 class cy8c64xx_cm4_s25hx512t(cy8c64xx_s25hx512t):
     def __init__(self, session):
         super(cy8c64xx_cm4_s25hx512t, self).__init__(session, 2)
-        
-        
+
+
 class cy8c64xx_cm0_nosmif(cy8c64xx_nosmif):
     def __init__(self, session):
         super(cy8c64xx_cm0_nosmif, self).__init__(session, 1)

--- a/pyocd/target/builtin/cypress/target_CY8C6xx7.py
+++ b/pyocd/target/builtin/cypress/target_CY8C6xx7.py
@@ -120,7 +120,7 @@ class CY8C6xx7_S25FS512S(PSoC6):
 
     def __init__(self, session):
         super(CY8C6xx7_S25FS512S, self).__init__(session, CortexM_PSoC6_BLE2, self.MEMORY_MAP)
-        
+
 class CY8C6xx7_nosmif(PSoC6):
     from .flash_algos.flash_algo_CY8C6xx7 import flash_algo as flash_algo_main
     from .flash_algos.flash_algo_CY8C6xxx_WFLASH import flash_algo as flash_algo_work

--- a/pyocd/target/builtin/target_CC3220SF.py
+++ b/pyocd/target/builtin/target_CC3220SF.py
@@ -113,7 +113,7 @@ class Flash_cc3220sf(Flash):
 
 class CC3220SF(CoreSightTarget):
     VENDOR = "Texas Instruments"
-    
+
     MEMORY_MAP = MemoryMap(
         RomRegion(start=0x00000000, length=0x00080000),
         FlashRegion(start=0x01000000, length=0x00100000, blocksize=0x800, is_boot_memory=True, flash_class=Flash_cc3220sf),
@@ -125,4 +125,4 @@ class CC3220SF(CoreSightTarget):
 
     def post_connect_hook(self):
         self.cores[0].default_reset_type = self.ResetType.SW_VECTRESET
-        
+

--- a/pyocd/target/builtin/target_HC32L07x.py
+++ b/pyocd/target/builtin/target_HC32L07x.py
@@ -24,7 +24,7 @@ from ...debug.svd.loader import SVDFile
 DEBUG_ACTIVE = 0x40002038
 DEBUG_ACTIVE_VAL = 0x00000FFF
 
-FLASH_ALGO = { 
+FLASH_ALGO = {
     'load_address' : 0x20000000,
     # Flash algorithm as a hex string
     'instructions': [

--- a/pyocd/target/builtin/target_HC32L110.py
+++ b/pyocd/target/builtin/target_HC32L110.py
@@ -24,7 +24,7 @@ from ...debug.svd.loader import SVDFile
 DEBUG_ACTIVE = 0x40002038
 DEBUG_ACTIVE_VAL = 0x00000FFF
 
-FLASH_ALGO = { 
+FLASH_ALGO = {
     'load_address' : 0x20000000,
     # Flash algorithm as a hex string
     'instructions': [
@@ -58,7 +58,7 @@ FLASH_ALGO = {
     'page_size' : 0x200,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000,
-    'page_buffers' : [0x20000600],   
+    'page_buffers' : [0x20000600],
     'min_program_length' : 0x200,
   }
 

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -24,7 +24,7 @@ from ...debug.svd.loader import SVDFile
 DEBUG_ACTIVE = 0x40002038
 DEBUG_ACTIVE_VAL = 0x00000FFF
 
-FLASH_ALGO = { 
+FLASH_ALGO = {
     'load_address' : 0x20000000,
     # Flash algorithm as a hex string
     'instructions': [

--- a/pyocd/target/builtin/target_HC32L19x.py
+++ b/pyocd/target/builtin/target_HC32L19x.py
@@ -24,7 +24,7 @@ from ...debug.svd.loader import SVDFile
 DEBUG_ACTIVE = 0x40002038
 DEBUG_ACTIVE_VAL = 0x00000FFF
 
-FLASH_ALGO = { 
+FLASH_ALGO = {
     'load_address' : 0x20000000,
     # Flash algorithm as a hex string
     'instructions': [

--- a/pyocd/target/builtin/target_LPC1114FN28_102.py
+++ b/pyocd/target/builtin/target_LPC1114FN28_102.py
@@ -52,7 +52,7 @@ FLASH_ALGO = {
 class LPC11XX_32(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       is_boot_memory=True,
                                                                 blocksize=4096,

--- a/pyocd/target/builtin/target_LPC11U24FBD64_401.py
+++ b/pyocd/target/builtin/target_LPC11U24FBD64_401.py
@@ -50,7 +50,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
 
 class LPC11U24(CoreSightTarget):
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,   is_boot_memory=True,
                                                             blocksize=0x1000,

--- a/pyocd/target/builtin/target_LPC1768.py
+++ b/pyocd/target/builtin/target_LPC1768.py
@@ -67,7 +67,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
 class LPC1768(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,
@@ -94,7 +94,7 @@ class LPC1768(CoreSightTarget):
     def add_core(self, core):
         super(LPC1768, self).add_core(core)
         core.delegate = self
-    
+
     def map_flash(self):
         self.write32(0x400FC040, 1)
 
@@ -104,10 +104,10 @@ class LPC1768(CoreSightTarget):
         # Clear reset vector catch and remember whether it was set.
         self._saved_vc = self.get_vector_catch()
         self.set_vector_catch(self._saved_vc & ~Target.VectorCatch.CORE_RESET)
-        
+
         # Map flash to 0.
         self.map_flash()
-        
+
         # Set breakpoint on user reset handler.
         self._reset_handler = self.read32(0x4)
         if self._reset_handler < 0x80000:
@@ -120,6 +120,6 @@ class LPC1768(CoreSightTarget):
         # Clear breakpoint if it wasn't previously set.
         if not self._had_reset_handler_bp:
             self.remove_breakpoint(self._reset_handler)
-        
+
         # Restore vector catch.
         self.set_vector_catch(self._saved_vc)

--- a/pyocd/target/builtin/target_LPC4088FBD144.py
+++ b/pyocd/target/builtin/target_LPC4088FBD144.py
@@ -64,7 +64,7 @@ FLASH_ALGO = {
 class LPC4088(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x10000,      is_boot_memory=True,
                                                                 blocksize=0x1000,

--- a/pyocd/target/builtin/target_LPC4330.py
+++ b/pyocd/target/builtin/target_LPC4330.py
@@ -318,7 +318,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
 class LPC4330(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x14000000,  length=0x4000000,    blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/builtin/target_LPC54114J256BD64.py
+++ b/pyocd/target/builtin/target_LPC54114J256BD64.py
@@ -59,7 +59,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class LPC54114(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash',   start=0,           length=0x40000,  is_boot_memory=True,
                                                                         blocksize=0x8000,

--- a/pyocd/target/builtin/target_LPC54608J512ET180.py
+++ b/pyocd/target/builtin/target_LPC54608J512ET180.py
@@ -55,7 +55,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class LPC54608(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='flash',   start=0,           length=0x80000,  is_boot_memory=True,
                                                                         blocksize=0x8000,

--- a/pyocd/target/builtin/target_LPC824M201JHI33.py
+++ b/pyocd/target/builtin/target_LPC824M201JHI33.py
@@ -51,7 +51,7 @@ FLASH_ALGO = {
 class LPC824(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x8000,       is_boot_memory=True,
                                                                 blocksize=1024,

--- a/pyocd/target/builtin/target_MAX32600.py
+++ b/pyocd/target/builtin/target_MAX32600.py
@@ -57,7 +57,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class MAX32600(CoreSightTarget):
 
     VENDOR = "Maxim"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x800, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,  length=0x8000),

--- a/pyocd/target/builtin/target_MAX32625.py
+++ b/pyocd/target/builtin/target_MAX32625.py
@@ -60,7 +60,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class MAX32625(CoreSightTarget):
 
     VENDOR = "Maxim"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,            length=0x80000, blocksize=0x2000, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x20000000,   length=0x28000),

--- a/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1015xxxxx.py
@@ -727,7 +727,7 @@ class MIMXRT1015xxxxx(IMXRT):
     VENDOR = "NXP"
 
     # Note: by default there are 64 KB ITCM, 64 KB DTCM and 128 KB OCRAM available for MIMXRT1015.
-    # And it also has 256 KB FlexRAM that can be enabled and configured by GPR17, customers can 
+    # And it also has 256 KB FlexRAM that can be enabled and configured by GPR17, customers can
     # allocate this 256 KB FlexRAM to ITCM/DTCM/OCRAM, but the FlexRAM is not available by default.
     MEMORY_MAP = MemoryMap(
         RamRegion(name="itcm",      start=0x00000000, length=0x10000), # 64 KB

--- a/pyocd/target/builtin/target_MIMXRT1176xxxxx.py
+++ b/pyocd/target/builtin/target_MIMXRT1176xxxxx.py
@@ -21,7 +21,7 @@ from ...coresight.coresight_target import CoreSightTarget
 from ...core.memory_map import (FlashRegion, RomRegion, RamRegion, MemoryMap)
 from ...debug.svd.loader import SVDFile
 from ...coresight.ap import AccessPort, APv1Address
-from ...coresight.cortex_m import CortexM 
+from ...coresight.cortex_m import CortexM
 
 LOG = logging.getLogger(__name__)
 FCFB = 0x42464346
@@ -777,7 +777,7 @@ FLASH_ALGO = {
 class MIMXRT1176xxxxx_CM7(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     # Note: itcm, dtcm, and ocram share a single 512 KB block of RAM that can be configurably
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 512 KB, but that is the maximum and
@@ -857,7 +857,7 @@ class MIMXRT1176xxxxx_CM7(CoreSightTarget):
 class MIMXRT1176xxxxx_CM4(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     # Note: itcm, dtcm, and ocram share a single 512 KB block of RAM that can be configurably
     # divided between those regions (this is called FlexRAM). Thus, the memory map regions for
     # each of these RAMs allocate the maximum possible of 512 KB, but that is the maximum and

--- a/pyocd/target/builtin/target_MPS3_AN522.py
+++ b/pyocd/target/builtin/target_MPS3_AN522.py
@@ -20,7 +20,7 @@ from ...core.memory_map import (RamRegion, MemoryMap)
 class AN522(CoreSightTarget):
 
     VENDOR = "Arm"
-    
+
     MEMORY_MAP = MemoryMap(
         RamRegion(  name='itcm',        start=0x00000000, length=0x00080000, access='rwx'),
         RamRegion(  name='sram',        start=0x30000000, length=0x00100000, access='rwx'),

--- a/pyocd/target/builtin/target_MPS3_AN540.py
+++ b/pyocd/target/builtin/target_MPS3_AN540.py
@@ -20,7 +20,7 @@ from ...core.memory_map import (RamRegion, MemoryMap)
 class AN540(CoreSightTarget):
 
     VENDOR = "Arm"
-    
+
     MEMORY_MAP = MemoryMap(
         RamRegion(  name='itcm_ns',     start=0x00000000, length=0x00100000, access='rwx'),
         RamRegion(  name='itcm_s',      start=0x10000000, length=0x00100000, access='rwxs'),

--- a/pyocd/target/builtin/target_RP2040.py
+++ b/pyocd/target/builtin/target_RP2040.py
@@ -85,12 +85,12 @@ def _parity32(value):
 
 class RP2040Base(CoreSightTarget):
     """! @brief Raspberry Pi RP2040.
-    
+
     This device is very strange in that it as three DPs. The first two DPs each have a single AHB-AP
     for the two Cortex-M0+ cores. The third DP is a "Rescue DP" that has no APs, but the CDBGPWRUPREQ
     signal is repurposed as a rescue signal.
     """
-    
+
     class Targetsel:
         """! @brief DP TARGETEL values for each DP."""
         CORE_0 = 0x01002927
@@ -98,10 +98,10 @@ class RP2040Base(CoreSightTarget):
         RESCUE_DP = 0xf1002927
 
     VENDOR = "Raspberry Pi"
-    
+
     MEMORY_MAP = MemoryMap(
         RomRegion(  start=0,            length=0x4000,      name="bootrom",             ),
-        FlashRegion(start=0x10000000,   length=0x1000000,   name="xip",                 
+        FlashRegion(start=0x10000000,   length=0x1000000,   name="xip",
             sector_size=4096,
             page_size=256,
             algo=FLASH_ALGO,
@@ -127,12 +127,12 @@ class RP2040Base(CoreSightTarget):
 
     def create_init_sequence(self):
         seq = super().create_init_sequence()
-        
+
         seq.insert_before('load_svd', ('check_probe', self._check_probe)) \
             .insert_before('dp_init', ('select_core0', self._select_core))
 
         return seq
-    
+
     def _check_probe(self):
         # Have to import here to avoid a circular import
         from ...probe.debug_probe import DebugProbe
@@ -145,7 +145,7 @@ class RP2040Base(CoreSightTarget):
     def select_dp(self, targetsel):
         """! @brief Select the DP with the matching TARGETSEL."""
         probe = self.session.probe
-        
+
         # Have to connect the probe first, or SWCLK will not be enabled.
         probe.connect(DebugProbe.Protocol.SWD)
 
@@ -157,7 +157,7 @@ class RP2040Base(CoreSightTarget):
         # SWD line reset to activate all DPs.
         swj.line_reset()
         swj.idle_cycles(2)
-        
+
         # Send multi-drop SWD target selection sequence to select the requested DP.
         probe.swd_sequence([
             # DP TARGETSEL write
@@ -171,10 +171,10 @@ class RP2040Base(CoreSightTarget):
             #   - Park = 1
             # -> LSB first, that's 0b10011001 or 0x99
             (8, 0x99),
-            
+
             # 5 cycles with SWDIO as input
             (5,),
-            
+
             # DP TARGETSEL value
             # output 32 + 1 cycles
             (33, targetsel | mask.parity32_high(targetsel)),
@@ -186,15 +186,15 @@ class RP2040Base(CoreSightTarget):
         DP_IDR = 0x00
         dpidr = probe.read_dp(DP_IDR)
         LOG.debug("DP IDR after writing TARGETSEL: 0x%08x", dpidr)
-        
+
         probe.write_dp(0x8, 0x2) # DPBANKSEL=2 to select TARGETID
         targetid = probe.read_dp(0x4)
         LOG.debug("DP TARGETID: 0x%08x", targetid)
-        
+
         probe.write_dp(0x8, 0x3) # DPBANKSEL=3 to select DLPIDR
         dlpidr = probe.read_dp(0x4)
         LOG.debug("DP DLPIDR: 0x%08x", dlpidr)
-        
+
         probe.write_dp(0x8, 0x0) # restore DPBANKSEL=0
 
 class RP2040Core0(RP2040Base):
@@ -206,7 +206,7 @@ class RP2040Core0(RP2040Base):
 
 class RP2040Core1(RP2040Base):
     """! @brief RP2040 target for core 1."""
-    
+
     def __init__(self, session):
         super().__init__(session)
         self._core_targetsel = self.Targetsel.CORE_1

--- a/pyocd/target/builtin/target_RTL8195AM.py
+++ b/pyocd/target/builtin/target_RTL8195AM.py
@@ -21,7 +21,7 @@ from ...core.memory_map import (RamRegion, MemoryMap)
 class RTL8195AM(CoreSightTarget):
 
     VENDOR = "Realtek Semiconductor"
-    
+
     MEMORY_MAP = MemoryMap(
         RamRegion(      start=0x00000000,  length=0x400000),
         RamRegion(      start=0x10000000,  length=0x80000),

--- a/pyocd/target/builtin/target_STM32F051T8.py
+++ b/pyocd/target/builtin/target_STM32F051T8.py
@@ -69,7 +69,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class STM32F051(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x08000000,  length=0x10000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/builtin/target_STM32F103RC.py
+++ b/pyocd/target/builtin/target_STM32F103RC.py
@@ -52,7 +52,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class STM32F103RC(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x08000000,  length=0x80000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/builtin/target_STM32F439xx.py
+++ b/pyocd/target/builtin/target_STM32F439xx.py
@@ -67,10 +67,10 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class STM32F439xG(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
-                                                        page_size=0x1000, 
+                                                        page_size=0x1000,
                                                         is_boot_memory=True,
                                                         erase_all_weight=CHIP_ERASE_WEIGHT,
                                                         algo=FLASH_ALGO),
@@ -97,7 +97,7 @@ class STM32F439xG(CoreSightTarget):
 class STM32F439xI(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion( start=0x08000000, length=0x10000,  sector_size=0x4000,
                                                         page_size=0x1000,

--- a/pyocd/target/builtin/target_STM32L031x6.py
+++ b/pyocd/target/builtin/target_STM32L031x6.py
@@ -80,7 +80,7 @@ FLASH_ALGO = {
 class STM32L031x6(CoreSightTarget):
 
     VENDOR = "STMicroelectronics"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='Flash', start=0x08000000, length=0x8000, blocksize=0x80,  is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(name='RAM', start=0x20000000, length=0x2000),

--- a/pyocd/target/builtin/target_STM32L432xx.py
+++ b/pyocd/target/builtin/target_STM32L432xx.py
@@ -78,7 +78,7 @@ FLASH_ALGO = {
 }
 
 class STM32L432xC(CoreSightTarget):
-        
+
     VENDOR = "STMicroelectronics"
 
     MEMORY_MAP = MemoryMap(

--- a/pyocd/target/builtin/target_STM32L475xx.py
+++ b/pyocd/target/builtin/target_STM32L475xx.py
@@ -66,7 +66,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
   }
 
 class STM32L475xx(CoreSightTarget):
-        
+
     VENDOR = "STMicroelectronics"
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_lpc800.py
+++ b/pyocd/target/builtin/target_lpc800.py
@@ -51,7 +51,7 @@ FLASH_ALGO = { 'load_address' : 0x10000000,
 class LPC800(CoreSightTarget):
 
     VENDOR = "NXP"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x4000,       blocksize=0x400, is_boot_memory=True, algo=FLASH_ALGO),
         RamRegion(      start=0x10000000,  length=0x1000)

--- a/pyocd/target/builtin/target_musca_a1.py
+++ b/pyocd/target/builtin/target_musca_a1.py
@@ -68,7 +68,7 @@ FLASH_ALGO = {
     0xfe31f7ff, 0x0018f89d, 0xf89d7020, 0x70600019, 0x001af89d, 0xf89d70a0, 0x70e0001b, 0xb0082000,
     0x0000bd70, 0x00000000, 0x00000000
     ],
-    
+
     # Function addresses
     'pc_init': 0x20000021,
     'pc_unInit': 0x20000043,
@@ -96,7 +96,7 @@ FLASH_ALGO = {
 class MuscaA1(CoreSightTarget):
 
     VENDOR = "Arm"
-    
+
     MEMORY_MAP = MemoryMap(
         # Due to an errata, only the first 256 kB of QSPI is memory mapped. The remainder
         # of the 8 MB region can be read and written via register accesses only.

--- a/pyocd/target/builtin/target_musca_b1.py
+++ b/pyocd/target/builtin/target_musca_b1.py
@@ -143,7 +143,7 @@ FLASH_ALGO_QSPI = {
     0xf811e003, 0xf8003b01, 0x1e523b01, 0x4770d2f9, 0x52800000, 0x0003ffff, 0x00000000, 0x00000000,
     0x00000000, 0x00000000, 0x00000000, 0x00000004, 0x00800000, 0x00000000, 0x00000000
     ],
-    
+
     # Function addresses
     'pc_init': 0x20000021,
     'pc_unInit': 0x20000071,
@@ -252,7 +252,7 @@ FLASH_ALGO_EFLASH = {
 class MuscaB1(CoreSightTarget):
 
     VENDOR = "Arm"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(name='neflash',     start=0x0A000000, length=0x00200000, access='rx',
                         blocksize=0x4000,
@@ -295,17 +295,17 @@ class MuscaB1(CoreSightTarget):
 
     def create_init_sequence(self):
         seq = super(MuscaB1, self).create_init_sequence()
-        
-        seq.insert_before('halt_on_connect',  
+
+        seq.insert_before('halt_on_connect',
             ('enable_sysresetreq',        self._enable_sysresetreq),
             )
-        
+
         return seq
-    
+
     def _enable_sysresetreq(self):
         LOG.info("Enabling SYSRSTREQ0_EN and SYSRSTREQ1_EN")
         reset_mask = self.read32(RESET_MASK)
         reset_mask |= RESET_MASK_SYSRSTREQ0_EN | RESET_MASK_SYSRSTREQ1_EN
         self.write32(RESET_MASK, reset_mask)
-    
-    
+
+

--- a/pyocd/target/builtin/target_nRF51822_xxAA.py
+++ b/pyocd/target/builtin/target_nRF51822_xxAA.py
@@ -53,7 +53,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class NRF51(CoreSightTarget):
 
     VENDOR = "Nordic Semiconductor"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0,           length=0x40000,      blocksize=0x400, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/builtin/target_ncs36510.py
+++ b/pyocd/target/builtin/target_ncs36510.py
@@ -82,7 +82,7 @@ FLASH_ALGO = {
 class NCS36510(CoreSightTarget):
 
     VENDOR = "ONSemiconductor"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x2000,           length=0x50000,      blocksize=0x800, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/builtin/target_w7500.py
+++ b/pyocd/target/builtin/target_w7500.py
@@ -41,7 +41,7 @@ FLASH_ALGO = { 'load_address' : 0x20000000,
 class W7500(CoreSightTarget):
 
     VENDOR = "WIZnet"
-    
+
     MEMORY_MAP = MemoryMap(
         FlashRegion(    start=0x00000000,  length=0x20000,      blocksize=0x100, is_boot_memory=True,
             algo=FLASH_ALGO),

--- a/pyocd/target/family/flash_kinetis.py
+++ b/pyocd/target/family/flash_kinetis.py
@@ -39,10 +39,10 @@ class Flash_Kinetis(Flash):
 
     def override_security_bits(self, address, data):
         """! @brief Check security bytes.
-        
+
         Override Flash Configuration Field bytes at address 0x400-0x40f to ensure that flash security
         won't be enabled. If flash security is enabled, then the chip is inaccessible via SWD.
-        
+
         FCF bytes:
         [0x0-0x7]=backdoor key
         [0x8-0xb]=flash protection bytes
@@ -54,14 +54,14 @@ class Flash_Kinetis(Flash):
         [0xd]=FOPT
         [0xe]=EEPROM protection bytes (FlexNVM devices only)
         [0xf]=data flash protection bytes (FlexNVM devices only)
-        
+
         This function enforces that:
         - 0x8-0xb==0xff
         - 0xe-0xf==0xff
         - FSEC=0xfe
-        
+
         FOPT can be set to any value except 0x00.
-        
+
         @retval Data with modified security bits
         """
         # Check if the data passed in contains the security bits

--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -80,7 +80,7 @@ class LPC5500Family(CoreSightTarget):
 
     def create_init_sequence(self):
         seq = super(LPC5500Family, self).create_init_sequence()
-        
+
         seq.wrap_task('discovery', self.modify_discovery)
         return seq
 
@@ -96,25 +96,25 @@ class LPC5500Family(CoreSightTarget):
                         ) \
            .append(('restore_max_invalid_aps', self.restore_max_invalid_aps))
         return seq
-    
+
     def set_max_invalid_aps(self):
         # Save current option and make sure it is set to at least 3.
         self._saved_max_invalid_aps = self.session.options.get('adi.v5.max_invalid_ap_count')
         if self._saved_max_invalid_aps < self._MIN_INVALID_APS:
             self.session.options.set('adi.v5.max_invalid_ap_count', self._MIN_INVALID_APS)
-    
+
     def restore_max_invalid_aps(self):
         # Only restore if we changed it.
         if self._saved_max_invalid_aps < self._MIN_INVALID_APS:
             self.session.options.set('adi.v5.max_invalid_ap_count', self._saved_max_invalid_aps)
-    
+
     def _modify_ap1(self, seq):
         # If AP#1 exists we need to adjust it before we can read the ROM.
         if seq.has_task('init_ap.1'):
             seq.insert_before('init_ap.1',
                 ('set_ap1_nonsec',        self._set_ap1_nonsec),
                 )
-        
+
         return seq
 
     def check_locked_state(self, seq):
@@ -122,12 +122,12 @@ class LPC5500Family(CoreSightTarget):
         # The device is not locked if AP#0 was found and is enabled.
         if (0 in self.aps) and self.aps[0].is_enabled:
             return
-        
+
         # The debugger mailbox should always be present.
         if not DM_AP in self.aps:
             LOG.error("cannot request debug unlock; no debugger mailbox AP was found")
             return
-        
+
         # Perform the unlock procedure using the debugger mailbox.
         self.unlock(self.aps[DM_AP])
 
@@ -160,7 +160,7 @@ class LPC5500Family(CoreSightTarget):
             self.add_core(core0)
         except exceptions.Error as err:
             LOG.error("Error creating core 0: %s", err, exc_info=self.session.log_tracebacks)
-        
+
         # Create core 1 if the AP is present. It uses the standard Cortex-M core class for v8-M.
         if (1 in self.aps) and (self.aps[0].is_enabled):
             try:
@@ -171,22 +171,22 @@ class LPC5500Family(CoreSightTarget):
                 self.add_core(core1)
             except exceptions.Error as err:
                 LOG.error("Error creating core 1: %s", err, exc_info=self.session.log_tracebacks)
-    
+
     def _enable_traceclk(self):
         # Don't make it worse if no APs were found.
         if (0 not in self.aps) or (not self.aps[0].is_enabled):
             return
-        
+
         SYSCON_NS_Base_Addr = 0x40000000
         IOCON_NS_Base_Addr  = 0x40001000
         TRACECLKSEL_Addr    = SYSCON_NS_Base_Addr + 0x268
         TRACECLKDIV_Addr    = SYSCON_NS_Base_Addr + 0x308
         AHBCLKCTRLSET0_Addr = IOCON_NS_Base_Addr  + 0x220
-        
+
         clksel = self.read32(TRACECLKSEL_Addr)  # Read current TRACECLKSEL value
         if clksel > 2:
             self.write32(TRACECLKSEL_Addr, 0x0) # Select Trace divided clock
-        
+
         clkdiv = self.read32(TRACECLKDIV_Addr) & 0xFF # Read current TRACECLKDIV value, preserve divider but clear rest to enable
         self.write32(TRACECLKDIV_Addr, clkdiv)
 
@@ -195,7 +195,7 @@ class LPC5500Family(CoreSightTarget):
     def trace_start(self):
         # Configure PIO0_10: FUNC - 6, MODE - 0, SLEW - 1, INVERT - 0, DIGMODE - 0, OD - 0
         self.write32(0x40001028, 0x00000046)
-        
+
         self.call_delegate('trace_start', target=self, mode=0)
 
         # On a reset when ITM is enabled, TRACECLKDIV/TRACECLKSEL will be reset
@@ -213,20 +213,20 @@ class LPC5500Family(CoreSightTarget):
         # Set RESYNCH_REQ (0x1) and CHIP_RESET_REQ (0x20) in DM.CSW.
         dm_ap.write_reg(addr=DM_CSW, data=(DM_CSW_RESYNCH_REQ_MASK | DM_CSW_CHIP_RESET_REQ_MASK))
         dm_ap.dp.flush()
-        
+
         # Wait for reset to complete.
         sleep(0.1)
-        
+
         # Read CSW to verify the reset happened and the register is cleared.
         retval = dm_ap.read_reg(addr=DM_CSW)
         if retval != 0:
             LOG.error("debugger mailbox failed to reset the device")
             return
-        
+
         # Write debug unlock request.
         dm_ap.write_reg(addr=DM_REQUEST, data=DM_START_DBG_SESSION)
         dm_ap.dp.flush()
-        
+
         # Read reply from boot ROM. The return status is the low half-word.
         retval = dm_ap.read_reg(addr=DM_RETURN) & 0xffff
         if retval != 0:
@@ -242,7 +242,7 @@ class CortexM_LPC5500(CortexM_v8M):
         catch_mode = 0
 
         delegateResult = self.call_delegate('set_reset_catch', core=self, reset_type=reset_type)
-        
+
         # Save CortexM.DEMCR
         demcr = self.read_memory(CortexM.DEMCR)
 
@@ -250,10 +250,10 @@ class CortexM_LPC5500(CortexM_v8M):
         if not delegateResult:
             # This sequence is copied from the NXP LPC55S69_DFP debug sequence.
             reset_vector = 0xFFFFFFFF
-            
+
             # Clear reset vector catch.
             self.write32(CortexM.DEMCR, demcr & ~CortexM.DEMCR_VC_CORERESET)
-            
+
             # If the processor is in Secure state, we have to access the flash controller
             # through the secure alias.
             if self.get_security_state() == Target.SecurityState.SECURE:
@@ -297,7 +297,7 @@ class CortexM_LPC5500(CortexM_v8M):
                         if (self.read32(base + FLASH_INT_STATUS) & 0x00000004) != 0:
                             break
                         sleep(0.01)
-            
+
                 # Check for error reading flash word.
                 if (self.read32(base + FLASH_INT_STATUS) & 0xB) == 0:
                     # Read the reset vector address.

--- a/pyocd/target/pack/flash_algo.py
+++ b/pyocd/target/pack/flash_algo.py
@@ -41,7 +41,7 @@ class PackFlashAlgo(object):
     This class is intended to provide easy access to the information
     provided by a flash algorithm, such as symbols and the flash
     algorithm itself.
-    
+
     @sa PackFlashInfo
     """
 
@@ -57,7 +57,7 @@ class PackFlashAlgo(object):
         "EraseChip",
         "Verify",
         }
-        
+
     SECTIONS_TO_FIND = (
         ("PrgCode", "SHT_PROGBITS"),
         ("PrgData", "SHT_PROGBITS"),
@@ -106,18 +106,18 @@ class PackFlashAlgo(object):
 
     def get_pyocd_flash_algo(self, blocksize, ram_region):
         """! @brief Return a dictionary representing a pyOCD flash algorithm, or None.
-        
+
         The most interesting operation this method performs is dynamically allocating memory
         for the flash algo from a given RAM region. Note that the .data and .bss sections are
         concatenated with .text. That's why there isn't a specific allocation for those sections.
-        
+
         Double buffering is supported as long as there is enough RAM.
-        
+
         Memory layout:
         ```
         [stack] [code] [buf1] [buf2]
         ```
-        
+
         @param self
         @param blocksize The size to use for page buffers, normally the erase block size.
         @param ram_region A RamRegion object where the flash algo will be allocated.

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -34,7 +34,7 @@ LOG = logging.getLogger(__name__)
 
 class ManagedPacks(object):
     """! @brief Namespace for managed CMSIS-Pack utilities.
-    
+
     By managed, we mean managed by the cmsis-pack-manager package. All the methods on this class
     apply only to those packs managed by cmsis-pack-manager, not any targets from packs specified
     by the user.
@@ -52,7 +52,7 @@ class ManagedPacks(object):
         for pack in cache.packs_for_devices(cache.index.values()):
             # Generate full path to the .pack file.
             pack_path = os.path.join(cache.data_path, pack.get_pack_name())
-            
+
             # If the .pack file exists, the pack is installed.
             if os.path.isfile(pack_path):
                 results.append(pack)

--- a/pyocd/tools/gdb_server.py
+++ b/pyocd/tools/gdb_server.py
@@ -257,7 +257,7 @@ class GDBServerTool(object):
 
         if not self.args.no_deprecation_warning:
             LOG.warning("pyocd-gdbserver is deprecated; please use the new combined pyocd tool.")
-    
+
         self.process_commands(self.args.commands)
 
         gdb = None
@@ -271,7 +271,7 @@ class GDBServerTool(object):
                 # Build dict of session options.
                 sessionOptions = convert_session_options(self.args.option)
                 sessionOptions.update(self.gdb_server_settings)
-                
+
                 session = ConnectHelper.session_with_chosen_probe(
                     config_file=self.args.config,
                     no_config=self.args.no_config,
@@ -290,7 +290,7 @@ class GDBServerTool(object):
                     for core_number, core in session.board.target.cores.items():
                         if isinstance(session.board.target.cores[core_number], GenericMemAPTarget):
                             continue
-                            
+
                         gdb = GDBServer(session, core=core_number)
                         # Only subscribe to the server for the first core, so echo messages aren't printed
                         # multiple times.

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -31,7 +31,7 @@ class ListGenerator(object):
     @staticmethod
     def list_probes():
         """! @brief Generate dictionary with info about the connected debug probes.
-        
+
         Output version history:
         - 1.0, initial version
         """
@@ -71,7 +71,7 @@ class ListGenerator(object):
     @staticmethod
     def list_boards(name_filter=None):
         """! @brief Generate dictionary with info about supported boards.
-        
+
         Output version history:
         - 1.0, initial version
         - 1.1, added is_target_builtin and is_target_supported keys
@@ -112,7 +112,7 @@ class ListGenerator(object):
     @staticmethod
     def list_targets(name_filter=None, vendor_filter=None, source_filter=None):
         """! @brief Generate dictionary with info about all supported targets.
-        
+
         Output version history:
         - 1.0, initial version
         - 1.1, added part_families
@@ -136,19 +136,19 @@ class ListGenerator(object):
             # Filter by name.
             if name_filter and name_filter not in name.lower():
                 continue
-            
+
             s = Session(None) # Create empty session
             t = TARGET[name](s)
-            
+
             # Filter by vendor.
             if vendor_filter and vendor_filter not in t.vendor.lower():
                 continue
-            
+
             # Filter by source.
             source = 'pack' if hasattr(t, '_pack_device') else 'builtin'
             if source_filter and source_filter != source:
                 continue
-            
+
             d = {
                 'name' : name,
                 'vendor' : t.vendor,
@@ -161,7 +161,7 @@ class ListGenerator(object):
                 if isinstance(svdPath, str) and os.path.exists(svdPath):
                     d['svd_path'] = svdPath
             targets.append(d)
-        
+
         if not source_filter or source_filter == 'pack':
             # Add targets from cmsis-pack-manager cache.
             for dev in pack_target.ManagedPacks.get_installed_targets():
@@ -183,11 +183,11 @@ class ListGenerator(object):
                     pass
 
         return obj
-        
+
     @staticmethod
     def list_plugins():
         """! @brief Generate dictionary with lists of available plugins.
-        
+
         Output version history:
         - 1.0, initial version with debug probe and RTOS plugins
         """
@@ -204,7 +204,7 @@ class ListGenerator(object):
             'status': 0,
             'plugins': plugin_groups_list,
             }
-        
+
         # Add plugins info
         for group_name in plugin_groups:
             plugin_list = []
@@ -212,7 +212,7 @@ class ListGenerator(object):
                 'plugin_type': group_name,
                 'plugins': plugin_list,
                 }
-            
+
             for entry_point in pkg_resources.iter_entry_points(group_name):
                 klass = entry_point.load()
                 plugin = klass()
@@ -224,13 +224,13 @@ class ListGenerator(object):
                     }
                 plugin_list.append(info)
             plugin_groups_list.append(group_info)
-        
+
         return obj
-        
+
     @staticmethod
     def list_features():
         """! @brief Generate dictionary with info about supported features and options.
-        
+
         Output version history:
         - 1.1, added 'plugins' feature
         - 1.0, initial version
@@ -249,11 +249,11 @@ class ListGenerator(object):
                 ],
             'options' : options_list,
             }
-        
+
         # Add plugins
         plugins = ListGenerator.list_plugins()
         plugins_list.extend(plugins['plugins'])
-        
+
         # Add options
         for option_name in options.OPTIONS_INFO.keys():
             info = options.OPTIONS_INFO[option_name]
@@ -270,5 +270,5 @@ class ListGenerator(object):
                 types_list = [info.type.__name__]
             option_dict['type'] = types_list
             options_list.append(option_dict)
-        
+
         return obj

--- a/pyocd/trace/events.py
+++ b/pyocd/trace/events.py
@@ -19,15 +19,15 @@ class TraceEvent(object):
     def __init__(self, desc="", ts=0):
         self._desc = desc
         self._timestamp = ts
-    
+
     @property
     def timestamp(self):
         return self._timestamp
-    
+
     @timestamp.setter
     def timestamp(self, ts):
         self._timestamp = ts
-        
+
     def __str__(self):
         return "[{}] {}".format(self._timestamp, self._desc)
 
@@ -44,11 +44,11 @@ class TraceTimestamp(TraceEvent):
     def __init__(self, tc, ts=0):
         super(TraceTimestamp, self).__init__("timestamp", ts)
         self._tc = 0
-    
+
     @property
     def tc(self):
         return self._tc
-        
+
     def __str__(self):
         return "[{}] local timestamp TC={:#x} {}".format(self._timestamp, self.tc, self.timestamp)
 
@@ -59,19 +59,19 @@ class TraceITMEvent(TraceEvent):
         self._port = port
         self._data = data
         self._width = width
-    
+
     @property
     def port(self):
         return self._port
-    
+
     @property
     def data(self):
         return self._data
-    
+
     @property
     def width(self):
         return self._width
-    
+
     def __str__(self):
         width = self.width
         if width == 1:
@@ -94,11 +94,11 @@ class TraceEventCounter(TraceEvent):
     def __init__(self, counterMask, ts=0):
         super(TraceEventCounter, self).__init__("exception", ts)
         self._mask = counterMask
-    
+
     @property
     def counter_mask(self):
         return self._mask
-    
+
     def _get_event_desc(self, evt):
         msg = ""
         if evt & TraceEventCounter.CYC_MASK:
@@ -114,7 +114,7 @@ class TraceEventCounter(TraceEvent):
         if evt & TraceEventCounter.CPI_MASK:
             msg += " CPI"
         return msg
-    
+
     def __str__(self):
         return "[{}] DWT: Event:{}".format(self.timestamp, self._get_event_desc(self.counter_mask))
 
@@ -129,25 +129,25 @@ class TraceExceptionEvent(TraceEvent):
         EXITED : "Exited",
         RETURNED : "Returned"
         }
-    
+
     def __init__(self, exceptionNumber, exceptionName, action, ts=0):
         super(TraceExceptionEvent, self).__init__("exception", ts)
         self._number = exceptionNumber
         self._name = exceptionName
         self._action = action
-    
+
     @property
     def exception_number(self):
         return self._number
-    
+
     @property
     def exception_name(self):
         return self._name
-    
+
     @property
     def action(self):
         return self._action
-    
+
     def __str__(self):
         action = TraceExceptionEvent.ACTION_DESC.get(self.action, "<invalid action>")
         return "[{}] DWT: Exception #{:d} {} {}".format(self.timestamp, self.exception_number, action, self.exception_name)
@@ -161,13 +161,13 @@ class TracePeriodicPC(TraceEvent):
     @property
     def pc(self):
         return self._pc
-    
+
     def __str__(self):
         return "[{}] DWT: PC={:#010x}".format(self.timestamp, self.pc)
 
 class TraceDataTraceEvent(TraceEvent):
     """! @brief DWT data trace event.
-    
+
     Valid combinations:
     - PC value.
     - Bits[15:0] of a data address.
@@ -191,23 +191,23 @@ class TraceDataTraceEvent(TraceEvent):
     @property
     def pc(self):
         return self._pc
-    
+
     @property
     def address(self):
         return self._addr
-    
+
     @property
     def value(self):
         return self._value
-    
+
     @property
     def is_read(self):
         return self._rnw
-    
+
     @property
     def transfer_size(self):
         return self._sz
-    
+
     def __str__(self):
         hasPC = self.pc is not None
         hasAddress = self.address is not None

--- a/pyocd/trace/sink.py
+++ b/pyocd/trace/sink.py
@@ -27,20 +27,20 @@ class TraceEventSink(object):
 
 class TraceEventFilter(TraceEventSink):
     """! @brief Abstract interface for a trace event filter."""
-    
+
     def __init__(self, sink=None):
         self._sink = sink
 
     def connect(self, sink):
         """! @brief Connect the downstream trace sink or filter."""
         self._sink = sink
-    
+
     def receive(self, event):
         """! @brief Handle a single trace event.
-        
+
         Passes the event through the filter() method. If one or more objects are returned, they
         are then passed to the trace sink connected to this filter (which may be another filter).
-        
+
         @param self
         @param event An instance of TraceEvent or one of its subclasses.
         """
@@ -51,10 +51,10 @@ class TraceEventFilter(TraceEventSink):
                     self._sink.receive(event_item)
             else:
                 self._sink.receive(event)
-    
+
     def filter(self, event):
         """! @brief Filter a single trace event.
-        
+
         @param self
         @param event An instance of TraceEvent or one of its subclasses.
         @return Either None, a single TraceEvent, or a sequence of TraceEvents.
@@ -63,13 +63,13 @@ class TraceEventFilter(TraceEventSink):
 
 class TraceEventTee(TraceEventSink):
     """! @brief Trace event sink that replicates events to multiple sinks."""
-    
+
     def __init__(self):
         self._sinks = []
 
     def connect(self, sinks):
         """! @brief Connect one or more downstream trace sinks.
-        
+
         @param self
         @param sinks If this parameter is a single object, it will be added to the list of
           downstream trace event sinks. If it is an iterable (list, tuple, etc.), then it will
@@ -82,7 +82,7 @@ class TraceEventTee(TraceEventSink):
 
     def receive(self, event):
         """! @brief Replicate a single trace event to all connected downstream trace event sinks.
-        
+
         @param self
         @param event An instance of TraceEvent or one of its subclasses.
         """

--- a/pyocd/trace/swo.py
+++ b/pyocd/trace/swo.py
@@ -19,12 +19,12 @@ from . import events
 
 class SWOParser(object):
     """! @brief SWO data stream parser.
-    
+
     Processes a stream of SWO data and generates TraceEvent objects. SWO data is passed to the
     parse() method. It processes the data and creates TraceEvent objects which are passed to an
     event sink object that is a subclass of TraceEventSink. The event sink must either be provided
     when the SWOParser is constructed, or can be set using the connect() method.
-    
+
     A SWOParser instance can be reused for multiple SWO sessions. If a break in SWO data streaming
     occurs, the reset() method should be called before passing further data to parse().
     """
@@ -32,18 +32,18 @@ class SWOParser(object):
         self.reset()
         self._core = core
         self._sink = sink
-    
+
     def reset(self):
         self._bytes_parsed = 0
         self._itm_page = 0
         self._timestamp = 0
         self._pending_events = []
         self._pending_data_trace = None
-        
+
         # Get generator instance and prime it.
         self._parser = self._parse()
         next(self._parser)
-    
+
     def connect(self, sink):
         """! @brief Connect the downstream trace sink or filter."""
         self._sink = sink
@@ -55,26 +55,26 @@ class SWOParser(object):
 
     def parse(self, data):
         """! @brief Process SWO data.
-        
+
         This method will return once the provided data is consumed, and can be called again when
         more data is available. There is no minimum or maximum limit on the size of the provided
         data. As trace events are identified during parsing, they will be passed to the event
         sink object passed into the constructor or connect().
-        
+
         @param self
         @param data A sequence of integer byte values, usually a bytearray.
         """
         for value in data:
             self._parser.send(value)
             self._bytes_parsed += 1
-    
+
     def _flush_events(self):
         """! @brief Send all pending events to event sink."""
         if self._sink is not None:
             for event in self._pending_events:
                 self._sink.receive(event)
         self._pending_events = []
-    
+
     def _merge_data_trace_events(self, event):
         """! @brief Look for pairs of data trace events and merge."""
         if isinstance(event, events.TraceDataTraceEvent):
@@ -105,21 +105,21 @@ class SWOParser(object):
             self._pending_events.append(self._pending_data_trace)
             self._pending_data_trace = None
         return False
-    
+
     def _send_event(self, event):
         """! @brief Process event objects and decide when to send to event sink.
-        
+
         This method handles the logic to associate a timestamp event with the prior other
         event. A list of pending events is built up until either a timestamp or overflow event
         is generated, at which point all pending events are flushed to the event sink. If a
         timestamp is seen, the timestamp of all pending events is set prior to flushing.
         """
         flush = False
-        
+
         # Handle merging data trace events.
         if self._merge_data_trace_events(event):
             return
-        
+
         if isinstance(event, events.TraceTimestamp):
             for ev in self._pending_events:
                 ev.timestamp = event.timestamp
@@ -128,13 +128,13 @@ class SWOParser(object):
             self._pending_events.append(event)
             if isinstance(event, events.TraceOverflow):
                 flush = True
-        
+
         if flush:
             self._flush_events()
-    
+
     def _parse(self):
         """! @brief SWO parser as generator function coroutine.
-        
+
         The generator yields every time it needs a byte of SWO data. The caller must use the
         generator's send() method to provide the next byte.
         """
@@ -143,7 +143,7 @@ class SWOParser(object):
         while True:
             byte = yield
             hdr = byte
-            
+
             # Sync packet.
             if hdr == 0:
                 packets = 0
@@ -218,18 +218,18 @@ class SWOParser(object):
                 elif l == 2:
                     byte1 = yield
                     byte2 = yield
-                    payload = (byte1 | 
+                    payload = (byte1 |
                                 (byte2 << 8))
                 else:
                     byte1 = yield
                     byte2 = yield
                     byte3 = yield
                     byte4 = yield
-                    payload = (byte1 | 
+                    payload = (byte1 |
                                 (byte2 << 8) |
                                 (byte3 << 16) |
                                 (byte4 << 24))
-                
+
                 # Instrumentation packet.
                 if (hdr & 0x4) == 0:
                     port = (self._itm_page * 32) + a
@@ -248,7 +248,7 @@ class SWOParser(object):
                     else:
                         invalid = True
                 # Periodic PC
-                elif a == 2:                        
+                elif a == 2:
                     # A payload of 0 indicates a period PC sleep event.
                     self._send_event(events.TracePeriodicPC(payload, timestamp))
                 # Data trace
@@ -270,6 +270,6 @@ class SWOParser(object):
                 # Invalid DWT 'a' value.
                 else:
                     invalid = True
-        
+
 
 

--- a/pyocd/utility/autoflush.py
+++ b/pyocd/utility/autoflush.py
@@ -18,24 +18,24 @@ from ..core import exceptions
 
 class Autoflush(object):
     """! @brief Context manager for performing flushes.
-    
+
     Pass a Target instance to the constructor, and when the context exits, the target will be
     automatically flushed. If a TransferError or subclass, such as TransferFaultError, is raised
     within the context, then the flush will be skipped.
-    
+
     The parameter passed to the constructor can actually be any object with a `flush()` method,
     due to Python's dynamic dispatch.
     """
-    
+
     def __init__(self, target):
         """! @brief Constructor.
-        
+
         @param self The object.
         @param target Object on which the flush will be performed. Normally this is a Target
             instance.
         """
         self._target = target
-    
+
     def __enter__(self):
         return self
 

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -53,7 +53,7 @@ VECTOR_CATCH_CHAR_MAP = {
 
 def convert_vector_catch(vcvalue: Union[str, bytes]) -> int:
     """! @brief Convert a vector catch string to a mask.
-    
+
     @exception ValueError Raised if an invalid vector catch character is encountered.
     """
     # Make case insensitive.
@@ -84,14 +84,14 @@ def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
             else:
                 name = o.strip().lower()
                 value = None
-            
+
             # Check for and strip "no-" prefix before we validate the option name.
             if (value is None) and (name.startswith('no-')):
                 name = name[3:]
                 had_no_prefix = True
             else:
                 had_no_prefix = False
-            
+
             # Look for this option.
             try:
                 info = OPTIONS_INFO[name]
@@ -121,7 +121,7 @@ def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
                 except ValueError:
                     LOG.warning("invalid value for option '%s'", name)
                     continue
-            
+
             options[name] = value
     return options
 

--- a/pyocd/utility/columns.py
+++ b/pyocd/utility/columns.py
@@ -22,13 +22,13 @@ LOG = logging.getLogger(__name__)
 
 class ColumnFormatter(object):
     """! @brief Formats a set of values in multiple columns.
-    
+
     The value_list must be a list of bi-tuples (name, value) sorted in the desired display order.
-    
+
     The number of columns will be determined by the terminal width and maximum value width. The values
     will be printed in column major order.
     """
-    
+
     def __init__(self, maxwidth=None, inset=2):
         """! @brief Constructor.
         @param self The object.
@@ -42,19 +42,19 @@ class ColumnFormatter(object):
         self._items = []
         self._max_name_width = 0
         self._max_value_width = 0
-    
+
     def add_items(self, item_list):
         """! @brief Add items to the output.
         @param self The object.
         @param item_list Must be a list of bi-tuples (name, value) sorted in the desired display order.
         """
         self._items.extend(item_list)
-        
+
         # Update max widths.
         for name, value in item_list:
             self._max_name_width = max(self._max_name_width, len(name))
             self._max_value_width = max(self._max_value_width, len(value))
-    
+
     def format(self):
         """! @brief Return the formatted columns as a string.
         @param self The object.
@@ -63,7 +63,7 @@ class ColumnFormatter(object):
         item_width = self._max_name_width + self._max_value_width  + self._inset * 2 + 2
         column_count = self._term_width // item_width
         row_count = (len(self._items) + column_count - 1) // column_count
-        
+
         rows = [[i for i in self._items[r::row_count]]
                 for r in range(row_count)]
 
@@ -77,7 +77,7 @@ class ColumnFormatter(object):
                     inset=(" " * self._inset))
             txt += "\n"
         return txt
-    
+
     def write(self, output_file=None):
         """! @brief Write the formatted columns to stdout or the specified file.
         @param self The object.
@@ -87,5 +87,5 @@ class ColumnFormatter(object):
         if output_file is None:
             output_file = sys.stdout
         output_file.write(self.format())
-        
+
 

--- a/pyocd/utility/concurrency.py
+++ b/pyocd/utility/concurrency.py
@@ -18,7 +18,7 @@ from functools import wraps
 
 def locked(func):
     """! @brief Decorator to automatically lock a method of a class.
-    
+
     The class is required to have `lock()` and `unlock()` methods.
     """
     @wraps(func)

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -23,10 +23,10 @@ from .mask import align_up
 
 def byte_list_to_nbit_le_list(data, bitwidth, pad=0x00):
     """! @brief Convert a list of bytes to a list of n-bit integers (little endian)
-    
+
     If the length of the data list is not a multiple of `bitwidth` // 8, then the pad value is used
     for the additional required bytes.
-    
+
     @param data List of bytes.
     @param bitwidth Width in bits of the resulting values.
     @param pad Optional value used to pad input data if not aligned to the bitwidth.
@@ -46,7 +46,7 @@ def byte_list_to_nbit_le_list(data, bitwidth, pad=0x00):
 
 def nbit_le_list_to_byte_list(data, bitwidth):
     """! @brief Convert a list of n-bit values into a byte list.
-    
+
     @param data List of n-bit values.
     @param bitwidth Width in bits of the input vales.
     @result List of integer bytes.
@@ -55,7 +55,7 @@ def nbit_le_list_to_byte_list(data, bitwidth):
 
 def byte_list_to_u32le_list(data, pad=0x00):
     """! @brief Convert a list of bytes to a list of 32-bit integers (little endian)
-    
+
     If the length of the data list is not a multiple of 4, then the pad value is used
     for the additional required bytes.
     """
@@ -118,7 +118,7 @@ def float64_to_u64(data):
 def uint_to_hex_le(value, width):
     """! @brief Create an n-digit hexadecimal string from an integer value.
     @param value Integer value to format.
-    @param width The width in bits. 
+    @param width The width in bits.
     @return A string with the number of hex bytes required to fit `width` bits, rounded up to the
         next whole byte. The bytes represent `value` in little-endian order. That is, the first hex
         byte contains the LSB of `value`, while the last hex byte the MSB.

--- a/pyocd/utility/graph.py
+++ b/pyocd/utility/graph.py
@@ -17,9 +17,9 @@
 
 class GraphNode(object):
     """! @brief Simple graph node.
-    
+
     All nodes have a parent, which is None for a root node, and zero or more children.
-    
+
     Supports indexing and iteration over children.
     """
 
@@ -28,34 +28,34 @@ class GraphNode(object):
         super(GraphNode, self).__init__()
         self._parent = None
         self._children = []
-    
+
     @property
     def parent(self):
         """! @brief This node's parent in the object graph."""
         return self._parent
-    
+
     @property
     def children(self):
         """! @brief Child nodes in the object graph."""
         return self._children
-    
+
     @property
     def is_leaf(self):
         """! @brief Returns true if the node has no children."""
         return len(self.children) == 0
-    
+
     def add_child(self, node):
         """! @brief Link a child node onto this object."""
         node._parent = self
         self._children.append(node)
-    
+
     def find_root(self):
         """! @brief Returns the root node of the object graph."""
         root = self
         while root.parent is not None:
             root = root.parent
         return root
-    
+
     def find_children(self, predicate, breadth_first=True):
         """! @brief Recursively search for children that match a given predicate.
         @param self
@@ -76,14 +76,14 @@ class GraphNode(object):
                     results.extend(_search(child, klass))
                 elif breadth_first:
                     childrenToExamine.append(child)
-                
+
             if breadth_first:
                 for child in childrenToExamine:
                     results.extend(_search(child, klass))
             return results
-        
+
         return _search(self, predicate)
-    
+
     def get_first_child_of_type(self, klass):
         """! @brief Breadth-first search for a child of the given class.
         @param self
@@ -97,33 +97,33 @@ class GraphNode(object):
             return matches[0]
         else:
             return None
-    
+
     def __getitem__(self, key):
         """! @brief Returns the indexed child.
-        
+
         Slicing is supported.
         """
         return self._children[key]
-    
+
     def __iter__(self):
         """! @brief Iterate over the node's children."""
         return iter(self.children)
-    
+
     def _dump_desc(self):
         """! @brief Similar to __repr__ by used for dump_to_str()."""
         return str(self)
-    
+
     def dump_to_str(self):
         """! @brief Returns a string describing the object graph."""
-    
+
         def _dump(node, level):
             result = ("  " * level) + "- " + node._dump_desc() + "\n"
             for child in node.children:
                 result += _dump(child, level + 1)
             return result
-    
+
         return _dump(self, 0)
-    
+
     def dump(self):
         """! @brief Pretty print the object graph to stdout."""
         print(self.dump_to_str())

--- a/pyocd/utility/hex.py
+++ b/pyocd/utility/hex.py
@@ -25,7 +25,7 @@ _PRINTABLE = string.digits + string.ascii_letters + string.punctuation + ' '
 
 def format_hex_width(value, width):
     """! @brief Formats the value as hex of the specified bit width.
-    
+
     @param value Integer value to be formatted.
     @param width Bit width, must be one of 8, 16, 32, 64.
     @return String with (width / 8) hex digits. Does not have a "0x" prefix.
@@ -43,27 +43,27 @@ def format_hex_width(value, width):
 
 def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True):
     """! @brief Prints a canonical hex dump of the given data.
-    
+
     Each line of the output consists of an address column, the data as hex, and a printable ASCII
     representation of the data.
-    
+
     The @a width parameter controls grouping of the hex bytes in the output. The bytes of the
     provided data are progressively read as little endian values of the specified bit width, then
     printed at that width. For example, for input data of [0x61 0x62 0x63 0x64], if @width is set to
     8 the output will be "61 62 63 64", for 16 it will be printed as "6261 6463", and for 32 bit
     width it will be shown as "64636261". A space is inserted after each bit-width value, with an
     extra space every 4 bytes for 8 bit width.
-    
+
     The output looks similar to this (width of 8):
     ```
     00000000:  85 89 70 0f  20 b1 ff bc  a9 0c c8 3c  bc a6 47 dd    ..p. ......<..G.
     00000010:  c8 c9 66 ab  59 c8 35 6c  57 94 00 c8  17 35 85 b2    ..f.Y.5lW....5..
     ```
-    
+
     The output is always terminated with a newline.
-    
+
     If you want a string instead of output to a file, use the dump_hex_data_to_str() function.
-    
+
     @param data The data to print as hex. Can be a `bytes`, `bytearray`, or list of integers.
     @param start_address Address of the first byte of the data. Defaults to 0. If set to None,
         then the address column is not printed.
@@ -126,7 +126,7 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
                     d.reverse()
                 s += "".join((chr(b) if (chr(b) in _PRINTABLE) else '.') for b in d)
             output.write(" " * (max_line_width - actual_line_width) + "   " + s + "|")
-        
+
         output.write("\n")
 
 def dump_hex_data_to_str(data, **kwargs):

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -19,20 +19,20 @@ from functools import reduce
 
 def bitmask(*args):
     """! @brief Returns a mask with specified bit ranges set.
-    
+
     An integer mask is generated based on the bits and bit ranges specified by the
     arguments. Any number of arguments can be provided. Each argument may be either
     a 2-tuple of integers, a list of integers, or an individual integer. The result
     is the combination of masks produced by the arguments.
-    
+
     - 2-tuple: The tuple is a bit range with the first element being the MSB and the
           second element the LSB. All bits from LSB up to and included MSB are set.
     - list: Each bit position specified by the list elements is set.
     - int: The specified bit position is set.
-    
+
     @return An integer mask value computed from the logical OR'ing of masks generated
       by each argument.
-    
+
     Example:
     @code
       >>> hex(bitmask((23,17),1))
@@ -56,7 +56,7 @@ def bitmask(*args):
 
 def bit_invert(value, width=32):
     """! @brief Return the bitwise inverted value of the argument given a specified width.
-    
+
     @param value Integer value to be inverted.
     @param width Bit width of both the input and output. If not supplied, this defaults to 32.
     @return Integer of the bitwise inversion of @a value.
@@ -91,11 +91,11 @@ class Bitfield(object):
         self._lsb = lsb if (lsb is not None) else msb
         self._name = name
         assert self._msb >= self._lsb
-    
+
     @property
     def width(self):
         return self._msb - self._lsb + 1
-    
+
     def get(self, value):
         """! @brief Extract the bitfield value from a register value.
         @param self The Bitfield object.
@@ -103,7 +103,7 @@ class Bitfield(object):
         @return Integer value of the bitfield extracted from `value`.
         """
         return bfx(value, self._msb, self._lsb)
-    
+
     def set(self, register_value, field_value):
         """! @brief Modified the bitfield in a register value.
         @param self The Bitfield object.
@@ -112,7 +112,7 @@ class Bitfield(object):
         @return Integer register value with the bitfield updated to `field_value`.
         """
         return bfi(register_value, self._msb, self._lsb, field_value)
-    
+
     def __repr__(self):
         return "<{}@{:x} name={} {}:{}>".format(self.__class__.__name__, id(self), self._name, self._msb, self._lsb)
 
@@ -126,7 +126,7 @@ def msb(n):
 
 def same(d1, d2):
     """! @brief Test whether two sequences contain the same values.
-    
+
     Unlike a simple equality comparison, this function works as expected when the two sequences
     are of different types, such as a list and bytearray. The sequences must return
     compatible types from indexing.

--- a/pyocd/utility/notification.py
+++ b/pyocd/utility/notification.py
@@ -46,17 +46,17 @@ class Notification(object):
 
 class Notifier(object):
     """!@brief Mix-in class that provides notification broadcast capabilities.
-    
+
     In this notification model, subscribers register callbacks for one or more events. The events
     are simply a Python object of any kind, as long as it is hashable. Typically integers or Enums
     are used. Subscriptions can be registered for any sender of an event, or be filtered by the
     sender (called the source).
-    
+
     When a notification is sent to the callback, it is wrapped up as a Notification object. Along
     with the notification, an optional, arbitrary data value can be sent. This allows for further
     specifying the event, or passing related values (or anything else you can think of).
     """
-    
+
     def __init__(self):
         ## Dict of subscribers for particular events and sources.
         #
@@ -75,7 +75,7 @@ class Notifier(object):
 
     def subscribe(self, cb, events, source=None):
         """!@brief Subscribe to selection of events from an optional source.
-        
+
         @param self
         @param cb The callable that will be invoked when a matching notification is sent. Must
             accept a single parameter, a Notification instance.
@@ -87,12 +87,12 @@ class Notifier(object):
         """
         if not isinstance(events, (tuple, list, set)):
             events = [events]
-        
+
         for event in events:
             if event not in self._subscribers:
                 self._subscribers[event] = ([], {})
             event_info = self._subscribers[event]
-            
+
             if source is None:
                 event_info[0].append(cb)
             else:
@@ -102,7 +102,7 @@ class Notifier(object):
 
     def unsubscribe(self, cb, events=None):
         """!@brief Remove a callback from the subscribers list.
-        
+
         @param self
         @param cb The callback to remove from all subscriptions.
         @param events Optional. May be a single event or an iterable of events. If specified, the
@@ -110,16 +110,16 @@ class Notifier(object):
         """
         if (events is not None) and (not isinstance(events, (tuple, list, set))):
             events = [events]
-        
+
         for event, event_info in self._subscribers.items():
             # Skip this event if it's not one on the removal list.
             if (events is not None) and (event not in events):
                 continue
-            
+
             # Remove callback from all-sources list.
             if cb in event_info[0]:
                 event_info[0].remove(cb)
-            
+
             # Scan source-specific subscribers.
             for source_info in event_info[1].values():
                 if cb in source_info:
@@ -127,7 +127,7 @@ class Notifier(object):
 
     def notify(self, event, source=None, data=None):
         """!@brief Notify subscribers of an event.
-        
+
         @param self
         @param event Event to send. Must be a hashable object. It is acceptable to notify for an
             event for which there are no subscribers.
@@ -142,26 +142,26 @@ class Notifier(object):
             # Nobody has subscribed to this event, so nothing to do.
             TRACE.debug("Not sending notification because no subscribers: event=%s", event)
             return
-        
+
         # Look up subscribers for this event + source combo.
         try:
             source_subscribers = event_info[1][source]
         except KeyError:
             # No source-specific subscribers.
             source_subscribers = []
-        
+
         # Create combined subscribers list. Exit if no subscribers matched.
         subscribers = event_info[0] + source_subscribers
         if not subscribers:
             TRACE.debug("Not sending notification because no matching subscribers: event=%s", event)
             return
-        
+
         # Create the notification object now that we know there are some subscribers.
         if source is None:
             source = self
         note = Notification(event, source, data)
         TRACE.debug("Sending notification to %d subscribers: %s", len(subscribers), note)
-        
+
         # Tell everyone!
         for cb in subscribers:
             cb(note)

--- a/pyocd/utility/progress.py
+++ b/pyocd/utility/progress.py
@@ -23,7 +23,7 @@ LOG = logging.getLogger(__name__)
 class ProgressReport(object):
     """!
     @brief Base progress report class.
-    
+
     This base class implements the logic but no output.
     """
     def __init__(self, file=None):
@@ -32,11 +32,11 @@ class ProgressReport(object):
         self.backwards_progress = False
         self.done = False
         self.last = 0
-    
+
     def __call__(self, progress):
         assert progress >= 0.0
 
-        # Cap progress at 1.0.        
+        # Cap progress at 1.0.
         if progress > 1.0:
             progress = 1.0
             LOG.debug("progress out of bounds: %.3f", progress)
@@ -60,7 +60,7 @@ class ProgressReport(object):
                 self._finish()
                 if self.backwards_progress:
                     LOG.debug("Progress went backwards!")
-    
+
     def _start(self):
         self.prev_progress = 0
         self.backwards_progress = False
@@ -76,14 +76,14 @@ class ProgressReport(object):
 class ProgressReportTTY(ProgressReport):
     """!
     @brief Progress report subclass for TTYs.
-    
+
     The progress bar is fully redrawn onscreen as progress is updated to give the
     impression of animation.
     """
 
     ## These width constants can't be changed yet without changing the code below to match.
     WIDTH = 50
-    
+
     def _update(self, progress):
         self._file.write('\r')
         i = int(progress * self.WIDTH)
@@ -96,7 +96,7 @@ class ProgressReportTTY(ProgressReport):
 class ProgressReportNoTTY(ProgressReport):
     """!
     @brief Progress report subclass for non-TTY output.
-    
+
     A simpler progress bar is used than for the TTY version. Only the difference between
     the previous and current progress is drawn for each update, making the output suitable
     for piping to a file or similar output.
@@ -104,7 +104,7 @@ class ProgressReportNoTTY(ProgressReport):
 
     ## These width constants can't be changed yet without changing the code below to match.
     WIDTH = 40
-    
+
     def _start(self):
         super(ProgressReportNoTTY, self)._start()
 
@@ -125,14 +125,14 @@ class ProgressReportNoTTY(ProgressReport):
 def print_progress(file=None):
     """!
     @brief Progress printer factory.
-    
+
     This factory function checks whether the output file is a TTY, and instantiates the
     appropriate subclass of ProgressReport.
-    
+
     @param file The output file. Optional. If not provided, or if set to None, then sys.stdout
           will be used automatically.
     """
-    
+
     if file is None:
         file = sys.stdout
     try:
@@ -141,7 +141,7 @@ def print_progress(file=None):
         # Either the file doesn't have a fileno method, or calling it returned an
         # error. In either case, just assume we're not connected to a TTY.
         istty = False
-    
+
     klass = ProgressReportTTY if istty else ProgressReportNoTTY
     return klass(file)
 

--- a/pyocd/utility/sequencer.py
+++ b/pyocd/utility/sequencer.py
@@ -22,21 +22,21 @@ LOG = logging.getLogger(__name__)
 
 class CallSequence(object):
     """! @brief Call sequence manager.
-    
+
     Contains an ordered sequence of tasks. Each task has a name and associated
     callable. The CallSequence class itself is callable, so instances can be nested
     as tasks within other CallSequences.
-    
+
     When tasks within a sequence are called, they may optionally return a new CallSequence
     instance. If this happens, the new sequence is executed right away, before continuing
     with the next task in the original sequence.
-    
+
     A CallSequence can be iterated over. It will return tuples of (task-name, callable).
     """
 
     def __init__(self, *args):
         """! @brief Constructor.
-        
+
         The constructor accepts an arbitrary number of parameters describing an ordered
         set of tasks. Each parameter must be a 2-tuple with the first element being the
         task's name and the second element a callable that implements the task. If you
@@ -44,64 +44,64 @@ class CallSequence(object):
         """
         self._validate_tasks(args)
         self._calls = OrderedDict(args)
-    
+
     def _validate_tasks(self, tasks):
         for i in tasks:
             assert len(i) == 2
             assert type(i[0]) is str
             assert isinstance(i[1], Callable)
-    
+
     @property
     def sequence(self):
         """! @brief Returns an OrderedDict of the call sequence.
-        
+
         Task names are keys.
         """
         return self._calls
-    
+
     @sequence.setter
     def sequence(self, seq):
         """! @brief Replace the entire call sequence.
-        
+
         Accepts either an OrderedDict or a list of 2-tuples like the constructor.
         """
         if isinstance(seq, OrderedDict):
             self._calls = seq
         elif type(seq) is list and len(seq) and type(seq[0]) is tuple:
             self._calls = OrderedDict(seq)
-    
+
     @property
     def count(self):
         """! @brief Returns the number of tasks in the sequence."""
         return len(self._calls)
-    
+
     def clear(self):
         """! @brief Remove all tasks from the sequence."""
         self._calls = OrderedDict()
-    
+
     def copy(self):
         """! @brief Duplicate the sequence."""
         new_seq = CallSequence()
         new_seq._calls = self._calls.copy()
         return new_seq
-    
+
     def remove_task(self, name):
         """! @brief Remove a task with the given name.
         @exception KeyError Raised if no task with the specified name exists.
         """
         del self._calls[name]
         return self
-    
+
     def has_task(self, name):
         """! @brief Returns a boolean indicating presence of the named task in the sequence."""
         return name in self._calls
-    
+
     def get_task(self, name):
         """! @brief Return the callable for the named task.
         @exception KeyError Raised if no task with the specified name exists.
         """
         return self._calls[name]
-    
+
     def replace_task(self, name, replacement):
         """! @brief Change the callable associated with a task."""
         assert isinstance(replacement, Callable)
@@ -112,10 +112,10 @@ class CallSequence(object):
             # that is already in the dict.
             self._calls[name] = replacement
         return self
-    
+
     def wrap_task(self, name, wrapper):
         """! @brief Wrap an existing task with a new callable.
-        
+
         The wrapper is expected to take a single parameter, the return value from the
         original task. This allows for easy filtering of a new call sequence returned by
         the original task.
@@ -125,15 +125,15 @@ class CallSequence(object):
 
         # Get original callable.
         orig = self._calls[name]
-        
+
         # OrderedDict preserves the order when changing the value of a key
         # that is already in the dict.
         self._calls[name] = lambda : wrapper(orig())
         return self
-    
+
     def append(self, *args):
         """! @brief Append a new task or tasks to the sequence.
-        
+
         Like the constructor, this method takes any number of arguments. Each must be a
         2-tuple task description.
         """
@@ -145,17 +145,17 @@ class CallSequence(object):
 
     def insert_before(self, beforeTaskName, *args):
         """! @brief Insert a task or tasks before a named task.
-        
+
         @param beforeTaskName The name of an existing task. The new tasks will be inserted
           prior to this task.
-        
+
         After the task name parameter, any number of task description 2-tuples may be
         passed.
-        
+
         @exception KeyError Raised if the named task does not exist in the sequence.
         """
         self._validate_tasks(args)
-        
+
         if not self.has_task(beforeTaskName):
             raise KeyError(beforeTaskName)
 
@@ -172,17 +172,17 @@ class CallSequence(object):
 
     def insert_after(self, afterTaskName, *args):
         """! @brief Insert a task or tasks after a named task.
-        
+
         @param afterTaskName The name of an existing task. The new tasks will be inserted
           after this task.
-        
+
         After the task name parameter, any number of task description 2-tuples may be
         passed.
-        
+
         @exception KeyError Raised if the named task does not exist in the sequence.
         """
         self._validate_tasks(args)
-        
+
         if not self.has_task(afterTaskName):
             raise KeyError(afterTaskName)
 
@@ -199,30 +199,30 @@ class CallSequence(object):
 
     def invoke(self):
         """! @brief Execute each task in order.
-        
+
         A task may return a CallSequence, in which case the new sequence is immediately
         executed.
         """
         for name, call in self._calls.items():
             LOG.debug("Running task %s", name)
             resultSequence = call()
-            
+
             # Invoke returned call sequence.
             if resultSequence is not None and isinstance(resultSequence, CallSequence):
 #                 LOG.debug("Invoking returned call sequence: %s", resultSequence)
                 resultSequence.invoke()
-    
+
     def __call__(self, *args, **kwargs):
         """! @brief Another way to execute the tasks.
-        
+
         Supports nested CallSequences.
         """
         self.invoke()
-    
+
     def __iter__(self):
         """! @brief Iterate over the sequence."""
         return iter(self._calls.items())
-    
+
     def __repr__(self):
         s = "<%s@%x: " % (self.__class__.__name__, id(self))
         for name, task in self._calls.items():

--- a/pyocd/utility/server.py
+++ b/pyocd/utility/server.py
@@ -26,18 +26,18 @@ LOG = logging.getLogger(__name__)
 
 class StreamServer(threading.Thread):
     """! @brief File-like object that serves data over a TCP socket.
-    
+
     The user can connect to the socket with telnet or netcat.
-    
+
     The server thread will automatically be started by the constructor. To shut down the
     server and its thread, call the stop() method.
     """
-    
+
     def __init__(self, port, serve_local_only=True, name=None, is_read_only=True, extra_info=None):
         """! @brief Constructor.
-        
+
         Starts the server immediately.
-        
+
         @param self
         @param port The TCP/IP port number on which the server should listen. If 0 is passed,
             then an arbitrary unused port is selected by the OS. In this case, the `port` property
@@ -68,7 +68,7 @@ class StreamServer(threading.Thread):
         self._shutdown_event = threading.Event()
         self.daemon = True
         self.start()
-    
+
     @property
     def port(self):
         return self._port

--- a/pyocd/utility/sockets.py
+++ b/pyocd/utility/sockets.py
@@ -79,22 +79,22 @@ class ListenerSocket(object):
 
 class ClientSocket(object):
     """! @brief Simple client-side TCP socket.
-    
+
     Provides a file-like interface to a TCP socket. Blocking and timeout are configurable.
     """
-    
+
     DEFAULT_TIMEOUT = 10.0
-    
+
     def __init__(self, host, port, packet_size=4096, timeout=None):
         self._address = (host, port)
         self._packet_size = packet_size
         self._timeout = timeout or self.DEFAULT_TIMEOUT
         self._socket = None
         self._buffer = bytearray()
-    
+
     def connect(self):
         self._socket = socket.create_connection(self._address, self._timeout)
-    
+
     def close(self):
         if self._socket is not None:
             # Close both ends of the connection, then close the socket itself.
@@ -122,7 +122,7 @@ class ClientSocket(object):
 
     def write(self, data):
         return self._socket.sendall(data)
-    
+
     def readline(self):
         while True:
             # Try to extract a line from the buffer.

--- a/pyocd/utility/strings.py
+++ b/pyocd/utility/strings.py
@@ -19,21 +19,21 @@ from typing import (Iterable, Sequence, Optional, Tuple)
 
 class UniquePrefixMatcher:
     """! @brief Manages detection of shortest unique prefix match of a set of strings."""
-    
+
     def __init__(self, items: Optional[Iterable[str]] = None):
         """! @brief Constructor.
         @param self This object.
         @param items Optional sequence of strings.
         """
         self._items = set(items) if (items is not None) else set()
-    
+
     def add_items(self, items: Iterable[str]) -> None:
         """! @brief Add some items to be matched.
         @param self This object.
         @param items Sequence of strings.
         """
         self._items.update(items)
-    
+
     def find_all(self, prefix: str) -> Tuple[str, ...]:
         """! @brief Return all items matching the given prefix.
         @param self This object.
@@ -48,7 +48,7 @@ class UniquePrefixMatcher:
         if prefix in self._items:
             return (prefix,)
         return tuple(i for i in self._items if i.startswith(prefix))
-    
+
     def find_one(self, prefix: str) -> Optional[str]:
         """! @brief Return the item matching the given prefix, or None.
         @param self This object.
@@ -66,10 +66,10 @@ _INT_SUFFIX_RE = re.compile(r'[0-9]+$')
 
 def uniquify_name(name: str, others: Sequence[str]) -> str:
     """@brief Ensure the given name is unique amongst the other provided names.
-    
+
     If the `name` parameter is not unique, an integer will be appended to it. If the name already ends in an
     integer, that value will be incremented by 1.
-    
+
     @param name The name to uniqify.
     @param others Sequence of other names to compare against.
     @return A string guaranteed to not be the same as any string contained in `others`.
@@ -87,5 +87,5 @@ def uniquify_name(name: str, others: Sequence[str]) -> str:
 
         # Update the name with the trailing int incremented.
         name += str(u_value + 1)
-    
+
     return name

--- a/pyocd/utility/timeout.py
+++ b/pyocd/utility/timeout.py
@@ -20,11 +20,11 @@ from typing import Optional
 
 class Timeout:
     """! @brief Timeout helper context manager.
-    
+
     The recommended way to use this class is demonstrated here. It uses an else block on a
     while loop to handle the timeout. The code in the while loop must use a break statement
     to exit in the successful case.
-    
+
     @code
     with Timeout(5, sleeptime=0.1) as t_o:
         while t_o.check(): # or "while not t_o.did_time_out"
@@ -34,10 +34,10 @@ class Timeout:
         else:
             print("Timed out!")
     @endcode
-    
+
     Another method of using the class is to check the `did_time_out` property from within the
     while loop, as shown below.
-    
+
     @code
     with Timeout(5) as t_o:
         while perform_some_test():
@@ -47,14 +47,14 @@ class Timeout:
                 break
             sleep(0.1)
     @endcode
-    
+
     You may also combine the call to check() in the while loop with other boolean expressions
     related to the operation being performed.
-    
+
     If you pass a non-zero value for _sleeptime_ to the constructor, the check() method will
     automatically sleep by default starting with the second call. You can disable auto-sleep
     by passing `autosleep=False` to check().
-    
+
     Passing a timeout of None to the constructor is allowed. In this case, check() will always return
     True and the loop must be exited via some other means.
     """
@@ -92,10 +92,10 @@ class Timeout:
         self._start = time()
         self._timed_out = False
         self._is_first_check = True
-    
+
     def clear(self):
         """! @brief Reset the timeout back to initial, non-running state.
-        
+
         The timeout can be made to run again by calling start().
         """
         self._is_running = False
@@ -104,19 +104,19 @@ class Timeout:
 
     def check(self, autosleep: bool = True) -> bool:
         """! @brief Check for timeout and possibly sleep.
-        
+
         Starting with the second call to this method, it will automatically sleep before returning
         if:
             - The timeout has not yet occurred.
             - A non-zero _sleeptime_ was passed to the constructor.
             - The _autosleep_ parameter is True.
-        
+
         This method is intended to be used as the predicate of a while loop.
 
         If this method is called prior to the timeout being started (by the start() method or entering
         it as a context manager) this the return value will always be True (not timeed out). Only after
         the timeout is running will the elapsed time be tested.
-        
+
         @param self
         @param autosleep Whether to sleep if not timed out yet. The sleeptime passed to the
             constructor must have been non-zero.
@@ -131,7 +131,7 @@ class Timeout:
             sleep(self._sleeptime)
         self._is_first_check = False
         return not self._timed_out
-    
+
     @property
     def is_running(self) -> bool:
         """! @brief Whether the timeout object has started timing."""

--- a/src/gdb_test_program/linker_script.ld
+++ b/src/gdb_test_program/linker_script.ld
@@ -39,12 +39,12 @@ SECTIONS
     . = ALIGN(4);
     *(.data)           /* .data sections */
     *(.data*)          /* .data* sections */
-    
+
     . = ALIGN(4);
     *(.bss)
     *(.bss*)
     *(COMMON)
-    
+
     . = ALIGN(4);
     *(.rodata)         /* .rodata sections (constants, strings, etc.) */
     *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */

--- a/src/gdb_test_program/main.c
+++ b/src/gdb_test_program/main.c
@@ -28,22 +28,22 @@ volatile uint32_t watchpoint_write_buffer[3];
 
 void function_1()
 {
-    
+
 }
 
 void function_2()
 {
-    
+
 }
 
 void function_3()
 {
-    
+
 }
 
 void breakpoint_test()
 {
-    
+
 }
 
 void watchpoint_test()
@@ -75,7 +75,7 @@ void watchpoint_test()
 int main()
 {
     int i;
-    
+
     // Initialize variables
     run_breakpoint_test = 0;
     watchpoint_write = 0;

--- a/test/basic_test.py
+++ b/test/basic_test.py
@@ -53,7 +53,7 @@ RANGE_STEP_CODE = u16le_list_to_byte_list([
 class BasicTest(Test):
     def __init__(self):
         super(BasicTest, self).__init__("Basic Test", run_basic_test)
-    
+
 def run_basic_test(board_id):
     return basic_test(board_id, None)
 
@@ -171,7 +171,7 @@ def basic_test(board_id, file):
             print("Failed to write range step test code to RAM")
         else:
             print("wrote range test step code to RAM successfully")
-        
+
         target.write_core_register('pc', test_addr)
         currentPC = target.read_core_register('pc')
         print("start PC: 0x%X" % currentPC)
@@ -288,7 +288,7 @@ def basic_test(board_id, file):
         data = target.read_memory_block8(address, sector_size)
         if data != [flash.region.erased_byte_value] * sector_size:
             print("FAILED to erase sector @ 0x%x (%d bytes)" % (address, sector_size))
-       
+
         # Re-verify the 1st and 3rd page were not erased, and that the 2nd page is fully erased
         did_pass = False
         for i in range(0, sectors_to_test):

--- a/test/commander_test.py
+++ b/test/commander_test.py
@@ -66,21 +66,21 @@ def commander_test(board_id):
     test_count = 0
     failed_commands = []
     result = CommanderTestResult()
-    
+
     COMMANDS_TO_TEST = [
             # general commands
             ["continue"],
             ["status"],
             ["halt"],
             ["status"],
-            
+
             # commander command group - these are not tested by commands_test.py.
             ["list"],
             ["exit"], # Must be last command!
             ]
 
     print("\n------ Testing commander ------\n")
-    
+
     # Set up commander args.
     args = UserDict()
     args.no_init = False
@@ -96,7 +96,7 @@ def commander_test(board_id):
     args.unique_id = board_id
     args.target_override = None
     args.elf = GDB_TEST_ELF
-    
+
     test_count += 1
     try:
         cmdr = PyOCDCommander(args, COMMANDS_TO_TEST)
@@ -106,7 +106,7 @@ def commander_test(board_id):
     except Exception:
         print("TEST FAILED")
         traceback.print_exc()
-        
+
     test_count += 1
     print("Testing exit code")
     print("Exit code:", cmdr.exit_code)

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -81,7 +81,7 @@ def commands_test(board_id):
         temp_test_hex_name = binary_to_hex_file(binary_file, boot_region.start)
 
         temp_bin_file = tempfile.mktemp('.bin')
-        
+
         with open(binary_file, "rb") as f:
             test_data = list(bytearray(f.read()))
         test_data_length = len(test_data)
@@ -93,10 +93,10 @@ def commands_test(board_id):
         test_count = 0
         failed_commands = []
         result = CommandsTestResult()
-        
+
         context = CommandExecutionContext()
         context.attach_session(session)
-        
+
         COMMANDS_TO_TEST = [
                 "status",
                 "reset",
@@ -183,10 +183,10 @@ def commands_test(board_id):
                 "set step-into-interrupts 1",
                 "set log info",
                 "set frequency %d" % test_params['test_clock'],
-                
+
                 # Semicolon-separated commands.
                 'rw 0x%08x ; rw 0x%08x' % (ram_base, ram_base + 4),
-                
+
                 # Python and system commands.
                 '$2+ 2',
                 '!echo hello',
@@ -203,10 +203,10 @@ def commands_test(board_id):
 #                 "where",
 #                 "symbol",
                 ]
-        
+
         # For now we just verify that the commands run without raising an exception.
         print("\n------ Testing commands ------")
-        
+
         def test_command(cmd):
             try:
                 print("\nTEST: %s" % cmd)

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -56,7 +56,7 @@ class CortexTestResult(TestResult):
         "run_halt",
         "gdb_step",
         ]
-    
+
     def __init__(self):
         super(CortexTestResult, self).__init__(None, None, None)
         self.name = "cortex"
@@ -218,7 +218,7 @@ def cortex_test(board_id):
             print("Software reset (default=emulated)")
             target.selected_core.default_reset_type = Target.ResetType.SW_EMULATED
             fnc(reset_type=None)
-            
+
             print("(Default) Software reset (SYSRESETREQ)")
             target.selected_core.default_software_reset_type = Target.ResetType.SW_SYSRESETREQ
             fnc(reset_type=Target.ResetType.SW)
@@ -228,7 +228,7 @@ def cortex_test(board_id):
             print("(Default) Software reset (emulated)")
             target.selected_core.default_software_reset_type = Target.ResetType.SW_EMULATED
             fnc(reset_type=Target.ResetType.SW)
-            
+
             print("Software reset (option=default)")
             target.selected_core.default_reset_type = Target.ResetType.SW
             target.selected_core.default_software_reset_type = Target.ResetType.SW_SYSRESETREQ
@@ -251,7 +251,7 @@ def cortex_test(board_id):
             fnc(reset_type=None)
 
         reset_methods(target.reset)
-        
+
         # Test passes if there are no exceptions
         test_pass_count += 1
         test_count += 1
@@ -312,11 +312,11 @@ def cortex_test(board_id):
             print("TEST PASSED")
         else:
             print("TEST FAILED")
-            
+
         # Restore regs
         origRegs[0] = origR0
         target.write_core_registers_raw(['r0', 'r1', 'r2', 'r3'], origRegs)
-        
+
         print("Verify exception is raised while core is running")
         target.resume()
         try:
@@ -331,7 +331,7 @@ def cortex_test(board_id):
             print("TEST PASSED")
         else:
             print("TEST FAILED")
-        
+
         print("Verify failure to write core register while running raises exception")
         try:
             target.write_core_register('r0', 0x1234)
@@ -345,7 +345,7 @@ def cortex_test(board_id):
             print("TEST PASSED")
         else:
             print("TEST FAILED")
-        
+
         # Resume execution.
         target.halt()
 
@@ -404,11 +404,11 @@ def cortex_test(board_id):
             else:
                 print("TEST FAILED (0x%08x==0x%08x, %f==%f, 0x%08x==0x%08x, %f==%f)" \
                     % (vals[0], _1p1, s0, 1.1, vals[1], _2p2, s1, 2.2))
-            
+
             # Restore s0
             origRegs[0] = origRawS0
             target.write_core_registers_raw(['s0', 's1'], origRegs)
-        
+
         print("Verify that all listed core registers can be accessed")
         reg_count = 0
         passed_reg_count = 0

--- a/test/debug_context_test.py
+++ b/test/debug_context_test.py
@@ -88,24 +88,24 @@ def debug_context_test(board_id):
         with open(binary_file, "rb") as f:
             test_binary_data = bytearray(f.read())
         test_binary_data_length = len(test_binary_data)
-        
+
         # Generate ELF file from the binary test file.
         temp_test_elf_name = binary_to_elf_file(binary_file, boot_region.start)
 
         test_pass_count = 0
         test_count = 0
         result = DebugContextTestResult()
-        
+
         target.reset_and_halt()
-        
+
         # Reproduce a gdbserver failure.
         print("\n------ Test 1: Mem cache ------")
-        
+
         ctx = target.get_target_context()
 
         print("Writing gdb test binary")
         ctx.write_memory_block8(ram_base, gdb_test_binary_data)
-        
+
         print("Reading first chunk")
         data = ctx.read_memory_block8(ram_base, 64)
         if data == gdb_test_binary_data[:64]:
@@ -114,7 +114,7 @@ def debug_context_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-            
+
         print("Reading N chunks")
         did_pass = True
         for n in range(8):
@@ -129,20 +129,20 @@ def debug_context_test(board_id):
             print("TEST PASSED")
         else:
             print("TEST FAILED")
-        
+
         # Force a memory cache clear.
         target.step()
-        
+
         # ELF reader test goals:
         # 1. Verify correct data is read without accessing the target memory.
         # 2. Test null interval failure.
         #
         print("\n------ Test 2: ELF reader ------")
-        
+
         # Set the elf on the target, which will add a context to read from the elf.
         target.elf = temp_test_elf_name
         ctx = target.get_target_context()
-        
+
         print("Check that ElfReaderContext was created")
         if isinstance(ctx, ElfReaderContext):
             test_pass_count += 1
@@ -150,7 +150,7 @@ def debug_context_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         # Program the test binary.
         print("Programming test binary to boot memory")
         FileProgrammer(session).program(binary_file, base_address=boot_region.start)

--- a/test/flash_loader_test.py
+++ b/test/flash_loader_test.py
@@ -86,18 +86,18 @@ def flash_loader_test(board_id):
 
         # Generate an Intel hex file from the binary test file.
         temp_test_hex_name = binary_to_hex_file(binary_file, boot_region.start)
-        
+
         # Generate ELF file from the binary test file.
         temp_test_elf_name = binary_to_elf_file(binary_file, boot_region.start)
 
         test_pass_count = 0
         test_count = 0
         result = FlashLoaderTestResult()
-        
+
         with open(binary_file, "rb") as f:
             data = list(bytearray(f.read()))
         data_length = len(data)
-        
+
         print("\n------ Test Basic Load ------")
         loader = FlashLoader(session, chip_erase="sector")
         loader.add_data(boot_start_addr, data)
@@ -109,7 +109,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test Load Sector Erase ------")
         test_data = [0x55] * boot_blocksize
         addr = (boot_end_addr + 1) - (boot_blocksize * num_test_sectors)
@@ -117,12 +117,12 @@ def flash_loader_test(board_id):
             orig_data_length = addr - boot_start_addr
         else:
             orig_data_length = data_length
-        
+
         loader = FlashLoader(session, chip_erase="sector")
         loader.add_data(addr, test_data)
         loader.add_data(addr + boot_blocksize, test_data)
         loader.commit()
-        
+
         verify_data = target.read_memory_block8(addr, boot_blocksize * num_test_sectors)
         verify_data2 = target.read_memory_block8(boot_start_addr, orig_data_length)
         if same(verify_data, test_data * num_test_sectors) and same(verify_data2, data[:orig_data_length]):
@@ -131,7 +131,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test Basic Sector Erase ------")
         addr = (boot_end_addr + 1) - (boot_blocksize * num_test_sectors)
         eraser = FlashEraser(session, FlashEraser.Mode.SECTOR)
@@ -143,7 +143,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test Load Chip Erase ------")
         loader = FlashLoader(session, chip_erase="chip")
         loader.add_data(boot_start_addr, data)
@@ -155,7 +155,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test Binary File Load ------")
         programmer = FileProgrammer(session)
         programmer.program(binary_file, file_format='bin', base_address=boot_start_addr)
@@ -166,7 +166,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test Intel Hex File Load ------")
         programmer = FileProgrammer(session)
         programmer.program(temp_test_hex_name, file_format='hex')
@@ -177,7 +177,7 @@ def flash_loader_test(board_id):
         else:
             print("TEST FAILED")
         test_count += 1
-        
+
         print("\n------ Test ELF File Load ------")
         programmer = FileProgrammer(session)
         programmer.program(temp_test_elf_name, file_format='elf')

--- a/test/flash_test.py
+++ b/test/flash_test.py
@@ -142,7 +142,7 @@ def flash_test(board_id):
         test_pass_count = 0
         test_count = 0
         result = FlashTestResult()
-        
+
         # Test each flash region separately.
         for rom_region in memory_map.iter_matching_regions(type=MemoryType.FLASH, is_testable=True):
             rom_start = rom_region.start
@@ -150,7 +150,7 @@ def flash_test(board_id):
 
             flash = rom_region.flash
             flash_info = flash.get_flash_info()
-            
+
             # This can be any value, as long as it's not the erased byte value. We take the
             # inverse of the erased value so that for most flash, the unerased value is 0x00.
             unerasedValue = invert32(flash.region.erased_byte_value) & 0xff
@@ -162,7 +162,7 @@ def flash_test(board_id):
                 data = f.read()
             data = struct.unpack("%iB" % len(data), data)
             unused = rom_size - len(data)
-            
+
             # Make sure data doesn't overflow this region.
             if unused < 0:
                 data = data[:rom_size]
@@ -173,7 +173,7 @@ def flash_test(board_id):
 
             # Turn on extra checks for the next 4 tests
             flash.set_flash_algo_debug(True)
-            
+
             print("\n------ Test Erased Value Check ------")
             d = [flash.region.erased_byte_value] * 128
             if flash.region.is_data_erased(d):

--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -114,7 +114,7 @@ def test_gdb(board_id=None, n=0):
         target_test_params = get_target_test_params(session)
         test_port = 3333 + n
         telnet_port = 4444 + n
-        
+
         # Hardware breakpoints are not supported above 0x20000000 on
         # Cortex-M devices with FPB revision 1.
         fpb = session.target.selected_core.fpb

--- a/test/gdb_test_script.py
+++ b/test/gdb_test_script.py
@@ -220,7 +220,7 @@ def run_test():
 
         # Connect to server
         gdb_execute("target remote localhost:%d" % test_port)
-        
+
         # Show memory regions, useful for debug and verification.
         gdb_execute("info mem")
 

--- a/test/import_all.py
+++ b/test/import_all.py
@@ -29,15 +29,15 @@ def process_dir(dotted_path: str, dir_path: Path) -> None:
     for entry in sorted(dir_path.iterdir(), key=lambda v: v.name):
         is_subpackage = (entry.is_dir() and (entry / "__init__.py").exists())
         is_module = entry.suffix == ".py"
-        
+
         if not (is_subpackage or is_module):
             continue
-        
+
         module_path = dotted_path + '.' + entry.stem
         print(f"Importing: {module_path}")
         import_module(module_path)
         import_count += 1
-        
+
         # Recursive into valid sub-packages.
         if is_subpackage:
             process_dir(module_path, entry)

--- a/test/probeserver_test.py
+++ b/test/probeserver_test.py
@@ -100,7 +100,7 @@ def test_probeserver(board_id=None, n=0):
             board_id = board.unique_id
         target_type = board.target_type
 
-    # Run the test. We can't kill the server thread, so 
+    # Run the test. We can't kill the server thread, so
     LOG.info('Starting server on port %d', test_port)
     server_args = ['pyocd', 'server',
             '-v',
@@ -108,7 +108,7 @@ def test_probeserver(board_id=None, n=0):
             "--uid=%s" % board_id,
             ]
     server_program = Popen(server_args, stdout=PIPE, stderr=STDOUT)
-    
+
     try:
         # Read server output waiting for it to report that the server is running.
         with Timeout(TEST_TIMEOUT_SECONDS) as time_out:
@@ -121,7 +121,7 @@ def test_probeserver(board_id=None, n=0):
                     raise TestError("no more output from server")
             else:
                 raise TestError("server failed to start")
-    
+
         server_thread = threading.Thread(target=wait_with_deadline, args=[server_program, TEST_TIMEOUT_SECONDS])
         server_thread.daemon = True
         server_thread.start()

--- a/test/speed_test.py
+++ b/test/speed_test.py
@@ -108,7 +108,7 @@ def speed_test(board_id):
 
         test_params = get_target_test_params(session)
         session.probe.set_clock(test_params['test_clock'])
-        
+
         test_config = "uncached 8-bit"
 
         def test_ram(record_speed=False, width=8):
@@ -185,44 +185,44 @@ def speed_test(board_id):
             print("Reading %i byte took %.3f seconds: %.3f B/s" % (test_size, diff, read_speed))
             print("TEST PASSED")
             return True
-        
+
         # 8-bit without memcache
         passed = test_ram(True, 8)
         test_count += 1
         test_pass_count += int(passed)
-        
+
         passed = test_rom(True, 8)
         test_count += 1
         test_pass_count += int(passed)
-        
+
         # 32-bit without memcache
         test_config = "uncached 32-bit"
         passed = test_ram(False, 32)
         test_count += 1
         test_pass_count += int(passed)
-        
+
         passed = test_rom(False, 32)
         test_count += 1
         test_pass_count += int(passed)
-        
+
         # With memcache
         target = target.get_target_context()
         test_config = "cached 8-bit, pass 1"
-        
+
         passed = test_ram()
         test_count += 1
         test_pass_count += int(passed)
-        
+
         passed = test_rom()
         test_count += 1
         test_pass_count += int(passed)
-        
+
         # Again with memcache
         test_config = "cached 8-bit, pass 2"
         passed = test_ram()
         test_count += 1
         test_pass_count += int(passed)
-        
+
         passed = test_rom()
         test_count += 1
         test_pass_count += int(passed)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -155,7 +155,7 @@ def wait_with_deadline(process, timeout):
 class IOTee(object):
     def __init__(self, *args):
         self.outputs = list(args)
-    
+
     def add(self, output):
         self.outputs.append(output)
 
@@ -171,7 +171,7 @@ class RecordingLogHandler(logging.Handler):
     def __init__(self, iostream, level=logging.NOTSET):
         super(RecordingLogHandler, self).__init__(level)
         self.stream = iostream
-    
+
     def emit(self, record):
         try:
             message = self.format(record)
@@ -189,11 +189,11 @@ class TestResult(object):
         self.name = "test"
         self.time = 0
         self.output = ""
-    
+
     @property
     def board(self):
         return self._board
-    
+
     @board.setter
     def board(self, newBoard):
         self._board = newBoard.target_type if newBoard else 'unknown'
@@ -220,7 +220,7 @@ class TestResult(object):
         system_out = ElementTree.SubElement(case, 'system-out')
         system_out.text = self.filter_output(self.output)
         return case
-    
+
     def filter_output(self, output):
         """! @brief Hex-encode null byte and control characters."""
         result = six.text_type()
@@ -285,4 +285,4 @@ class Test(object):
         if len(result_list) <= 0:
             passed = False
         return passed
-            
+

--- a/test/unit/mockcore.py
+++ b/test/unit/mockcore.py
@@ -59,7 +59,7 @@ class MockCore(CoreSightCoreComponent, MemoryInterface):
         if has_fpu:
             self.core_registers.add_group(CoreRegisterGroups.VFP_V5)
         self.clear_all_regs()
-    
+
     def clear_all_regs(self):
         self.regs = {i:0 for i in self.core_registers.by_index.keys()} # r0-15, xpsr, msp, psp
         self.regs[CFBP_INDEX] = 0

--- a/test/unit/test_cmdline.py
+++ b/test/unit/test_cmdline.py
@@ -45,7 +45,7 @@ class TestSplitCommandLine(object):
         assert split_command_line('a\rb') == ['a', 'b']
         assert split_command_line('a\nb') == ['a', 'b']
         assert split_command_line('a   \tb') == ['a', 'b']
-    
+
     @pytest.mark.parametrize(("input", "result"), [
         (r'\h\e\l\l\o', ['hello']),
         (r'"\"hello\""', ['"hello"']),
@@ -79,14 +79,14 @@ class TestConvertVectorCatch(object):
         [(six.b(x), y) for x,y in VECTOR_CATCH_CHAR_MAP.items()])
     def test_vc_b(self, vc, msk):
         assert convert_vector_catch(vc) == msk
-        
+
 class TestConvertSessionOptions(object):
     def test_empty(self):
         assert convert_session_options([]) == {}
-    
+
     def test_unknown_option(self):
         assert convert_session_options(['dumkopf']) == {}
-    
+
     def test_bool(self):
         assert convert_session_options(['auto_unlock']) == {'auto_unlock': True}
         assert convert_session_options(['no-auto_unlock']) == {'auto_unlock': False}
@@ -97,12 +97,12 @@ class TestConvertSessionOptions(object):
         assert convert_session_options(['auto_unlock=0']) == {'auto_unlock': False}
         assert convert_session_options(['auto_unlock=false']) == {'auto_unlock': False}
         assert convert_session_options(['auto_unlock=anything-goes-here']) == {'auto_unlock': False}
-    
+
     def test_noncasesense(self):
         # Test separate paths for with and without a value.
         assert convert_session_options(['AUTO_Unlock']) == {'auto_unlock': True}
         assert convert_session_options(['AUTO_Unlock=0']) == {'auto_unlock': False}
-    
+
     def test_int(self):
         # Non-bool with no value is ignored (and logged).
         assert convert_session_options(['frequency']) == {}
@@ -114,7 +114,7 @@ class TestConvertSessionOptions(object):
         assert convert_session_options(['frequency=1000']) == {'frequency': 1000}
         # Valid hex int
         assert convert_session_options(['frequency=0x40']) == {'frequency': 64}
-    
+
     def test_str(self):
         # Ignore with no value
         assert convert_session_options(['test_binary']) == {}
@@ -122,5 +122,5 @@ class TestConvertSessionOptions(object):
         assert convert_session_options(['no-test_binary']) == {}
         # Valid
         assert convert_session_options(['test_binary=abc']) == {'test_binary': 'abc'}
-        
+
 

--- a/test/unit/test_compatibility.py
+++ b/test/unit/test_compatibility.py
@@ -30,11 +30,11 @@ class TestCompatibility(object):
         assert next(i) == b'2'
         assert next(i) == b'3'
         assert next(i) == b'4'
-    
+
     def test_to_bytes_safe(self):
         assert to_bytes_safe(b"hello") == b"hello"
         assert to_bytes_safe("string") == b"string"
-    
+
     def test_to_str_safe(self):
         assert to_str_safe(b"bytes") == "bytes"
         assert to_str_safe("string") == "string"

--- a/test/unit/test_conversion.py
+++ b/test/unit/test_conversion.py
@@ -114,7 +114,7 @@ class TestConversionUtilities(object):
 
     def test_byte_list_to_u32le_list_empty(self):
         assert byte_list_to_u32le_list([]) == []
-        
+
     def test_byteListToU32leList(self):
         data = range(32)
         assert byte_list_to_u32le_list(data) == [
@@ -127,7 +127,7 @@ class TestConversionUtilities(object):
             0x1B1A1918,
             0x1F1E1D1C,
         ]
-    
+
     def test_byte_list_to_u32le_list_unaligned(self):
         assert byte_list_to_u32le_list([1]) == [0x00000001]
         assert byte_list_to_u32le_list([1, 2, 3]) == [0x00030201]
@@ -193,10 +193,10 @@ class TestConversionUtilities(object):
 
     def test_hex16ToU64le(self):
         assert hex16_to_u64le("0102ABCD171819EF") == 0x0102ABCD171819EF
-    
+
     def test_uint_to_hex_le_odd_width(self):
         assert uint_to_hex_le(0xd0102ABCD, 36) == "cdab02010d"
-    
+
     def test_hex_le_to_uint_odd_width(self):
         assert hex_le_to_uint("0102ABCD0d", 36) == 0x0dCDAB0201
 
@@ -248,7 +248,7 @@ class TestGdbEscape(object):
         [six.int2byte(x) for x in range(256) if (x not in ESCAPEES)])
     def test_escape_passthrough(self, data):
         assert escape(data) == data
-    
+
     @pytest.mark.parametrize(("data", "expected"), [
             (b'#', b'}\x03'),
             (b'$', b'}\x04'),
@@ -257,16 +257,16 @@ class TestGdbEscape(object):
         ])
     def test_escape_1(self, data, expected):
         assert escape(data) == expected
-    
+
     def test_escape_2(self):
         assert escape(b'1234#09*xyz') == b'1234}\x0309}\x0axyz'
-    
+
     # Verify all chars that shouldn't be escaped pass through unmodified.
     @pytest.mark.parametrize("data",
         [six.int2byte(x) for x in range(256) if (x not in ESCAPEES)])
     def test_unescape_passthrough(self, data):
         assert unescape(data) == [six.byte2int(data)]
-    
+
     @pytest.mark.parametrize(("expected", "data"), [
             (0x23, b'}\x03'),
             (0x24, b'}\x04'),
@@ -275,7 +275,7 @@ class TestGdbEscape(object):
         ])
     def test_unescape_1(self, data, expected):
         assert unescape(data) == [expected]
-    
+
     def test_unescape_2(self):
         assert unescape(b'1234}\x0309}\x0axyz') == \
             [0x31, 0x32, 0x33, 0x34, 0x23, 0x30, 0x39, 0x2a, 0x78, 0x79, 0x7a]
@@ -283,9 +283,9 @@ class TestGdbEscape(object):
 class TestPairwise(object):
     def test_empty(self):
         assert list(pairwise([])) == []
-    
+
     def test_str(self):
         assert list(pairwise('abcdef')) == [('a','b'), ('c','d'), ('e','f')]
-    
+
     def test_int(self):
         assert list(pairwise([1, 2, 3, 4, 5, 6])) == [(1, 2), (3, 4), (5, 6)]

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -23,12 +23,12 @@ class TestFaultError:
     def test_no_args(self):
         e = TransferFaultError()
         assert str(e) == 'Memory transfer fault'
-    
+
     def test_no_args_set_addr(self):
         e = TransferFaultError()
         e.fault_address = 0x1000
         assert str(e) == 'Memory transfer fault @ 0x00001000'
-    
+
     def test_no_args_set_addr_len(self):
         e = TransferFaultError()
         e.fault_address = 0x1000
@@ -42,12 +42,12 @@ class TestFaultError:
     def test_arg_tuple(self):
         e = TransferFaultError(-1, 1234)
         assert str(e) == 'Memory transfer fault (-1, 1234)'
-    
+
     def test_msg_ctor_addr(self):
         e = TransferFaultError("my bad", fault_address=0x20008400)
         assert e.fault_address == 0x20008400
         assert str(e) == 'Memory transfer fault (my bad) @ 0x20008400'
-    
+
     def test_msg_ctor_addr_len(self):
         e = TransferFaultError("my bad", fault_address=0x20008400, length=32)
         assert e.fault_address == 0x20008400

--- a/test/unit/test_graph.py
+++ b/test/unit/test_graph.py
@@ -22,7 +22,7 @@ class BaseNode(GraphNode):
     def __init__(self, value):
         super(BaseNode, self).__init__()
         self.value = value
-    
+
     def __repr__(self):
         return "<{}@{:#010x} {}".format(self.__class__.__name__, id(self), self.value)
 
@@ -83,7 +83,7 @@ class TestGraph:
         assert a.children == []
         assert b.children == []
         assert c.children == []
-    
+
     def test_multilevel(self, graph, a, b, c):
         assert len(graph.children) == 2
         assert graph.children == [a, c]
@@ -95,17 +95,17 @@ class TestGraph:
         assert c.parent is graph
         assert b.children == []
         assert c.children == []
-    
+
     def test_find_breadth(self, graph, a, b, c):
         assert graph.find_children(lambda n: n.value == 1) == [b]
         assert graph.find_children(lambda n: n.value == 1 or n.value == 2) == [c, b]
-    
+
     def test_find_depth(self, graph, a, b, c):
         assert graph.find_children(lambda n: n.value == 1, breadth_first=False) == [b]
         assert graph.find_children(lambda n: n.value == 1 or n.value == 2, breadth_first=False) == [b, c]
-    
+
     def test_first(self, graph, a, b, c):
         assert graph.get_first_child_of_type(NodeA) == a
         assert graph.get_first_child_of_type(NodeB) == c
         assert a.get_first_child_of_type(NodeB) == b
-        
+

--- a/test/unit/test_memcache.py
+++ b/test/unit/test_memcache.py
@@ -135,7 +135,7 @@ class TestMemoryCache:
 
     def test_21_empty_write(self, memcache):
         memcache.write_memory_block8(128, [])
-    
+
     # This test reproduces a bug where writes followed by reads will start
     # accumulating and returning extra data.
     def test_22_multi_write_read_size(self, memcache):
@@ -173,14 +173,14 @@ class TestMemoryCache:
             memcache.write_memory_block8(64, data[64:96])
         block = memcache.read_memory_block8(0, test_size)
         assert data == block
-    
+
     def test_26_read_subrange(self, memcache):
         data = list((n % 256) for n in range(320))
         memcache.write_memory_block8(0x20000000, data)
         block = memcache.read_memory_block8(0x2000007e, 4)
         assert block == data[0x7e:0x82]
 
-     
+
 
 # TODO test read32/16/8 with and without callbacks
 

--- a/test/unit/test_memory_map.py
+++ b/test/unit/test_memory_map.py
@@ -94,27 +94,27 @@ class TestRange:
         assert range.start == 0x1000
         assert range.end == 0xfff
         assert range.length == 0
-    
+
     def test_empty_range_2(self):
         range = MemoryRange(start=0x1000, end=0xfff)
         assert range.start == 0x1000
         assert range.end == 0xfff
         assert range.length == 0
-    
+
     def test_eq(self):
         assert MemoryRange(0, length=1000) == MemoryRange(0, length=1000)
-    
+
     def test_lt(self):
         assert MemoryRange(0, length=1000) < MemoryRange(1000, length=1000)
-    
+
     def test_gt(self):
         assert MemoryRange(1000, length=1000) > MemoryRange(0, length=1000)
-    
+
     def test_sort(self, ram1, ram2, flash, rom):
         regionList = [ram2, rom, flash, ram1]
         sortedRegionList = sorted(regionList)
         assert sortedRegionList == [flash, rom, ram1, ram2]
-    
+
     def test_inplace_sort(self, ram1, ram2, flash, rom):
         regionList = [ram2, rom, flash, ram1]
         regionList.sort()
@@ -135,7 +135,7 @@ class TestHash:
         a = MemoryRange(0, 0x1000, region=ram1)
         b = MemoryRange(0x5000, length=200, region=rom)
         assert hash(a) != hash(b)
-        
+
         a = MemoryRange(0, 0x1000, region=ram1)
         b = MemoryRange(0, 0x1000, region=rom)
         assert hash(a) != hash(b)
@@ -150,11 +150,11 @@ class TestMemoryRegion:
     def test_empty_region_1(self):
         with pytest.raises(AssertionError):
             rgn = MemoryRegion(start=0x1000, length=0)
-    
+
     def test_empty_region_2(self):
         with pytest.raises(AssertionError):
             rgn = MemoryRegion(start=0x1000, end=0xfff)
-    
+
     def test_default_name(self):
         rgn = RamRegion(start=0x1000, end=0x1fff)
         assert rgn.name == 'ram'
@@ -167,7 +167,7 @@ class TestMemoryRegion:
 
         rgn = DeviceRegion(start=0x1000, end=0x1fff)
         assert rgn.name == 'device'
-    
+
     def test_block_sector_size(self):
         rgn = FlashRegion(start=0x1000, end=0x1fff, blocksize=256)
         assert rgn.blocksize == 256
@@ -176,7 +176,7 @@ class TestMemoryRegion:
         rgn = FlashRegion(start=0x1000, end=0x1fff, sector_size=256)
         assert rgn.blocksize == 256
         assert rgn.sector_size == 256
-    
+
     def test_flash_attrs(self, flash):
         assert flash.type == MemoryType.FLASH
         assert flash.start == 0
@@ -299,7 +299,7 @@ class TestMemoryRegion:
         assert ram1.intersects_range(0x20000020, length=0x10)
         assert ram1.intersects_range(0x1fff0000, end=0x20001000)
         assert ram1.intersects_range(0x1ffff000, length=0x40000)
-    
+
     def test_copy_ram(self, ram1):
         ramcpy = copy.copy(ram1)
         assert ramcpy.type == ram1.type
@@ -308,20 +308,20 @@ class TestMemoryRegion:
         assert ramcpy.length == ram1.length
         assert ramcpy.name == ram1.name
         assert ramcpy == ram1
-    
+
     def test_copy_flash(self, flash):
         flashcpy = copy.copy(flash)
         assert flashcpy == flash
-    
+
     def test_copy_flash_with_flm(self, flash_with_flm):
         flashcpy = copy.copy(flash_with_flm)
         assert flashcpy == flash_with_flm
-    
+
     def test_copy_flash_with_assigned_flm(self, flash):
         flash.flm = FLM_PATH
         flashcpy = copy.copy(flash)
         assert flashcpy == flash
-    
+
     def test_clone_with_changes(self, flash, ram1):
         flashcpy = flash.clone_with_changes(name='another flash')
         assert flashcpy.name == 'another flash'
@@ -333,10 +333,10 @@ class TestMemoryRegion:
         assert acopy.start == 0x30000000
         assert acopy.length == ram1.length
         assert acopy.end == 0x30000000 + ram1.length - 1
-    
+
     def test_eq(self, flash, ram1):
         assert flash != ram1
-        
+
         a = RamRegion(name='a', start=0x1000, length=0x2000)
         b = RamRegion(name='a', start=0x1000, length=0x2000)
         assert a == b
@@ -420,23 +420,23 @@ class TestMemoryMap:
             )
         rgns = dualMap.get_intersecting_regions(0x1fffc9f8, end=0x1fffc9fc)
         assert len(rgns) > 0
-    
+
     def test_get_type_iter(self, memmap, flash, rom, ram1, ram2):
         assert list(memmap.iter_matching_regions(type=MemoryType.FLASH)) == [flash]
         assert list(memmap.iter_matching_regions(type=MemoryType.ROM)) == [rom]
         assert list(memmap.iter_matching_regions(type=MemoryType.RAM)) == [ram1, ram2]
-    
+
     def test_match_iter(self, memmap, flash, ram1, ram2, ram_alias):
         assert list(memmap.iter_matching_regions(blocksize=0x100)) == [flash]
         assert list(memmap.iter_matching_regions(start=0x20000000)) == [ram1]
-    
+
     def test_first_match(self, memmap, flash, ram2):
         assert memmap.get_first_matching_region(blocksize=0x100) == flash
         assert memmap.get_first_matching_region(length=1024, is_cacheable=False) == ram2
-    
+
     def test_alias(self, memmap2, ram2, ram_alias):
         assert ram_alias.alias is ram2
-    
+
     def test_get_default(self, memmap, flash, ram2):
         assert memmap.get_default_region_of_type(MemoryType.FLASH) == flash
         assert memmap.get_default_region_of_type(MemoryType.RAM) == ram2
@@ -448,14 +448,14 @@ class TestMemoryMap:
     def test_index_by_name(self, memmap, rom, ram2):
         assert memmap['rom'] == rom
         assert memmap['ram2'] == ram2
-    
+
     def test_clone(self, memmap):
         mapcpy = memmap.clone()
         assert id(mapcpy) != id(memmap)
         assert id(mapcpy.get_first_matching_region(type=MemoryType.RAM)) != \
             id(memmap.get_first_matching_region(type=MemoryType.RAM))
         assert mapcpy == memmap
-    
+
     def test_contains_int(self, memmap):
         assert 0x200 in memmap
         assert 0x20000100 in memmap
@@ -463,32 +463,32 @@ class TestMemoryMap:
         assert 0x1c000040 in memmap
         assert 0x80000000 not in memmap
         assert 0xffffffff not in memmap
-    
+
     def test_contains_name(self, memmap):
         assert 'rom' in memmap
         assert 'flash' in memmap
         assert 'funky' not in memmap
         assert '' not in memmap
-    
+
     def test_contains_region(self, memmap, flash):
         assert flash in memmap
-    
+
     def test_len(self, memmap):
         assert len(memmap) == 4
-    
+
     def test_iter(self, memmap):
         assert [r.name for r in memmap] == ['flash', 'rom', 'ram', 'ram2']
-    
+
     def test_reversed(self, memmap):
         assert [r.name for r in reversed(memmap)] == ['ram2', 'ram', 'rom', 'flash']
-    
+
     def test_abc(self):
         assert isinstance(MemoryMap(), collections.abc.Sequence)
-    
+
     def test_name_uniquing(self, memmap):
         memmap.add_region(RomRegion(0x01000000, length=0x8000, name="rom"))
         assert memmap.get_first_matching_region(name="rom_1").start == 0x01000000
-    
+
     def test_multiple_unnamed_regions(self):
         map = MemoryMap(RomRegion(0x01000000, length=0x8000),
                 RamRegion(0x20000000, length=0x8000))

--- a/test/unit/test_mockcore.py
+++ b/test/unit/test_mockcore.py
@@ -65,7 +65,7 @@ class TestMockCoreReg:
             mockcore.write_core_registers_raw([r], [1+r])
         for r in range(0, 16):
             assert mockcore.read_core_registers_raw([r]) == [1+r]
-    
+
     def test_rw_cfbp(self, mockcore):
         mockcore.write_core_registers_raw([index_for_reg('cfbp')], [0x01020304])
         assert mockcore.read_core_registers_raw([

--- a/test/unit/test_notification.py
+++ b/test/unit/test_notification.py
@@ -28,7 +28,7 @@ class Subscriber(object):
     def __init__(self):
         self.was_called = False
         self.last_note = None
-    
+
     def cb(self, note):
         self.was_called = True
         self.last_note = note
@@ -111,4 +111,4 @@ class TestNotification(object):
         notifier.notify(EVENT_A, self)
         assert not subscriber.was_called
 
-        
+

--- a/test/unit/test_options_manager.py
+++ b/test/unit/test_options_manager.py
@@ -73,14 +73,14 @@ class TestOptionsManager(object):
         mgr.add_back({'debug__traceback': False})
         assert 'debug.traceback' in mgr
         assert mgr.get('debug.traceback') == False
-        
+
     def test_set(self, mgr, layer1):
         mgr.add_front(layer1)
         mgr.set('buzz', 1234)
         assert mgr['buzz'] == 1234
         mgr.add_front({'buzz': 4321})
         assert mgr.get('buzz') == 4321
-        
+
     def test_update(self, mgr, layer1, layer2):
         mgr.add_front(layer1)
         mgr.add_front(layer2)
@@ -121,4 +121,4 @@ class TestOptionsManager(object):
         mgr.add_back(layer2)
         assert flag[0] == False
 
-        
+

--- a/test/unit/test_pack.py
+++ b/test/unit/test_pack.py
@@ -109,14 +109,14 @@ class Disabled_TestPack(object):
     def test_get_installed(self, pack_ref):
         p = pack_target.ManagedPacks.get_installed_packs()
         assert p == [pack_ref]
-    
+
     def test_get_targets(self, k64dev):
         assert k64dev.part_number == K64F
-    
+
     def test_pop_managed_k64(self):
         pack_target.ManagedPacks.populate_target(K64F)
         assert K64F.lower() in TARGET
-    
+
     def test_k64_mem_map(self, k64dev):
         map = k64dev.memory_map
         raml = map.get_region_for_address(0x1fff0000)
@@ -126,14 +126,14 @@ class Disabled_TestPack(object):
         assert ramu.start == 0x20000000 and ramu.length == 0x30000
         assert flash.start == 0 and flash.length == 0x100000
         assert flash.sector_size == 0x1000
-        
+
 class TestPack(object):
     def test_devices(self, k64pack):
         devs = k64pack.devices
         pns = [x.part_number for x in devs]
         assert "MK64FN1M0xxx12" in pns
         assert "MK64FX512xxx12" in pns
-    
+
     # Make sure CmsisPack can open a zip file too.
     def test_zipfile(self):
         z = zipfile.ZipFile(K64F_PACK_PATH, 'r')
@@ -145,19 +145,19 @@ class TestPack(object):
         assert k64f1m0.vendor == "NXP"
         assert k64f1m0.families == ["MK64F12"]
         assert k64f1m0.default_reset_type == target.Target.ResetType.SW
-    
+
     def test_get_svd(self, k64f1m0):
         svd = k64f1m0.svd
         x = ElementTree.parse(svd)
         assert x.getroot().tag == 'device'
-    
+
     def test_mem_map(self, k64f1m0):
         map = k64f1m0.memory_map
         bm = map.get_boot_memory()
         assert bm.start == 0 and bm.length == 1 * 1024 * 1024
         ram = map.get_default_region_of_type(memory_map.MemoryType.RAM)
         assert ram.start == 0x20000000 and ram.length == 0x30000
-    
+
     # Verify the flash region was converted correctly.
     def test_flash(self, k64f1m0):
         map = k64f1m0.memory_map
@@ -165,7 +165,7 @@ class TestPack(object):
         assert isinstance(flash, memory_map.FlashRegion)
         assert flash.start == 0 and flash.length == 1 * 1024 * 1024
         assert flash.sector_size == 4096
-    
+
 class TestFLM(object):
     def test_algo(self, k64algo):
         i = k64algo.flash_info
@@ -175,7 +175,7 @@ class TestFLM(object):
         assert i.size == 1 * 1024 * 1024
         assert i.page_size == 512
         assert i.sector_info_list == [(0, 4 * 1024)]
-    
+
     def test_algo_dict(self, k64algo, k64f1m0):
         map = k64f1m0.memory_map
         ram = map.get_default_region_of_type(memory_map.MemoryType.RAM)
@@ -190,7 +190,7 @@ class TestFLM(object):
         assert d['pc_eraseAll'] == ram.start + STACK_SIZE + 0x95
         assert d['pc_erase_sector'] == ram.start + STACK_SIZE + 0xcb
         assert d['pc_program_page'] == ram.start + STACK_SIZE + 0xdf
-        
+
 def has_overlapping_regions(memmap):
     return any((len(memmap.get_intersecting_regions(r.start, r.end)) > 1) for r in memmap.regions)
 
@@ -198,7 +198,7 @@ class TestNRF():
     def test_regions(self, nrf5340):
         memmap = nrf5340.memory_map
         assert not has_overlapping_regions(memmap)
-        
+
 class TestSTM32L4():
     def test_regions(self, stm32l4r5):
         memmap = stm32l4r5.memory_map

--- a/test/unit/test_regcache.py
+++ b/test/unit/test_regcache.py
@@ -82,7 +82,7 @@ class TestRegisterCache:
                 modifier = 0
             mockcore.write_core_registers_raw([r], [get_expected_reg_value(r) + modifier])
             assert mockcore.read_core_registers_raw([r]) == [get_expected_reg_value(r) + modifier]
-        
+
     def test_r_1(self, mockcore, regcache):
         assert regcache.read_core_registers_raw(['r0']) == [0] # cache initial value of 0
         mockcore.write_core_registers_raw(['r0'], [1234]) # modify reg behind the cache's back
@@ -91,7 +91,7 @@ class TestRegisterCache:
         regcache.invalidate() # explicitly invalidate cache
         assert mockcore.read_core_registers_raw(['r0']) == [1234] # verify modified reg
         assert regcache.read_core_registers_raw(['r0']) == [1234] # now should return updated 1234 value
-        
+
     def test_run_token(self, mockcore, regcache):
         assert regcache.read_core_registers_raw(['r0']) == [0] # cache initial value of 0
         mockcore.write_core_registers_raw(['r0'], [1234]) # modify reg behind the cache's back
@@ -136,7 +136,7 @@ class TestRegisterCache:
         mockcore.write_core_registers_raw(['control', 'primask'], [0x55, 0xaa])
         # cache should return original value
         assert regcache.read_core_registers_raw(['cfbp']) == [get_expected_cfbp()]
-    
+
     def test_read_cached_xpsr(self, mockcore, regcache):
         self.set_core_regs(mockcore)
         # cache it
@@ -153,14 +153,14 @@ class TestRegisterCache:
         regcache.write_core_registers_raw(['r0'], [1234])
         assert mockcore.read_core_registers_raw(['r0']) == [1234]
         assert regcache.read_core_registers_raw(['r0']) == [1234]
-    
+
     def test_write_regs(self, mockcore, regcache):
         self.set_core_regs(mockcore)
         for r in core_regs_composite_regs(mockcore):
             regcache.write_core_registers_raw([r], [get_expected_reg_value(r) + get_modifier(r)])
         for r in core_regs_composite_regs(mockcore):
             assert mockcore.read_core_registers_raw([r]) == [get_expected_reg_value(r) + get_modifier(r)]
-     
+
     def test_write_cfbp(self, mockcore, regcache):
         self.set_core_regs(mockcore)
         assert mockcore.read_core_registers_raw(['cfbp']) == [get_expected_cfbp()]
@@ -170,7 +170,7 @@ class TestRegisterCache:
             ((3 << 24) | (get_expected_reg_value('faultmask') << 16) |
             (get_expected_reg_value('basepri') << 8) | 19)
             ]
-   
+
     def test_write_xpsr(self, mockcore, regcache):
         self.set_core_regs(mockcore)
         assert mockcore.read_core_registers_raw(['xpsr']) == [get_expected_xpsr()]
@@ -196,16 +196,16 @@ class TestRegisterCache:
     def test_invalid_reg_w(self, regcache):
         with pytest.raises(KeyError):
             regcache.write_core_registers_raw([132423], [1234])
-    
+
     def test_invalid_fpu_reg_r(self, regcache_no_fpu):
         with pytest.raises(KeyError):
             regcache_no_fpu.read_core_registers_raw(['s1'])
-    
+
     def test_invalid_fpu_reg_w(self, regcache_no_fpu):
         with pytest.raises(KeyError):
             regcache_no_fpu.write_core_registers_raw(['s1'], [1.234])
 
-            
+
 
 
 

--- a/test/unit/test_rom_table.py
+++ b/test/unit/test_rom_table.py
@@ -32,7 +32,7 @@ from pyocd.debug.context import DebugContext
 
 class MockCoreForMemCache(CoreSightCoreComponent):
     """! @brief Just enough of a core to satisfy MemoryCache.
-    
+
     Most importantly, it defines a memory map with a single RAM region covering almost the
     full 4 GB address space.
     """
@@ -49,18 +49,18 @@ MockDebugContext = mock.Mock(spec=DebugContext)
 
 class RomMemory(MemoryCache, MemoryInterface):
     """! @brief Memory interface for reading constant values.
-    
+
     Uses the memory cache as readily-available component to store data at fixed addresses. We
     just have to make sure the cache is never invalidated.
     """
     def __init__(self, ranges):
         """! @brief Constructor.
-        
+
         @param self
         @param ranges Dict of start address -> list of word values.
         """
         super(RomMemory, self).__init__(MockDebugContext(), MockCoreForMemCache())
-        
+
         # Fill in cache with data from ranges.
         for addr, data in ranges.items():
             self.write_memory_block32(addr, data)
@@ -73,25 +73,25 @@ class MockCoreSight(RomMemory):
     """! @brief RomMemory based on a list of MockCoreSightComponent objects."""
     def __init__(self, components):
         """! @brief Constructor.
-        
+
         @param self
         @param components List of component dicts, where each component dict consists of start
             address -> list of word values.
         """
         ranges = {base: data for c in components for base, data in c.data.items()}
         super(MockCoreSight, self).__init__(ranges)
-    
+
     @property
     def short_description(self):
         return "MockCoreSight"
 
 class MockCoreSightComponent(object):
     """! @brief Generates a data dict from CoreSight component ID register values."""
-    
+
     # Start offset within the 4 kB CoreSight component memory window of the ID registers
     # we care about, particularly those read by CoreSightComponentID.
     CMPID_REGS_OFFSET = 0xfbc
-    
+
     def __init__(self, base, cidr, pidr, **kwargs):
         """! @brief Constructor.
         @param self
@@ -111,7 +111,7 @@ class MockCoreSightComponent(object):
         self._devid = kwargs.get('devid', [0, 0, 0])
         self._devtype = kwargs.get('devtype', 0)
         self._extra = kwargs.get('extra', {})
-    
+
     @property
     def data(self):
         d = self._extra.copy()
@@ -140,7 +140,7 @@ class MockCoreSightComponent(object):
 
 class MockM4Components:
     """! @ brief Namespace for mock Cortex-M4 Class 0x1 ROM table and core complex components."""
-    
+
     # ROM table #0 @ 0xe00ff000 (designer=244 part=00d)
     M4_ROM_TABLE_BASE = 0xe00ff000
     M4_ROM_TABLE = MockCoreSightComponent(M4_ROM_TABLE_BASE, cidr=0xb105100d, pidr=0x4000bb4c4,
@@ -179,10 +179,10 @@ class MockM4Components:
     # [5]<e0041000:ETM-M4 class=9 designer=43b part=925 devtype=13 archid=0000 devid=0:0:0>
     ETM_BASE = 0xe0041000
     ETM = MockCoreSightComponent(ETM_BASE, cidr=0xb105900d, pidr=0x4000bb925, devtype=0x13)
-    
+
 class MockCSSOC600Components:
     """! @ brief Namespace for mock Class 0x9 ROM table and CoreSight SoC-600 components."""
-    
+
     C9_ROM_TABLE_BASE = 0x00000000
     C9_ROM_TABLE = MockCoreSightComponent(C9_ROM_TABLE_BASE, cidr=0xb105900d, pidr=0x4000bb7d5,
         devarch=0x47700af7, devid=[0x20, 0, 0],
@@ -194,13 +194,13 @@ class MockCSSOC600Components:
                             0x00000000, 0x00000000, 0x00000000, 0x00000000, # (extra)
                         ],
         })
-    
+
     SDC600_BASE = 0x00001000
     SDC600 = MockCoreSightComponent(SDC600_BASE, cidr=0xb105900d, pidr=0x4000bb9ef, devarch=0x47700a57)
-    
+
     C9_AHB_AP_BASE = 0x00002000
     C9_AHB_AP = MockCoreSightComponent(C9_AHB_AP_BASE, cidr=0xb105900d, pidr=0x4002bb9e3, devarch=0x47700a17)
-    
+
 
 # Complete set of components for a Cortex-M4 subsystem.
 @pytest.fixture(scope='function')
@@ -266,7 +266,7 @@ class TestRomMemory:
     def test_rb8(self, testrom):
         assert testrom.read_memory_block8(0x1008, 6) == [3, 0, 0, 0, 4, 0]
         assert testrom.read_memory_block8(0x4001, 6) == [0, 0, 0, 0xef, 0xbe, 00]
-    
+
 class TestMockCoreSight:
     def test_1(self, testcoresight):
         assert testcoresight.read32(0xe00ff000) == 0xfff0f003
@@ -284,7 +284,7 @@ class TestCoreSightComponentID:
         assert cmp.part == 0xc
         assert cmp.devarch == 0
         assert cmp.devid == [0, 0, 0]
-    
+
     # Test parsing a CoreSight (class 9) component in isolation.
     def test_etm(self):
         cmp = CoreSightComponentID(None, MockCoreSight([MockM4Components.ETM]),
@@ -297,7 +297,7 @@ class TestCoreSightComponentID:
         assert cmp.archid == 0
         assert cmp.devarch == 0
         assert cmp.devid == [0, 0, 0]
-    
+
     # Test parsing a CoreSight (class 9) component with a DEVID.
     def test_tpiu(self):
         cmp = CoreSightComponentID(None, MockCoreSight([MockM4Components.TPIU]),
@@ -310,7 +310,7 @@ class TestCoreSightComponentID:
         assert cmp.archid == 0
         assert cmp.devarch == 0
         assert cmp.devid == [0xca1, 0, 0]
-    
+
     # Test parsing a Class 0x9 ROM table.
     def test_c9_rom(self):
         cmp = CoreSightComponentID(None, MockCoreSight([MockCSSOC600Components.C9_ROM_TABLE]),
@@ -325,32 +325,32 @@ class TestRomTable:
         # Read ROM table component ID.
         cmpid = CoreSightComponentID(None, m4_rom, MockM4Components.M4_ROM_TABLE_BASE)
         cmpid.read_id_registers()
-        
+
         # Create the ROM table.
         rom_table = ROMTable.create(m4_rom, cmpid)
         rom_table.init()
-        
+
         # Verify all components were parsed.
         assert len(rom_table.components) == 6
-        
+
         # Check SCS-M4.
         scs = rom_table.components[0]
         assert scs.component_class == 14
         assert scs.designer == 0x43b
         assert scs.part == 0xc
-        
+
         # Check TPIU.
         tpiu = rom_table.components[4]
         assert tpiu.component_class == 9
         assert tpiu.part == 0x9a1
         assert tpiu.devid == [0xca1, 0, 0]
-        
+
     # Test a Class 0x9 ROM table and CS-600 components.
     def test_c9_rom(self, c9_top_rom):
         # Read ROM table component ID.
         cmpid = CoreSightComponentID(None, c9_top_rom, MockCSSOC600Components.C9_ROM_TABLE_BASE)
         cmpid.read_id_registers()
-        
+
         # Create the ROM table.
         rom_table = ROMTable.create(c9_top_rom, cmpid)
         rom_table.init()
@@ -363,14 +363,14 @@ class TestRomTable:
 
         # Validate components.
         assert len(rom_table.components) == 2
-        
+
         # Validate SDC-600.
         sdc = rom_table.components[0]
         assert sdc.component_class == 9
         assert sdc.designer == 0x43b
         assert sdc.part == 0x9ef
         assert sdc.archid == 0xa57
-        
+
         # Validate AHB-AP.
         ahb = rom_table.components[1]
         assert ahb.component_class == 9

--- a/test/unit/test_sdc600.py
+++ b/test/unit/test_sdc600.py
@@ -74,7 +74,7 @@ class TestSDC600:
             if i in FLAGS:
                 continue
             assert sdc._destuff([i]) == [i]
-    
+
     # Test stuffing a single byte.
     def test_stuff_flag(self, sdc):
         for i in FLAGS:

--- a/test/unit/test_semihosting.py
+++ b/test/unit/test_semihosting.py
@@ -98,7 +98,7 @@ BKPT_AB = 0xbeab
 
 class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
     """! @brief Semihost IO handler that records output.
-    
+
     This handler is only meant to be used for console I/O since it doesn't implement
     open() or close().
     """
@@ -479,7 +479,7 @@ class TestSemihosting:
 #         telnet.stop()
 #     request.addfinalizer(stopit)
 #     return telnet
-# 
+#
 # @pytest.fixture(scope='function')
 # def semihost_telnet_agent(ctx, telnet, request):
 #     agent = semihost.SemihostAgent(ctx, console=telnet)
@@ -487,11 +487,11 @@ class TestSemihosting:
 #         agent.cleanup()
 #     request.addfinalizer(cleanup)
 #     return agent
-# 
+#
 # @pytest.fixture(scope='function')
 # def semihost_telnet_builder(tgt, semihost_telnet_agent, ramrgn):
 #     return SemihostRequestBuilder(tgt, semihost_telnet_agent, ramrgn)
-# 
+#
 # @pytest.fixture(scope='function')
 # def telnet_conn(request):
 #     from time import sleep
@@ -502,47 +502,47 @@ class TestSemihosting:
 #         telnet.close()
 #     request.addfinalizer(cleanup)
 #     return telnet
-# 
+#
 # class TestSemihostingTelnet:
 #     def test_connect(self, semihost_telnet_builder, telnet_conn):
 #         result = semihost_telnet_builder.do_no_args_call(semihost.TARGET_SYS_ERRNO)
 #         assert result == 0
-# 
+#
 #     def test_write(self, semihost_telnet_builder, telnet_conn):
 #         result = semihost_telnet_builder.do_write(semihost.STDOUT_FD, 'hello world')
 #         assert result == 0
-# 
+#
 #         index, _, text = telnet_conn.expect(['hello world'])
 #         assert index != -1
 #         assert text == 'hello world'
-# 
+#
 #     def test_writec(self, semihost_telnet_builder, telnet_conn):
 #         for c in 'xyzzy':
 #             result = semihost_telnet_builder.do_writec(c)
 #             assert result == 0
-# 
+#
 #             index, _, text = telnet_conn.expect([c])
 #             assert index != -1
 #             assert text == c
-# 
+#
 #     def test_write0(self, semihost_telnet_builder, telnet_conn):
 #         result = semihost_telnet_builder.do_write0('hello world')
 #         assert result == 0
-# 
+#
 #         index, _, text = telnet_conn.expect(['hello world'])
 #         assert index != -1
 #         assert text == 'hello world'
-# 
+#
 #     def test_read(self, semihost_telnet_builder, telnet_conn):
 #         telnet_conn.write('hello world')
-# 
+#
 #         result, data = semihost_telnet_builder.do_read(semihost.STDIN_FD, 11)
 #         assert result == 0
 #         assert data == 'hello world'
-# 
+#
 #     def test_readc(self, semihost_telnet_builder, telnet_conn):
 #         telnet_conn.write('xyz')
-# 
+#
 #         for c in 'xyz':
 #             rc = semihost_telnet_builder.do_no_args_call(semihost.TARGET_SYS_READC)
 #             assert chr(rc) == c

--- a/test/unit/test_sequencer.py
+++ b/test/unit/test_sequencer.py
@@ -24,7 +24,7 @@ class TestCallSequence:
     def test_empty(self):
         cs = CallSequence()
         assert cs.count == 0
-    
+
     def test_a(self):
         results = []
         cs = CallSequence(
@@ -42,11 +42,11 @@ class TestCallSequence:
                 )
         assert cs.count == 1
 
-        cs.append(        
+        cs.append(
                 ('b', lambda : results.append('b ran')),
                 )
         assert cs.count == 2
-        
+
         cs.invoke()
         assert results == ['a ran', 'b ran']
 
@@ -57,12 +57,12 @@ class TestCallSequence:
                 )
         assert cs.count == 1
 
-        cs.append(        
+        cs.append(
                 ('b', lambda : results.append('b ran')),
                 ('c', lambda : results.append('c ran')),
                 )
         assert cs.count == 3
-        
+
         cs.invoke()
         assert results == ['a ran', 'b ran', 'c ran']
 
@@ -73,10 +73,10 @@ class TestCallSequence:
                 ('b', lambda : results.append('b ran')),
                 )
         assert cs.count == 2
-        
+
         cs.remove_task('b')
         assert cs.count == 1
-        
+
         cs.invoke()
         assert results == ['a ran']
 

--- a/test/unit/test_strings_utility.py
+++ b/test/unit/test_strings_utility.py
@@ -21,31 +21,31 @@ from pyocd.utility.strings import (
 class TestUniquifyName:
     def test_empty_with_no_others(self):
         assert uniquify_name('', []) == ''
-    
+
     def test_empty_with_others(self):
         assert uniquify_name('', ['bar', 'buz']) == ''
-    
+
     def test_empty_with_another_empty(self):
         assert uniquify_name('', ['bar', 'buz', '']) == '_1'
-    
+
     def test_no_others(self):
         assert uniquify_name('foo', []) == 'foo'
-    
+
     def test_already_unique(self):
         assert uniquify_name('foo', ['bar']) == 'foo'
-    
+
     def test_no_trailing_int(self):
         assert uniquify_name('foo', ['foo']) == 'foo_1'
-    
+
     def test_1_trailing_int(self):
         assert uniquify_name('foo1', ['foo1']) == 'foo2'
-    
+
     def test_multiple_trailing_ints(self):
         assert uniquify_name('foo1', ['foo1', 'foo2']) == 'foo3'
-    
+
     def test_name_has_int(self):
         assert uniquify_name('foo2', ['foo2', 'bar', 'foo3']) == 'foo4'
-    
+
     def test_multiple_ints_in_name(self):
         assert uniquify_name('baz 2 monkey-3', ['fun', 'baz 2 monkey-3']) == 'baz 2 monkey-4'
 

--- a/test/unit/test_timeout.py
+++ b/test/unit/test_timeout.py
@@ -39,7 +39,7 @@ class TestTimeout:
                 sleep(0.01)
         assert to.did_time_out
         assert (time() - s) >= 0.05
-    
+
     def test_timeout_b(self):
         timedout = False
         s = time()
@@ -53,7 +53,7 @@ class TestTimeout:
         assert timedout
         assert to.did_time_out
         assert (time() - s) >= 0.05
-    
+
     def test_timeout_c(self):
         timedout = False
         with Timeout(0.05) as to:
@@ -64,7 +64,7 @@ class TestTimeout:
                 cnt += 1
         assert not timedout
         assert not to.did_time_out
-    
+
     def test_timeout_reset(self):
         cnt = 0
         cnta = 0

--- a/test/user_script_test.py
+++ b/test/user_script_test.py
@@ -70,7 +70,7 @@ def user_script_test(board_id):
         boot_region = memory_map.get_boot_memory()
         ram_region = memory_map.get_default_region_of_type(MemoryType.RAM)
         binary_file = get_test_binary_path(board.test_binary)
-        
+
         test_pass_count = 0
         test_count = 0
         result = UserScriptTestResult()
@@ -79,10 +79,10 @@ def user_script_test(board_id):
         target.resume()
         target.halt()
         target.step()
-        
+
         test_count += 1
         test_pass_count += 1
-        
+
         print("\nTest Summary:")
         print("Pass count %i of %i tests" % (test_pass_count, test_count))
         if test_pass_count == test_count:


### PR DESCRIPTION
Remove trailing whitespace from all source files.

The `.editorconfig` file is updated to disallow trailing whitespace.