### PR TITLE
CMSIS-DAP: hidapi backend improvement; protocol version fixes; more trace logging

### DIFF
--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -89,6 +89,10 @@ Trace logger                                            | Trace output
 `pyocd.probe.cmsis_dap_probe.trace`                     | CMSIS-DAP probe API calls
 `pyocd.probe.jlink_probe.trace`                         | Log output from JLink library
 `pyocd.probe.pydapaccess.dap_access_cmsis_dap.trace`    | CMSIS-DAP packet building
+`pyocd.probe.pydapaccess.interface.hidapi_backend.trace` | CMSIS-DAP v1 hidapi backend USB transfers
+`pyocd.probe.pydapaccess.interface.pyusb_backend.trace` | CMSIS-DAP v1 pyusb backend USB transfers
+`pyocd.probe.pydapaccess.interface.pyusb_v2_backend.trace` | CMSIS-DAP v2 pyusb backend USB transfers
+`pyocd.probe.pydapaccess.interface.pywinusb_backend.trace` | CMSIS-DAP v1 pywinusb backend USB transfers
 `pyocd.probe.stlink.usb.trace`                          | STLink USB transfers
 `pyocd.probe.tcp_client_probe.trace`                    | Remote probe client requests and responses
 `pyocd.probe.tcp_probe_server.trace`                    | Remote probe server requests and responses

--- a/docs/options.md
+++ b/docs/options.md
@@ -70,6 +70,14 @@ Restrict CMSIS-DAP backend to using a single in-flight command at a time. This i
 where USB is problematic, in particular virtual machines.
 </td></tr>
 
+<tr><td>cmsis_dap.prefer_v1</td>
+<td>bool</td>
+<td>False</td>
+<td>
+If a device provides both CMSIS-DAP v1 and v2 interfaces, use the v1 interface in preference of v2.
+Normal behaviour is to prefer the v2 interface. This option is primarily intended for testing.
+</td></tr>
+
 <tr><td>commander.history_length</td>
 <td>int</td>
 <td>1000</td>

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -1279,6 +1279,19 @@ class MakeApCommand(CommandBase):
         self.context.target.dp.aps[self.ap_addr] = ap # Same mutable dict as target.aps
         self.context.writef("AP#{:d} IDR = {:#010x}", self.apsel, ap.idr)
 
+class FlushProbeCommand(CommandBase):
+    INFO = {
+            'names': ['flushprobe'],
+            'group': 'commander',
+            'category': 'probe',
+            'nargs': 0,
+            'usage': "",
+            'help': "Ensure all debug probe requests have been completed.",
+            }
+
+    def execute(self):
+        self.context.probe.flush()
+
 class ReinitCommand(CommandBase):
     INFO = {
             'names': ['reinit'],

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -39,6 +39,9 @@ BUILTIN_OPTIONS = [
         "Whether the CMSIS-DAP probe backend will use deferred transfers for improved performance."),
     OptionInfo('cmsis_dap.limit_packets', bool, False,
         "Restrict CMSIS-DAP backend to using a single in-flight command at a time."),
+    OptionInfo('cmsis_dap.prefer_v1', bool, False,
+        "If a device provides both CMSIS-DAP v1 and v2 interfaces, use the v1 interface in preference of v2. "
+        "Normal behaviour is to prefer the v2 interface. This option is primarily intended for testing."),
     OptionInfo('commander.history_length', int, 1000,
         "Number of entries in the pyOCD Commander command history. Set to -1 for unlimited. Default is 1000."),
     OptionInfo('config_file', str, None,

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -96,9 +96,11 @@ class Session(Notifier):
         or for debug or other purposes.
         """
         if cls._current_session is not None:
-            return cls._current_session()
-        else:
-            return Session(None)
+            session = cls._current_session()
+            if session is not None:
+                return session
+
+        return Session(None)
 
     def __init__(self, probe, auto_open=True, options=None, option_defaults=None, **kwargs):
         """! @brief Session constructor.

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -90,6 +90,14 @@ class CMSISDAPVersion:
     V2_1_0 = (2, 1, 0)
 
     @classmethod
+    def major_versions(cls) -> Set[int]:
+        """@brief Returns a set of major versions."""
+        return {
+            v[0] for k, v in cls.__dict__.items()
+            if k.startswith('V')
+            }
+
+    @classmethod
     def minor_versions(cls) -> Set[Tuple[int, int]]:
         """@brief Returns a set of minor version tuples."""
         return {

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -70,11 +70,18 @@ def _get_interfaces():
     # Get CMSIS-DAPv2 interfaces.
     v2_interfaces = INTERFACE[USB_BACKEND_V2].get_all_connected_interfaces()
 
-    # Prefer v2 over v1 if a device provides both.
-    devices_in_both = [v1 for v1 in v1_interfaces for v2 in v2_interfaces
-                        if _get_unique_id(v1) == _get_unique_id(v2)]
-    for dev in devices_in_both:
-        v1_interfaces.remove(dev)
+    # Prefer v2 over v1 if a device provides both, unless the 'cmsis_dap.prefer_v1' option is set.
+    prefer_v1 = session.Session.get_current().options.get('cmsis_dap.prefer_v1')
+    if prefer_v1:
+        devices_in_both = [v2 for v2 in v2_interfaces for v1 in v1_interfaces
+                            if _get_unique_id(v1) == _get_unique_id(v2)]
+        for dev in devices_in_both:
+            v2_interfaces.remove(dev)
+    else:
+        devices_in_both = [v1 for v1 in v1_interfaces for v2 in v2_interfaces
+                            if _get_unique_id(v1) == _get_unique_id(v2)]
+        for dev in devices_in_both:
+            v1_interfaces.remove(dev)
 
     # Return the combined list.
     return v1_interfaces + v2_interfaces

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -26,6 +26,7 @@ from .dap_settings import DAPSettings
 from .dap_access_api import DAPAccessIntf
 from .cmsis_dap_core import CMSISDAPProtocol
 from .interface import (INTERFACE, USB_BACKEND, USB_BACKEND_V2)
+from .interface.common import ARM_DAPLINK_ID
 from .cmsis_dap_core import (
     Command,
     Pin,
@@ -608,47 +609,60 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def _read_protocol_version(self):
         """! Determine the CMSIS-DAP protocol version."""
+        # The fallback version to use when version parsing fails depends on whether v2 bulk endpoints are used
+        # (unfortunately conflating transport with protocol).
+        fallback_protocol_version = (CMSISDAPVersion.V1_0_0, CMSISDAPVersion.V2_0_0)[self._interface.is_bulk]
+
         protocol_version_str = self._protocol.dap_info(self.ID.CMSIS_DAP_PROTOCOL_VERSION)
         # Just in case we don't get a valid response, default to the lowest version (not including betas).
         if not protocol_version_str:
-            self._cmsis_dap_version = CMSISDAPVersion.V1_0_0
-            return
+            self._cmsis_dap_version = fallback_protocol_version
+        # Deal with DAPLink broken version number, where these versions of the firmware reported the DAPLink
+        # version number for DAP_INFO_FW_VER instead of the CMSIS-DAP version, due to a misunderstanding
+        # based on unclear documentation.
+        elif (self._vidpid == ARM_DAPLINK_ID) and (protocol_version_str in ("0254", "0255")):
+            self._cmsis_dap_version = CMSISDAPVersion.V2_0_0
+        else:
+            # Convert the version to a 3-tuple for easy comparison.
+            # 1.2.3 will be converted to (1,2,3), 1.10 to (1,1,0), and so on.
+            #
+            # There are two version formats returned from the reference CMSIS-DAP code: 2-field and 3-field.
+            # The older versions return versions like "1.07" and "1.10", while recent versions return "1.2.0"
+            # or "2.0.0".
+            #
+            # Some CMSIS-DAP compatible debug probes from various vendors return the probe's firmware version
+            # rather than protocol version (like DAPLink versions 0254 and 0255 do) due to a misunderstanding
+            # based on unclear documentation. These cases are handled by the additional error checking below.
+            #
+            # Note that the exact version identified here is not that important, as it's not used much in
+            # this code (so far at least). There are also DAP_Info Capability bits for availability of certain
+            # commands that should be used instead of checking the version.
+            try:
+                fw_version = protocol_version_str.split('.')
+                major = int(fw_version[0])
+                # Handle version of the form "1.10" by treating the two digits after the dot as minor and patch.
+                if (len(fw_version) == 2) and len(fw_version[1]) == 2:
+                    minor = int(fw_version[1][0])
+                    patch = int(fw_version[1][1])
+                # All other forms.
+                else:
+                    minor = int(fw_version[1] if len(fw_version) > 1 else 0)
+                    patch = int(fw_version[2] if len(fw_version) > 2 else 0)
+                self._cmsis_dap_version = (major, minor, patch)
+            except ValueError:
+                # One of the protocol version fields had a non-numeric character, indicating it is not a valid
+                # CMSIS-DAP version number. Default to the lowest version.
+                LOG.debug("Error parsing CMSIS-DAP protocol version '%s'", protocol_version_str)
+                self._cmsis_dap_version = fallback_protocol_version
 
-        # Convert the version to a 3-tuple for easy comparison.
-        # 1.2.3 will be converted to (1,2,3), 1.10 to (1,1,0), and so on.
-        #
-        # There are two version formats returned from the reference CMSIS-DAP code: 2-field and 3-field.
-        # The older versions return versions like "1.07" and "1.10", while recent versions return "1.2.0"
-        # or "2.0.0".
-        #
-        # Some CMSIS-DAP compatible debug probes from various vendors return the probe's firmware version
-        # rather than protocol version (like DAPLink versions 0254 and 0255 do) due to a misunderstanding
-        # based on unclear documentation. These cases are handled by the additional error checking below.
-        #
-        # Note that the exact version identified here is not that important, as it's not used much in
-        # this code (so far at least). There are also DAP_Info Capability bits for availability of certain
-        # commands that should be used instead of checking the version.
-        try:
-            fw_version = protocol_version_str.split('.')
-            major = int(fw_version[0])
-            # Handle version of the form "1.10" by treating the two digits after the dot as minor and patch.
-            if (len(fw_version) == 2) and len(fw_version[1]) == 2:
-                minor = int(fw_version[1][0])
-                patch = int(fw_version[1][1])
-            # All other forms.
-            else:
-                minor = int(fw_version[1] if len(fw_version) > 1 else 0)
-                patch = int(fw_version[2] if len(fw_version) > 2 else 0)
-            self._cmsis_dap_version = (major, minor, patch)
-        except ValueError:
-            # One of the protocol version fields had a non-numeric character, indicating it is not a valid
-            # CMSIS-DAP version number. Default to the lowest version.
-            self._cmsis_dap_version = CMSISDAPVersion.V1_0_0
-
-        # Validate the version against known CMSIS-DAP minor versions. This will also catch the beta release
-        # versions of CMSIS-DAP, 0.01 and 0.02, and raise them to 1.0.0.
-        if self._cmsis_dap_version[:2] not in CMSISDAPVersion.minor_versions():
-            self._cmsis_dap_version = CMSISDAPVersion.V1_0_0
+            # Catch the beta release versions of CMSIS-DAP, 0.01 and 0.02, and raise them to 1.0.0.
+            if self._cmsis_dap_version[:2] == (0, 0):
+                self._cmsis_dap_version = CMSISDAPVersion.V1_0_0
+            # Validate the version against known CMSIS-DAP major versions.
+            elif self._cmsis_dap_version[0] not in CMSISDAPVersion.major_versions():
+                LOG.debug("Unrecognised major version of CMSIS-DAP: protocol version %i.%i.%i",
+                        *self._cmsis_dap_version)
+                self._cmsis_dap_version = fallback_protocol_version
 
     @locked
     def open(self):
@@ -673,12 +687,16 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
                 and self._cmsis_dap_version < CMSISDAPVersion.V2_0_0):
             self._fw_version = self._protocol.dap_info(self.ID.PRODUCT_FW_VERSION)
 
+        # Major protocol version based on use of bulk endpoints.
+        proto_major = (2 if self._interface.is_bulk else 1)
+
         # Log probe's firmware version.
         if self._fw_version:
-            LOG.debug("CMSIS-DAP probe %s: firmware version %s, protocol version %i.%i.%i",
-                    self._unique_id, self._fw_version, *self._cmsis_dap_version)
+            LOG.debug("CMSIS-DAP v%d probe %s: firmware version %s, protocol version %i.%i.%i",
+                    proto_major, self._unique_id, self._fw_version, *self._cmsis_dap_version)
         else:
-            LOG.debug("CMSIS-DAP probe %s: protocol version %i.%i.%i", self._unique_id, *self._cmsis_dap_version)
+            LOG.debug("CMSIS-DAP v%d probe %s: protocol version %i.%i.%i",
+                    proto_major, self._unique_id, *self._cmsis_dap_version)
 
         self._interface.set_packet_count(self._packet_count)
         self._packet_size = self._protocol.dap_info(self.ID.MAX_PACKET_SIZE)

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -27,6 +27,8 @@ from ..dap_access_api import DAPAccessIntf
 from ....utility.compatibility import to_str_safe
 
 LOG = logging.getLogger(__name__)
+TRACE = LOG.getChild("trace")
+TRACE.setLevel(logging.CRITICAL)
 
 try:
     import hid
@@ -104,15 +106,18 @@ class HidApiUSB(Interface):
     def write(self, data):
         """! @brief Write data on the OUT endpoint associated to the HID interface
         """
+        if TRACE.isEnabledFor(logging.DEBUG):
+            TRACE.debug("  USB OUT> (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
         data.extend([0] * (self.packet_size - len(data)))
-#         LOG.debug("snd>(%d) %s" % (len(data), ' '.join(['%02x' % i for i in data])))
         self.device.write([0] + data)
 
     def read(self, timeout=-1):
         """! @brief Read data on the IN endpoint associated to the HID interface
         """
         data = self.device.read(self.packet_size)
-#         LOG.debug("rcv<(%d) %s" % (len(data), ' '.join(['%02x' % i for i in data])))
+        if TRACE.isEnabledFor(logging.DEBUG):
+            # Strip off trailing zero bytes to reduce clutter.
+            TRACE.debug("  USB IN < (%d) %s", len(data), ' '.join([f'{i:02x}' for i in bytes(data).rstrip(b'\x00')]))
         return data
 
     def close(self):

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -15,8 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import collections
 import logging
 import six
+import threading
 
 from .interface import Interface
 from .common import (
@@ -25,6 +27,7 @@ from .common import (
     )
 from ..dap_access_api import DAPAccessIntf
 from ....utility.compatibility import to_str_safe
+from ....utility.timeout import Timeout
 
 LOG = logging.getLogger(__name__)
 TRACE = LOG.getChild("trace")
@@ -43,17 +46,52 @@ class HidApiUSB(Interface):
 
     isAvailable = IS_AVAILABLE
 
+    HIDAPI_MAX_PACKET_COUNT = 30
+
     def __init__(self):
-        super(HidApiUSB, self).__init__()
+        super().__init__()
         # Vendor page and usage_id = 2
         self.device = None
         self.device_info = None
+        self.thread = None
+        self.read_sem = threading.Semaphore(0)
+        self.closed_event = threading.Event()
+        self.received_data = collections.deque()
+
+    def set_packet_count(self, count):
+        # hidapi for macos has an arbitrary limit on the number of packets it will queue for reading.
+        # Even though we have a read thread, it doesn't hurt to limit the packet count since the limit
+        # is fairly high.
+        self.packet_count = min(count, self.HIDAPI_MAX_PACKET_COUNT)
 
     def open(self):
         try:
             self.device.open_path(self.device_info['path'])
         except IOError as exc:
             raise DAPAccessIntf.DeviceError("Unable to open device: " + str(exc)) from exc
+
+        self.closed_event.clear()
+
+        # Start RX thread
+        self.thread = threading.Thread(target=self.rx_task)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def rx_task(self):
+        try:
+            while not self.closed_event.is_set():
+                self.read_sem.acquire()
+                if not self.closed_event.is_set():
+                    read_data = self.device.read(self.packet_size)
+
+                    if TRACE.isEnabledFor(logging.DEBUG):
+                        # Strip off trailing zero bytes to reduce clutter.
+                        TRACE.debug("  USB IN < (%d) %s", len(read_data), ' '.join([f'{i:02x}' for i in bytes(read_data).rstrip(b'\x00')]))
+
+                    self.received_data.append(read_data)
+        finally:
+            # Set last element of rcv_data to None on exit
+            self.received_data.append(None)
 
     @staticmethod
     def get_all_connected_interfaces():
@@ -109,19 +147,40 @@ class HidApiUSB(Interface):
         if TRACE.isEnabledFor(logging.DEBUG):
             TRACE.debug("  USB OUT> (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
         data.extend([0] * (self.packet_size - len(data)))
+        self.read_sem.release()
         self.device.write([0] + data)
 
-    def read(self, timeout=-1):
+    def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
         """! @brief Read data on the IN endpoint associated to the HID interface
         """
-        data = self.device.read(self.packet_size)
+        # Spin for a while if there's not data available yet. 100 µs sleep between checks.
+        with Timeout(timeout, sleeptime=0.0001) as t_o:
+            while t_o.check():
+                if len(self.received_data) != 0:
+                    break
+            else:
+                raise DAPAccessIntf.DeviceError(f"Timeout reading from device {self.serial_number}")
+
+        if self.received_data[0] is None:
+            raise DAPAccessIntf.DeviceError(f"Device {self.serial_number} read thread exited")
+
+        # Trace when the higher layer actually gets a packet previously read.
         if TRACE.isEnabledFor(logging.DEBUG):
             # Strip off trailing zero bytes to reduce clutter.
-            TRACE.debug("  USB IN < (%d) %s", len(data), ' '.join([f'{i:02x}' for i in bytes(data).rstrip(b'\x00')]))
-        return data
+            TRACE.debug("  USB RD < (%d) %s", len(self.received_data[0]),
+                    ' '.join([f'{i:02x}' for i in bytes(self.received_data[0]).rstrip(b'\x00')]))
+
+        return self.received_data.popleft()
+
 
     def close(self):
         """! @brief Close the interface
         """
+        assert not self.closed_event.is_set()
+
         LOG.debug("closing interface")
+        self.closed_event.set()
+        self.read_sem.release()
+        self.thread.join()
+        self.thread = None
         self.device.close()

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -30,6 +30,11 @@ class Interface(object):
     def has_swo_ep(self):
         return False
 
+    @property
+    def is_bulk(self):
+        """@brief Whether the interface uses CMSIS-DAP v2 bulk endpoints."""
+        return False
+
     def open(self):
         return
 
@@ -63,3 +68,6 @@ class Interface(object):
 
     def get_serial_number(self):
         return self.serial_number
+
+    def __repr__(self):
+        return f"<{type(self).__name__}@{id(self):x} {self.get_info()} {self.serial_number}>"

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -17,6 +17,8 @@
 
 class Interface(object):
 
+    DEFAULT_READ_TIMEOUT = 20
+
     def __init__(self):
         self.vid = 0
         self.pid = 0
@@ -44,7 +46,7 @@ class Interface(object):
     def write(self, data):
         return
 
-    def read(self, size=-1, timeout=-1):
+    def read(self, timeout=DEFAULT_READ_TIMEOUT):
         return
 
     def get_info(self):

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -75,6 +75,11 @@ class PyUSBv2(Interface):
     def has_swo_ep(self):
         return self.ep_swo is not None
 
+    @property
+    def is_bulk(self):
+        """@brief Whether the interface uses CMSIS-DAP v2 bulk endpoints."""
+        return True
+
     def open(self):
         assert self.closed is True
 

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -233,21 +233,25 @@ class STLinkUSBInterface:
 
         try:
             # Command phase.
-            TRACE.debug("  USB CMD> %s" % ' '.join(['%02x' % i for i in paddedCmd]))
+            if TRACE.isEnabledFor(logging.DEBUG):
+                TRACE.debug("  USB CMD> (%d) %s", len(paddedCmd), ' '.join([f'{i:02x}' for i in paddedCmd]))
             count = self._ep_out.write(paddedCmd, timeout)
             assert count == len(paddedCmd)
 
             # Optional data out phase.
             if writeData is not None:
-                TRACE.debug("  USB OUT> %s" % ' '.join(['%02x' % i for i in writeData]))
+                if TRACE.isEnabledFor(logging.DEBUG):
+                    TRACE.debug("  USB OUT> (%d) %s", len(writeData), ' '.join([f'{i:02x}' for i in writeData]))
                 count = self._ep_out.write(writeData, timeout)
                 assert count == len(writeData)
 
             # Optional data in phase.
             if readSize is not None:
-                TRACE.debug("  USB IN < (%d bytes)" % readSize)
+                if TRACE.isEnabledFor(logging.DEBUG):
+                    TRACE.debug("  USB IN < (req %d bytes)", readSize)
                 data = self._read(readSize)
-                TRACE.debug("  USB IN < %s" % ' '.join(['%02x' % i for i in data]))
+                if TRACE.isEnabledFor(logging.DEBUG):
+                    TRACE.debug("  USB IN < (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
                 return data
         except usb.core.USBError as exc:
             raise exceptions.ProbeError("USB Error: %s" % exc) from exc


### PR DESCRIPTION
There are two major, connected components to this PR, all focused on the CMSIS-DAP implementation.

The first component is some fixes/improvements:

- Fix issue #1257 in the hidapi backend (used for CMSIS-DAP v1 on Mac and Windows) where command responses could get lost if the CMSIS-DAP maximum outstanding packet count was over 30.
    - Add a background read thread. This reads an incoming response as soon as it's available.
    - Limit outstanding packets to 30, matching the arbitrary limit built in to the Mac version of hidapi.
- Introduce timeouts for packet reads in the hidapi, pyusb, and pyusb v2 backends (pywinusb already had a timeout).
- Better handle unrecognized versions during detection of the CMSIS-DAP protocol version.
    - The debug log message with the protocol version now also includes a "v1"/"v2" based solely on use of bulk endpoints.
    - If an unrecognised or unparseable version is found (like DAPLink's 0254 or 0255 releases, or Microchip EDBG), fall back to either v1.0.0 or v2.0.0 based on use of bulk endpoints.
    - Compare only major+minor protocol versions, and output a debug log message if an unrecognised version is seen.

The second component improves CMSIS-DAP trace logging and test features:

- Add USB packet trace logging to the backends. Can be enabled with `-Lpyocd.probe.pydapaccess.interface.*backend.trace=debug`.
- Improve trace logging for building of transfer command packets in the CMSIS-DAP core (`dap_access_cmsis_dap.py`). Enabled with `-Lpyocd.probe.pydapaccess.dap_access_cmsis_dap.trace=debug`.
- Add `cmsis_dap.prefer_v1` session option to force selection of v1 if a probe provides both v1 and v2 interfaces. Naturally, v2 is and always has been, used by default.
- New 'flushprobe' command that ensure all outstanding command responses have been received.

There are also some minor changes to go along with the above.

Thanks to @afeinman-snap for the bug report that drove these changes, and he and @bohdan-tymkiv for help solving it!

Fixes #1257.