### PR TITLE
commander: fix broken semicolon-separated commands from -c argument.

### DIFF
--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -307,22 +307,18 @@ class CommandExecutionContext(object):
 
     def _split_commands(self, line):
         """! @brief Generator yielding commands separated by semicolons."""
-        result = ''
-        i = 0
-        while i < len(line):
-            c = line[i]
-            # Don't split on escaped semicolons.
-            if (c == '\\') and (i < len(line) - 1) and (line[i + 1] == ';'):
-                i += 1
-                result += ';'
-            elif c == ';':
-                yield result
-                result = ''
+        # FIXME This is a big, inefficient hack to work around a bug splitting on quoted semicolons. Practically,
+        #   though, it will never be noticeable.
+        parts = split_command_line(line)
+        result = []
+        for p in parts:
+            if p == ';':
+                yield " ".join(f'"{a}"' for a in result)
+                result = []
             else:
-                result += c
-            i += 1
+                result.append(p)
         if result:
-            yield result
+            yield " ".join(f'"{a}"' for a in result)
 
     def parse_command(self, cmdline):
         """! @brief Create a CommandInvocation from a single command."""

--- a/test/commander_test.py
+++ b/test/commander_test.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,28 +14,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
 
 import argparse
 import sys
 import traceback
 import logging
-import six
+from types import SimpleNamespace
 import os
-from collections import UserDict
 
-from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
-from pyocd.utility.mask import round_up_div
-from pyocd.utility import conversion
-from pyocd.core.memory_map import MemoryType
 from pyocd.commands.commander import PyOCDCommander
-from pyocd.commands import commands
 from test_util import (
     Test,
     TestResult,
-    get_session_options,
-    binary_to_elf_file,
     PYOCD_DIR,
     )
 
@@ -73,7 +65,10 @@ def commander_test(board_id):
             ["status"],
             ["halt"],
             ["status"],
-            
+
+            # semicolon separated
+            ["status", ";", "halt", ";", "continue", ";", "halt"],
+
             # commander command group - these are not tested by commands_test.py.
             ["list"],
             ["exit"], # Must be last command!
@@ -82,7 +77,7 @@ def commander_test(board_id):
     print("\n------ Testing commander ------\n")
     
     # Set up commander args.
-    args = UserDict()
+    args = SimpleNamespace()
     args.no_init = False
     args.frequency = 1000000
     args.options = {} #get_session_options()
@@ -103,18 +98,18 @@ def commander_test(board_id):
         cmdr.run()
         test_pass_count += 1
         print("TEST PASSED")
+
+        test_count += 1
+        print("Testing exit code")
+        print("Exit code:", cmdr.exit_code)
+        if cmdr.exit_code == 0:
+            test_pass_count += 1
+            print("TEST PASSED")
+        else:
+            print("TEST FAILED")
     except Exception:
         print("TEST FAILED")
         traceback.print_exc()
-        
-    test_count += 1
-    print("Testing exit code")
-    print("Exit code:", cmdr.exit_code)
-    if cmdr.exit_code == 0:
-        test_pass_count += 1
-        print("TEST PASSED")
-    else:
-        print("TEST FAILED")
 
     print("\n\nTest Summary:")
     print("Pass count %i of %i tests" % (test_pass_count, test_count))


### PR DESCRIPTION
This change fixes commander `-c` arguments with multiple commands separated by semicolons, such as `pyocd cmd -c 'halt ; status ; continue'`. Note that spaces are required on both sides of semicolons due to the use of shell-style parsing.

Add test case to `commander_test.py`, plus cleanup of that file.

