### PR TITLE
RTT host-to-target communication

### DIFF
--- a/pyocd/subcommands/rtt_cmd.py
+++ b/pyocd/subcommands/rtt_cmd.py
@@ -26,9 +26,8 @@ from pyocd.subcommands.base import SubcommandBase
 from pyocd.utility.cmdline import convert_session_options, int_base_0
 from ctypes import Structure, c_char, c_int32, c_uint32, sizeof
 
-# The KBHit code below is based on the file https://simondlevy.academic.wlu.edu/files/software/kbhit.py ,
-# re-licensed under an MIT License by its author Simon D. Levy (https://github.com/simondlevy)
-# for inclusion in the pyOCD project.
+# The KBHit code below is based on https://github.com/simondlevy/kbhit by Simon D. Levy,
+# published under the MIT License.
 
 import os
 
@@ -90,7 +89,7 @@ class KBHit:
             dr,dw,de = select([sys.stdin], [], [], 0)
             return dr != []
 
-# end of the KBHit code re-licensed by its author Simon D. Levy under an MIT License 
+# end of the KBHit code
 
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/subcommands/rtt_cmd.py
+++ b/pyocd/subcommands/rtt_cmd.py
@@ -24,72 +24,8 @@ from pyocd.core.memory_map import MemoryMap, MemoryRegion, MemoryType
 from pyocd.core.soc_target import SoCTarget
 from pyocd.subcommands.base import SubcommandBase
 from pyocd.utility.cmdline import convert_session_options, int_base_0
+from pyocd.utility.kbhit import KBHit
 from ctypes import Structure, c_char, c_int32, c_uint32, sizeof
-
-# The KBHit code below is based on https://github.com/simondlevy/kbhit by Simon D. Levy,
-# published under the MIT License.
-
-import os
-
-# Windows
-if os.name == 'nt':
-    import msvcrt
-# Posix (Linux, OS X)
-else:
-    import sys
-    import termios
-    import atexit
-    from select import select
-
-class KBHit:
-
-    def __init__(self) -> None:
-        '''Creates a KBHit object that you can call to do various keyboard things.
-        '''
-
-        if os.name == 'nt':
-            pass
-        else:
-            # Save the terminal settings
-            self.fd = sys.stdin.fileno()
-            self.new_term = termios.tcgetattr(self.fd)
-            self.old_term = termios.tcgetattr(self.fd)
-
-            # New terminal setting unbuffered
-            self.new_term[3] = (self.new_term[3] & ~termios.ICANON & ~termios.ECHO)
-            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.new_term)
-
-            # Support normal-terminal reset at exit
-            atexit.register(self.set_normal_term)
-
-    def set_normal_term(self) -> None:
-        ''' Resets to normal terminal.  On Windows this is a no-op.
-        '''
-
-        if os.name == 'nt':
-            pass
-        else:
-            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
-
-    def getch(self) -> str:
-        ''' Returns a keyboard character after kbhit() has been called.
-        '''
-
-        if os.name == 'nt':
-            return msvcrt.getch().decode('utf-8')
-        else:
-            return sys.stdin.read(1)
-
-    def kbhit(self) -> bool:
-        ''' Returns True if keyboard character was hit, False otherwise.
-        '''
-        if os.name == 'nt':
-            return msvcrt.kbhit()
-        else:
-            dr,dw,de = select([sys.stdin], [], [], 0)
-            return dr != []
-
-# end of the KBHit code
 
 
 LOG = logging.getLogger(__name__)

--- a/pyocd/subcommands/rtt_cmd.py
+++ b/pyocd/subcommands/rtt_cmd.py
@@ -24,6 +24,70 @@ from pyocd.subcommands.base import SubcommandBase
 from pyocd.utility.cmdline import convert_session_options, int_base_0
 from ctypes import Structure, c_char, c_int32, c_uint32, sizeof
 
+import os
+# Windows
+if os.name == 'nt':
+    import msvcrt
+# Posix (Linux, OS X)
+else:
+    import sys
+    import termios
+    import atexit
+    from select import select
+
+class KBHit:
+    # taken from https://stackoverflow.com/questions/2408560/non-blocking-console-input
+
+    def __init__(self):
+        '''Creates a KBHit object that you can call to do various keyboard things.
+        '''
+
+        if os.name == 'nt':
+            pass
+        else:
+            # Save the terminal settings
+            self.fd = sys.stdin.fileno()
+            self.new_term = termios.tcgetattr(self.fd)
+            self.old_term = termios.tcgetattr(self.fd)
+
+            # New terminal setting unbuffered
+            self.new_term[3] = (self.new_term[3] & ~termios.ICANON & ~termios.ECHO)
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.new_term)
+
+            # Support normal-terminal reset at exit
+            atexit.register(self.set_normal_term)
+
+    def set_normal_term(self):
+        ''' Resets to normal terminal.  On Windows this is a no-op.
+        '''
+
+        if os.name == 'nt':
+            pass
+        else:
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
+
+    def getch(self):
+        ''' Returns a keyboard character after kbhit() has been called.
+            Should not be called in the same program as getarrow().
+        '''
+
+        s = ''
+        if os.name == 'nt':
+            return msvcrt.getch().decode('utf-8')
+        else:
+            return sys.stdin.read(1)
+
+    def kbhit(self):
+        ''' Returns True if keyboard character was hit, False otherwise.
+        '''
+        if os.name == 'nt':
+            return msvcrt.kbhit()
+        else:
+            dr,dw,de = select([sys.stdin], [], [], 0)
+            return dr != []
+
+
+
 LOG = logging.getLogger(__name__)
 
 
@@ -134,14 +198,20 @@ class RTTSubcommand(SubcommandBase):
 
                 rtt_cb = SEGGER_RTT_CB.from_buffer(bytearray(data[pos:]))
                 up_addr = rtt_cb_addr + SEGGER_RTT_CB.aUp.offset
-                # down_addr = up_addr + sizeof(SEGGER_RTT_BUFFER_UP) * rtt_cb.MaxNumUpBuffers
+                down_addr = up_addr + sizeof(SEGGER_RTT_BUFFER_UP) * rtt_cb.MaxNumUpBuffers
 
                 LOG.info(f"_SEGGER_RTT @ {rtt_cb_addr:#08x} with {rtt_cb.MaxNumUpBuffers} aUp and {rtt_cb.MaxNumDownBuffers} aDown")
 
                 target.resume()
 
-                while True:
+                # set up terminal input
+                kb = KBHit()
 
+                # byte array to send via RTT
+                cmd = bytes()
+
+                while True:
+                    # read data from up buffers (target -> host)    
                     data = target.read_memory_block8(up_addr, sizeof(SEGGER_RTT_BUFFER_UP))
                     up = SEGGER_RTT_BUFFER_UP.from_buffer(bytearray(data))
 
@@ -152,7 +222,7 @@ class RTTSubcommand(SubcommandBase):
                         """
                         data = target.read_memory_block8(up.pBuffer + up.RdOff, up.WrOff - up.RdOff)
                         target.write_memory(up_addr + SEGGER_RTT_BUFFER_UP.RdOff.offset, up.WrOff)
-                        print(bytes(data).decode(), end="")
+                        print(bytes(data).decode(), end="", flush=True)
 
                     elif up.WrOff < up.RdOff:
                         """
@@ -162,10 +232,61 @@ class RTTSubcommand(SubcommandBase):
                         data = target.read_memory_block8(up.pBuffer + up.RdOff, up.SizeOfBuffer - up.RdOff)
                         data += target.read_memory_block8(up.pBuffer, up.WrOff)
                         target.write_memory(up_addr + SEGGER_RTT_BUFFER_UP.RdOff.offset, up.WrOff)
-                        print(bytes(data).decode(), end="")
+                        print(bytes(data).decode(), end="", flush=True)
+
+                    else: # up buffer is empty
+
+                        # try and fetch character
+                        if not kb.kbhit():
+                            continue
+                        c = kb.getch()
+
+                        if ord(c) == 8 or ord(c) == 127: # process backspace
+                            print("\b \b", end="", flush=True)
+                            cmd = cmd[:-1]
+                            continue
+                        elif ord(c) == 27: # process ESC
+                            break
+                        else:
+                            print(c, end="", flush=True)
+                            cmd += c.encode()
+
+                        # keep accumulating until we see CR or LF
+                        if not c in "\r\n":
+                            continue
+
+                        # SEND TO TARGET
+
+                        data = target.read_memory_block8(down_addr, sizeof(SEGGER_RTT_BUFFER_DOWN))
+                        down = SEGGER_RTT_BUFFER_DOWN.from_buffer(bytearray(data))
+
+                        # compute free space in down buffer
+                        if down.WrOff >= down.RdOff:
+                            num_avail = down.SizeOfBuffer - (down.WrOff - down.RdOff)
+                        else:
+                            num_avail = down.RdOff - down.WrOff - 1
+
+                        # wait until there's space for the entire string in the RTT down buffer
+                        if (num_avail < len(cmd)):
+                            continue
+
+                        # write data to down buffer (host -> target), char by char
+                        for i in range(len(cmd)):
+                            target.write_memory_block8(down.pBuffer + down.WrOff, cmd[i:i+1])
+                            down.WrOff += 1
+                            if down.WrOff == down.SizeOfBuffer:
+                                down.WrOff = 0;
+                        target.write_memory(down_addr + SEGGER_RTT_BUFFER_DOWN.WrOff.offset, down.WrOff)
+
+                        # clear it and start anew
+                        cmd = bytes()
+
+        except KeyboardInterrupt:
+            pass
 
         finally:
             if session:
                 session.close()
+                kb.set_normal_term()
 
         return 0

--- a/pyocd/utility/kbhit.py
+++ b/pyocd/utility/kbhit.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2021 Simon D. Levy <simon.d.levy@gmail.com>
+# https://github.com/simondlevy/kbhit
+# 
+# MIT License
+# 
+# Copyright (c) 2021 Simon D. Levy
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+'''
+A Python class implementing KBHIT, the standard keyboard-interrupt poller.
+Works transparently on Windows and Posix (Linux, Mac OS X).  Doesn't work
+with IDLE.
+
+Copyright (c) 2021 Simon D. Levy
+
+MIT License
+'''
+
+import os
+
+# Windows
+if os.name == 'nt':
+    import msvcrt
+
+# Posix (Linux, OS X)
+else:
+    import sys
+    import termios
+    import atexit
+    from select import select
+
+
+class KBHit:
+    
+    def __init__(self):
+        '''Creates a KBHit object that you can call to do various keyboard things.
+        '''
+
+        if os.name == 'nt':
+            pass
+        
+        else:
+    
+            # Save the terminal settings
+            self.fd = sys.stdin.fileno()
+            self.new_term = termios.tcgetattr(self.fd)
+            self.old_term = termios.tcgetattr(self.fd)
+    
+            # New terminal setting unbuffered
+            self.new_term[3] = (self.new_term[3] & ~termios.ICANON & ~termios.ECHO)
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.new_term)
+    
+            # Support normal-terminal reset at exit
+            atexit.register(self.set_normal_term)
+    
+    
+    def set_normal_term(self):
+        ''' Resets to normal terminal.  On Windows this is a no-op.
+        '''
+        
+        if os.name == 'nt':
+            pass
+        
+        else:
+            termios.tcsetattr(self.fd, termios.TCSAFLUSH, self.old_term)
+
+
+    def getch(self):
+        ''' Returns a keyboard character after kbhit() has been called.
+            Should not be called in the same program as getarrow().
+        '''
+                
+        if os.name == 'nt':
+            return msvcrt.getch().decode('utf-8')
+        
+        else:
+            return sys.stdin.read(1)
+                        
+
+    def getarrow(self):
+        ''' Returns an arrow-key code after kbhit() has been called. Codes are
+        0 : up
+        1 : right
+        2 : down
+        3 : left
+        Should not be called in the same program as getch().
+        '''
+        
+        if os.name == 'nt':
+            msvcrt.getch() # skip 0xE0
+            c = msvcrt.getch()
+            vals = [72, 77, 80, 75]
+            
+        else:
+            c = sys.stdin.read(3)[2]
+            vals = [65, 67, 66, 68]
+        
+        return vals.index(ord(c.decode('utf-8')))
+        
+
+    def kbhit(self):
+        ''' Returns True if keyboard character was hit, False otherwise.
+        '''
+        if os.name == 'nt':
+            return msvcrt.kbhit()
+        
+        else:
+            dr,dw,de = select([sys.stdin], [], [], 0)
+            return dr != []
+    
+    
+# Test    
+if __name__ == "__main__":
+    
+    kb = KBHit()
+
+    print('Hit any key, or ESC to exit')
+
+    while True:
+
+        if kb.kbhit():
+            c = kb.getch()
+            if ord(c) == 27: # ESC
+                break
+            print(c)
+             
+    kb.set_normal_term()
+


### PR DESCRIPTION
This is an initial implementation of RTT host-to-target communication for pyOCD's `rtt` subcommand.
 - It is meant to provide bidirectional, terminal-like RTT communication with the target, with the assumption that the user will type on `stdin` short commands for the target
 - `stdin` is read one character at a time, in a non-blocking fashion. Characters are echoed to the terminal and accumulated in a buffer until we see a CR of LF. At that point, if there is sufficient space in the RTT down-buffer (host-to-target), the buffer is copied character-by-character to the RTT ring buffer.
 - the code processes backspace characters from `stdin`, allowing the user to make corrections before hitting CR/LF. ESC terminates the session.
 - all the modifications were carried out within `rtt_cmd.py`, including the addition of a class (copied from [here](https://stackoverflow.com/questions/2408560/non-blocking-console-input)) for cross-platform, non-blocking read of 1 character from stdin.
 