### PR TITLE
AZP: fix pyocd.yaml artifact access from fork PR builds

### DIFF
--- a/.azure/functional-test-pipeline.yml
+++ b/.azure/functional-test-pipeline.yml
@@ -77,6 +77,7 @@ jobs:
       vstsFeedPackage: 'pyocd-test-config'
       vstsPackageVersion: '*'
       downloadDirectory: 'test'
+      verbosity: 'debug'
     displayName: 'Install test config'
 
   # Linux/Mac: Activate venv and run automated test suite.

--- a/.azure/functional-test-pipeline.yml
+++ b/.azure/functional-test-pipeline.yml
@@ -6,8 +6,12 @@ trigger:
       - '*'
   paths:
     include:
+      - '.azure'
       - 'pyocd'
       - 'test'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
 
 pr:
   branches:
@@ -15,8 +19,12 @@ pr:
       - '*'
   paths:
     include:
+      - '.azure'
       - 'pyocd'
       - 'test'
+      - 'pyproject.toml'
+      - 'setup.cfg'
+      - 'setup.py'
 
 jobs:
 - job: functional_tests


### PR DESCRIPTION
When running the AZP pipeline with a PR from a fork, the job to download the [`pyocd.yaml` test config artifact](https://dev.azure.com/pyocd/pyocd/_packaging?_a=package&feed=config&package=pyocd-test-config&version=0.0.3&protocolType=UPack) fails due to a permissions error.

A small change to the pyocd code is included so the PR will pass the pipeline path filters.