### PR TITLE
Fix flash unmodified page detection regression; change keep_unwritten default to false

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -217,9 +217,9 @@ Disables flash programming progress bar when True.
 
 <tr><td>keep_unwritten</td>
 <td>bool</td>
-<td>True</td>
+<td>False</td>
 <td>
-Whether to load existing flash content for ranges of sectors that will be erased but not written
+Whether to preserve existing flash content for ranges of sectors that will be erased but not written
 with new data.
 </td></tr>
 

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -76,9 +76,9 @@ BUILTIN_OPTIONS = [
         "SWD/JTAG frequency in Hertz."),
     OptionInfo('hide_programming_progress', bool, False,
         "Disables flash programming progress bar."),
-    OptionInfo('keep_unwritten', bool, True,
-        "Whether to load existing flash content for ranges of sectors that will be erased but not "
-        "written with new data. Default is True."),
+    OptionInfo('keep_unwritten', bool, False,
+        "Whether to preserve existing flash content for ranges of sectors that will be erased but not "
+        "written with new data. Default is False."),
     OptionInfo('logging', (str, dict), None,
         "Logging configuration dictionary, or path to YAML file containing logging configuration."),
     OptionInfo('no_config', bool, False,

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -20,7 +20,7 @@ import abc
 from dataclasses import dataclass
 from time import time
 from binascii import crc32
-from typing import (Any, Union)
+from typing import (Any, List, Optional, Union)
 
 from ..core.target import Target
 from ..core.exceptions import (FlashFailure, FlashProgramFailure)
@@ -95,11 +95,11 @@ def _stub_progress(percent):
 class _FlashSector:
     """! @brief Info about an erase sector and all pages to be programmed within it."""
     def __init__(self, sector_info):
-        self.addr = sector_info.base_addr
-        self.size = sector_info.size
-        self.max_page_count = 0
-        self.page_list = []
-        self.erase_weight = sector_info.erase_weight
+        self.addr: int = sector_info.base_addr
+        self.size: int = sector_info.size
+        self.max_page_count: int = 0
+        self.page_list: List[_FlashPage] = []
+        self.erase_weight: float = sector_info.erase_weight
 
     def add_page(self, page):
         # The first time a page is added, compute the page count for this sector. This
@@ -128,14 +128,14 @@ class _FlashSector:
 class _FlashPage:
     """! @brief A page to be programmed and its data."""
     def __init__(self, page_info):
-        self.addr = page_info.base_addr
-        self.size = page_info.size
-        self.data = []
-        self.program_weight = page_info.program_weight
-        self.erased = None # Whether the data all matches the erased value.
-        self.same = False
-        self.crc = 0
-        self.cached_estimate_data = None
+        self.addr: int = page_info.base_addr
+        self.size: int = page_info.size
+        self.data: List[int] = []
+        self.program_weight: float = page_info.program_weight
+        self.erased: Optional[bool] = None # Whether the data all matches the erased value.
+        self.same: Optional[bool] = None
+        self.crc: int = 0
+        self.cached_estimate_data: Optional[List[int]] = None
 
     def get_program_weight(self):
         """! @brief Get time to program a page including the data transfer."""


### PR DESCRIPTION
Commit 0f06e50 introduced a regression that forced the flash programming optimiser to believe all pages were modified.

Included in this PR is a change to disable the `keep_unwritten` session option by default. For most people, this option just adds some time to programming without any benefit.