### PR TITLE
Fix ROM table negative addresses

### DIFF
--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -384,9 +384,11 @@ class Class1ROMTable(ROMTable):
     def _handle_table_entry(self, entry, number):
         # Nonzero entries can still be disabled, so check the present bit before handling.
         if (entry & self.ROM_TABLE_ENTRY_PRESENT_MASK) == 0:
+            LOG.debug("%s[%d]<%08x not present>", self.depth_indent, number, entry)
             return
         # Verify the entry format is 32-bit.
         if (entry & self.ROM_TABLE_32BIT_FORMAT_MASK) == 0:
+            LOG.debug("%s[%d]<%08x unsupported 8-bit format>", self.depth_indent, number, entry)
             return
 
         # Get the component's top 4k address.
@@ -554,6 +556,8 @@ class Class9ROMTable(ROMTable):
                         LOG.error("Error attempting to probe CoreSight component referenced by "
                                 "ROM table entry #%d: %s", entryNumber, err,
                                 exc_info=self.ap.dp.session.get_current().log_tracebacks)
+                else:
+                    LOG.debug("%s[%d]<%08x not present>", self.depth_indent, entryNumber, entry)
 
                 entryAddress += 4 * entrySizeMultiplier
                 entryNumber += 1

--- a/pyocd/coresight/rom_table.py
+++ b/pyocd/coresight/rom_table.py
@@ -394,6 +394,9 @@ class Class1ROMTable(ROMTable):
         if (entry & self.ROM_TABLE_ADDR_OFFSET_NEG_MASK) != 0:
             offset = ~bit_invert(offset)
         address = self.address + offset
+        # Handle address going negative, since python doesn't have unsigned ints.
+        if address < 0:
+            address = 0x100000000 + address
 
         # Check power ID.
         if (entry & self.ROM_TABLE_POWERIDVALID_MASK) != 0:
@@ -582,6 +585,9 @@ class Class9ROMTable(ROMTable):
         if (entry & self.ROM_TABLE_ADDR_OFFSET_NEG_MASK[self._width]) != 0:
             offset = ~bit_invert(offset, width=self._width)
         address = self.address + offset
+        # Handle address going negative, since python doesn't have unsigned ints.
+        if address < 0:
+            address = (1 << self._width) + address
 
         # Check power ID.
         if (entry & self.ROM_TABLE_ENTRY_POWERIDVALID_MASK) != 0:


### PR DESCRIPTION
If a CoreSight component's base address ends up being negative, correct it as an unsigned int. This is for cases where the address is intended to wrap around from the ROM table's base.

For instance, the Microchip SAML11's root ROM table is at 0x41003000, containing an entry with offset -0x60f04000 to the standard Cortex-M23 ROM table at 0xe00ff000. Without the adjustment, the M23 table base is -0x1ff01000.

Amazingly, it still worked without this adjustment because the Python bit-and operator converts to unsigned. Just dumb luck. 😄 

Additionally, debug logs are output for any ROM table entries that are skipped either because the entry says the component is not present or because the entry is an old 8-bit format that has never been seen in practise.