### PR TITLE
Color logging

### DIFF
--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -36,6 +36,7 @@ Subcommand     | Default level
 `list`         | INFO
 `pack`         | INFO
 `reset`        | WARNING
+`rtt`          | INFO
 `server`       | INFO
 
 
@@ -45,6 +46,20 @@ For most users, the command line `--verbose`/`-v` and `--quiet`/`-q` arguments p
 over logging. These arguments can be listed multiple times. Each use increases or decreases the
 logging verbosity level. For example, a single `--verbose` moves `pyocd flash` from the default
 level of WARNING to INFO.
+
+
+## Color logging
+
+By default, log output to the console is colorised. Control over colorised log output is possible two ways.
+
+The command-line `--color` argument accepts an optional parameter that must be one of `auto`, `always`, or `never`.
+The default is `auto`, which will enable color only when outputting to a tty.
+
+Another option for controlling color output is the `PYOCD_COLOR` environment variable. It should be set to one of the
+same values supported by `--color`, or left empty. This environment variable changes the default color output setting,
+and is overridden by `--color` on the command line.
+
+Currently, due to limitations in the colorisation support, `always` behaves the same as `auto`.
 
 
 ## Loggers
@@ -61,7 +76,7 @@ its package structure.
 ### Trace loggers
 
 Certain modules define additional sub-module loggers that output debug trace logs. These loggers always have the
-suffix ".trace" and are set to critical log level by default.
+suffix ".trace" and are disabled by default. This ensures the trace messages won't be seen unless explicitly enabled by the `--log-level` / `-L` argument described in the following section.
 
 Currently defined trace loggers:
 

--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import colorama
 import logging
 import os
 import traceback
@@ -76,16 +77,16 @@ class PyOCDCommander(object):
                                 status = self.session.target.get_state().name.capitalize()
                             except (AttributeError, KeyError):
                                 status = "<no core>"
-
-                        # Say what we're connected to.
-                        print("Connected to %s [%s]: %s" % (self.context.target.part_number,
-                            status, self.session.board.unique_id))
                     except exceptions.TransferFaultError:
-                        pass
+                        status = "<error>"
                 else:
                     # Say what we're connected to, but without status.
-                    print("Connected to %s [no init mode]: %s" % (self.context.target.part_number,
-                        self.session.board.unique_id))
+                    status = "no init mode"
+
+                # Say what we're connected to.
+                print(colorama.Fore.GREEN + f"Connected to {self.context.target.part_number} " +
+                        colorama.Fore.CYAN + f"[{status}]" +
+                        colorama.Style.RESET_ALL + f": {self.session.board.unique_id}")
 
                 # Run the REPL interface.
                 console = PyocdRepl(self.context)

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -48,6 +48,8 @@ class SubcommandBase:
             help="Set log level of loggers whose name matches any of the comma-separated list of glob-style "
             "patterns. Log level must be one of (critical, error, warning, info, debug). Can be "
             "specified multiple times. Example: -L*.trace,pyocd.core.*=debug")
+        LOGGING_GROUP.add_argument('--color', choices=("always", "auto", "never"), default=None, nargs='?',
+            const="auto", help="Control color logging. Default is auto.")
 
         # Define config related options for all subcommands.
         CONFIG = argparse.ArgumentParser(description='common', add_help=False)

--- a/pyocd/utility/color_log.py
+++ b/pyocd/utility/color_log.py
@@ -1,0 +1,98 @@
+# pyOCD debugger
+# Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from colorama import (Fore, Style)
+import logging
+from shutil import get_terminal_size
+
+class ColorFormatter(logging.Formatter):
+    """@brief Log formatter that applies colours based on the record's log level."""
+
+    FORMAT = "{timecolor}{relativeCreated:07.0f}{_reset} {lvlcolor:s}{levelname:<{levelnamewidth}.{levelnamewidth}s}{_reset} {msgcolor}{message} {_dim}[{module:s}]{_reset}"
+
+    ## Colors for the log level name.
+    LEVEL_COLORS = {
+            'CRITICAL': Style.BRIGHT + Fore.LIGHTRED_EX,
+            'ERROR': Fore.LIGHTRED_EX,
+            'WARNING': Fore.LIGHTYELLOW_EX,
+            'INFO': Fore.CYAN,
+            'DEBUG': Style.DIM,
+        }
+
+    ## Colors for the rest of the log message.
+    MESSAGE_COLORS = {
+            'CRITICAL': Fore.LIGHTRED_EX,
+            'ERROR': Fore.RED,
+            'WARNING': Fore.YELLOW,
+            'DEBUG': Style.DIM + Fore.LIGHTWHITE_EX,
+        }
+
+    ## Fixed maximum length of the log level name in log messages.
+    MAX_LEVELNAME_WIDTH = 1
+
+    def __init__(self, msg, use_color: bool, is_tty: bool) -> None:
+        super().__init__(msg, style='{')
+        self._use_color = use_color
+        self._is_tty = is_tty
+
+        # TODO: Handle resizing of terminal?
+        self._term_width = get_terminal_size()[0]
+
+    # Note: we can't set the type of `record` param to LogRecord because that causes type errors for
+    # each time below when an attribute is set on the record.
+    def format(self, record) -> str:
+        # Capture and remove exc_info and stack_info so the superclass format() doesn't
+        # print it and we can control the formatting.
+        exc_info = record.exc_info
+        record.exc_info = None
+        stack_info = record.stack_info
+        record.stack_info = None
+
+        # Add colors to the record.
+        if self._use_color:
+            record.lvlcolor = self.LEVEL_COLORS.get(record.levelname, '')
+
+            # Colorise the line.
+            record.msgcolor = self.MESSAGE_COLORS.get(record.levelname, '')
+
+            # Fixed colors.
+            record.timecolor = Fore.BLUE
+            record._reset = Style.RESET_ALL
+            record._dim = Style.DIM
+        else:
+            record.lvlcolor = ""
+            record.msgcolor = ""
+            record.timecolor = ""
+            record._reset = ""
+            record._dim = ""
+
+        record.message = record.getMessage()
+
+        # Add levelname alignment to record.
+        record.levelname_align = " " * max(self.MAX_LEVELNAME_WIDTH - len(record.levelname), 0)
+        record.levelnamewidth = self.MAX_LEVELNAME_WIDTH
+
+        # Let superclass handle formatting.
+        log_msg = super().format(record)
+
+        # Append uncolored exception/stack info.
+        if exc_info:
+            log_msg += "\n" + Style.DIM + self.formatException(exc_info) + Style.RESET_ALL
+        if stack_info:
+            log_msg += "\n" + Style.DIM + self.formatStack(stack_info) + Style.RESET_ALL
+
+        return log_msg


### PR DESCRIPTION
Colorised log when outputting to the console. Modified and simplified log message format so it's easier to read. The "Connected to" message for the commander is also colorised now.

A `--color` command line argument allows for controlling the color output. The `PYOCD_COLOR` environment variable is also available. (Session options can't be used because logging is set up before a session is created.)

This is what the log looks like with these changes:

<img width="899" alt="image" src="https://user-images.githubusercontent.com/3116536/143783393-248cf235-c029-4cf9-b712-0a1edae97b49.png">
