### PR TITLE
commands: replace use of str.removeprefix()

### DIFF
--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -343,7 +343,11 @@ class CommandExecutionContext:
         # Check for Python or system command. For these we yield a list of 2 elements: the command
         # followed by the rest of the command line as it was originally.
         if parts and (parts[0] in '$!'):
-            line_remainder = line.removeprefix(parts[0]).strip()
+            # Remove the Python/system command prefix from the command line. Can't use str.removeprefix()
+            # since it was added in 3.9.
+            line_remainder = line.strip()
+            assert line_remainder.find(parts[0]) == 0
+            line_remainder = line_remainder[len(parts[0]):].strip()
             yield [parts[0], line_remainder]
             return
 


### PR DESCRIPTION
PR #1268 used `str.removeprefix()`, but that method was only added in Python 3.9. Replace its use so the code will work down to Python 3.6.