### PR TITLE
First batch of type annotations

### DIFF
--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -16,20 +16,45 @@
 # limitations under the License.
 
 import logging
+from typing import (Any, Optional, TYPE_CHECKING)
 
 from ..core import exceptions
 from ..target import TARGET
 from ..target.pack import pack_target
 from ..utility.graph import GraphNode
 
+if TYPE_CHECKING:
+    from ..core.session import Session
+
 LOG = logging.getLogger(__name__)
 
 class Board(GraphNode):
-    """!
-    @brief This class associates a target and flash to create a board.
+    """!@brief Represents the board containing the target and associated components.
+
+    The board is the root of the runtime object graph.
     """
-    def __init__(self, session, target=None):
-        super(Board, self).__init__()
+    def __init__(self,
+            session: "Session",
+            target: Optional[str] = None,
+            ) -> None:
+        """@brief Constructor
+
+        This method is responsible for selecting the SoCTarget subclass for the SoC, implementing the target
+        type support. There are several possible sources for the target type name, with differing levels of
+        priority.
+
+        1. `target` parameter
+        2. `target_override` session option
+        3. `soft_target` parameter
+        4. Last resort `cortex_m` target type. If this type is used, a warning is printed (unless the
+            `warning.cortex_m_default` option is disabled).
+
+        @param self
+        @param session The session instance that owns us.
+        @param target Target type name to use. If this parameter is set, it overrides all other sources of the
+            target type.
+        """
+        super().__init__()
 
         # Use the session option if no target type was given to us.
         if target is None:
@@ -85,7 +110,7 @@ class Board(GraphNode):
 
         self.add_child(self.target)
 
-    def init(self):
+    def init(self) -> None:
         """! @brief Initialize the board."""
         # If we don't have a delegate set yet, see if there is a session delegate.
         if (self.delegate is None) and (self.session.delegate is not None):
@@ -103,7 +128,7 @@ class Board(GraphNode):
         if (self.delegate is not None) and hasattr(self.delegate, 'did_connect'):
             self.delegate.did_connect(board=self)
 
-    def uninit(self):
+    def uninit(self) -> None:
         """! @brief Uninitialize the board."""
         if self._inited:
             LOG.debug("uninit board %s", self)
@@ -115,34 +140,44 @@ class Board(GraphNode):
                 LOG.error("link exception during target disconnect: %s", err, exc_info=self._session.log_tracebacks)
 
     @property
-    def session(self):
+    def session(self) -> "Session":
+        """@brief The session that owns this board instance."""
         return self._session
 
     @property
-    def delegate(self):
+    def delegate(self) -> Any:
+        """@brief Delegate object that will be inherited by the SoCTarget."""
         return self._delegate
 
     @delegate.setter
-    def delegate(self, the_delegate):
+    def delegate(self, the_delegate: Any) -> None:
+        """@brief Set the delegate object that will be inherited by the SoCTarget."""
         self._delegate = the_delegate
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
+        """@brief The probe's unique ID.
+
+        Deprecated. Use the probe's `unique_id` property instead.
+        """
+        assert self.session.probe
         return self.session.probe.unique_id
 
     @property
-    def target_type(self):
+    def target_type(self) -> str:
+        """@brief Target type name."""
         return self._target_type
 
     @property
-    def test_binary(self):
+    def test_binary(self) -> Optional[str]:
         return self._test_binary
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "generic"
 
     @property
-    def description(self):
+    def description(self) -> str:
+        assert self.session.probe
         return "Generic board via " + self.session.probe.vendor_name + " " \
                 + self.session.probe.product_name + " [" + self.target_type + "]"

--- a/pyocd/board/board_ids.py
+++ b/pyocd/board/board_ids.py
@@ -15,11 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class BoardInfo(object):
-    def __init__(self, name, target, binary):
-        self.name = name
-        self.target = target
-        self.binary = binary
+from typing import (NamedTuple, Optional)
+
+class BoardInfo(NamedTuple):
+    name: str
+    target: str
+    binary: Optional[str] = None
+    vendor: Optional[str] = None
 
 BOARD_ID_TO_INFO = {
   # Note: please keep board list sorted by ID!

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -161,6 +161,7 @@ class RegisterCommandBase(CommandBase):
                 lsb = f.bit_offset
                 f_value = bfx(value, msb, lsb)
                 v_enum = None
+                v = None
                 if f.enumerated_values:
                     for v in f.enumerated_values:
                         if v.value == f_value:
@@ -176,6 +177,7 @@ class RegisterCommandBase(CommandBase):
                 f_value_bin_str = bin(f_value)[2:]
                 f_value_bin_str = "0" * (f.bit_width - len(f_value_bin_str)) + f_value_bin_str
                 if v_enum:
+                    assert v
                     f_value_enum_str = " %s: %s" % (v.name, v_enum.description)
                 else:
                     f_value_enum_str = ""

--- a/pyocd/core/core_registers.py
+++ b/pyocd/core/core_registers.py
@@ -17,12 +17,17 @@
 
 import logging
 from copy import copy
+from typing import (Any, Callable, Dict, Iterator, List, Optional, Sequence, Set, Union)
 
 from ..utility import conversion
 
 LOG = logging.getLogger(__name__)
 
-class CoreRegisterInfo(object):
+# Core register related types.
+CoreRegisterNameOrNumberType = Union[str, int]
+CoreRegisterValueType = Union[int, float]
+
+class CoreRegisterInfo:
     """! @brief Useful information about a core register.
 
     Provides properties for classification of the register, and utilities to convert to and from
@@ -34,25 +39,25 @@ class CoreRegisterInfo(object):
 
     ## Map of register name to info.
     #
-    # This is just a placeholder. The architecture-specific subclass should override the definition. Its
-    # value is set to None to cause an exception if used.
-    _NAME_MAP = None
+    # This is just the type declaration. The architecture-specific subclass must define the attribute, so
+    # that architectures
+    _NAME_MAP: Dict[str, "CoreRegisterInfo"]
 
     ## Map of register index to info.
     #
     # This is just a placeholder. The architecture-specific subclass should override the definition. Its
     # value is set to None to cause an exception if used.
-    _INDEX_MAP = None
+    _INDEX_MAP: Dict[int, "CoreRegisterInfo"]
 
     @classmethod
-    def add_to_map(cls, all_regs):
+    def add_to_map(cls, all_regs: Sequence["CoreRegisterInfo"]) -> None:
         """! @brief Build info map from list of CoreRegisterInfo instance."""
         for reg in all_regs:
             cls._NAME_MAP[reg.name] = reg
             cls._INDEX_MAP[reg.index] = reg
 
     @classmethod
-    def get(cls, reg):
+    def get(cls, reg: "CoreRegisterNameOrNumberType") -> "CoreRegisterInfo":
         """! @brief Return the CoreRegisterInfo instance for a register.
         @param reg Either a register name or internal register number.
         @return CoreRegisterInfo
@@ -67,7 +72,16 @@ class CoreRegisterInfo(object):
         except KeyError as err:
             raise KeyError('unknown core register %s' % reg) from err
 
-    def __init__(self, name, index, bitsize, reg_type, reg_group, reg_num=None, feature=None):
+    def __init__(
+                self,
+                name: str,
+                index: int,
+                bitsize: int,
+                reg_type: str,
+                reg_group: str,
+                reg_num: Optional[int] = None,
+                feature: Optional[str] = None
+                ) -> None:
         """! @brief Constructor."""
         self._name = name
         self._index = index
@@ -78,65 +92,66 @@ class CoreRegisterInfo(object):
         self._gdb_feature = feature
 
     @property
-    def name(self):
+    def name(self) -> str:
         """! @brief Name of the register. Always lowercase."""
         return self._name
 
     @property
-    def index(self):
+    def index(self) -> int:
         """! @brief Integer index of the register."""
         return self._index
 
     @property
-    def bitsize(self):
+    def bitsize(self) -> int:
         """! @brief Bit width of the register.."""
         return self._bitsize
 
     @property
-    def group(self):
+    def group(self) -> str:
         """! @brief Named group the register is contained within."""
         return self._group
 
     @property
-    def gdb_type(self):
+    def gdb_type(self) -> str:
         """! @brief Value type specific to gdb."""
         return self._gdb_type
 
     @property
-    def gdb_regnum(self):
+    def gdb_regnum(self) -> Optional[int]:
         """! @brief Register number specific to gdb."""
         return self._gdb_regnum
 
     @property
-    def gdb_feature(self):
+    def gdb_feature(self) -> Optional[str]:
         """! @brief GDB architecture feature to which the register belongs."""
         return self._gdb_feature
 
     @property
-    def is_float_register(self):
+    def is_float_register(self) -> bool:
         """! @brief Returns true for registers single or double precision float registers (but not, say, FPSCR)."""
         return self.is_single_float_register or self.is_double_float_register
 
     @property
-    def is_single_float_register(self):
+    def is_single_float_register(self) -> bool:
         """! @brief Returns true for registers holding single-precision float values"""
         return self.gdb_type == 'ieee_single'
 
     @property
-    def is_double_float_register(self):
+    def is_double_float_register(self) -> bool:
         """! @brief Returns true for registers holding double-precision float values"""
         return self.gdb_type == 'ieee_double'
 
-    def from_raw(self, value):
+    def from_raw(self, value: int) -> "CoreRegisterValueType":
         """! @brief Convert register value from raw (integer) to canonical type."""
         # Convert int to float.
         if self.is_single_float_register:
-            value = conversion.u32_to_float32(value)
+            return conversion.u32_to_float32(value)
         elif self.is_double_float_register:
-            value = conversion.u64_to_float64(value)
-        return value
+            return conversion.u64_to_float64(value)
+        else:
+            return value
 
-    def to_raw(self, value):
+    def to_raw(self, value: "CoreRegisterValueType") -> int:
         """! @brief Convert register value from canonical type to raw (integer)."""
         # Convert float to int.
         if isinstance(value, float):
@@ -148,20 +163,20 @@ class CoreRegisterInfo(object):
                 raise TypeError("non-float register value has float type")
         return value
 
-    def clone(self):
+    def clone(self) -> "CoreRegisterInfo":
         """! @brief Return a copy of the register info."""
         return copy(self)
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return isinstance(other, CoreRegisterInfo) and (self.index == other.index)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.index)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}@{:#x} {}={} {}-bit>".format(self.__class__.__name__, id(self), self.name, self.index, self.bitsize)
 
-class CoreRegistersIndex(object):
+class CoreRegistersIndex:
     """! @brief Class to hold indexes of available core registers.
 
     This class is meant to be used by a core to hold the set of core registers that are actually present on
@@ -170,38 +185,38 @@ class CoreRegistersIndex(object):
     """
 
     def __init__(self):
-        self._groups = set()
-        self._all = set()
-        self._by_name = {}
-        self._by_index = {}
-        self._by_feature = {}
+        self._groups: Set[str] = set()
+        self._all: Set[CoreRegisterInfo] = set()
+        self._by_name: Dict[str, CoreRegisterInfo] = {}
+        self._by_index: Dict[int, CoreRegisterInfo] = {}
+        self._by_feature: Dict[str, List[CoreRegisterInfo]] = {}
 
     @property
-    def groups(self):
+    def groups(self) -> Set[str]:
         """! @brief Set of unique register group names."""
         return self._groups
 
     @property
-    def as_set(self):
+    def as_set(self) -> Set[CoreRegisterInfo]:
         """! @brief Set of available registers as CoreRegisterInfo objects."""
         return self._all
 
     @property
-    def by_name(self):
+    def by_name(self) -> Dict[str, CoreRegisterInfo]:
         """! @brief Dict of (register name) -> CoreRegisterInfo."""
         return self._by_name
 
     @property
-    def by_index(self):
+    def by_index(self) -> Dict[int, CoreRegisterInfo]:
         """! @brief Dict of (register index) -> CoreRegisterInfo."""
         return self._by_index
 
     @property
-    def by_feature(self):
+    def by_feature(self) -> Dict[str, List[CoreRegisterInfo]]:
         """! @brief Dict of (register gdb feature) -> List[CoreRegisterInfo]."""
         return self._by_feature
 
-    def iter_matching(self, predicate):
+    def iter_matching(self, predicate: Callable[[CoreRegisterInfo], bool]) -> Iterator[CoreRegisterInfo]:
         """! @brief Iterate over registers matching a given predicate callable.
         @param self The object.
         @param predicate Callable accepting a single argument, a CoreRegisterInfo, and returning a boolean.
@@ -211,7 +226,7 @@ class CoreRegistersIndex(object):
             if predicate(reg):
                 yield reg
 
-    def add_group(self, regs):
+    def add_group(self, regs: Sequence[CoreRegisterInfo]) -> None:
         """! @brief Add a list of registers.
         @param self The object.
         @param regs Iterable of CoreRegisterInfo objects. The objects are copied as they are added.

--- a/pyocd/core/core_target.py
+++ b/pyocd/core/core_target.py
@@ -1,0 +1,47 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import (Optional, TYPE_CHECKING)
+
+from .target import (Target, TargetGraphNode)
+
+if TYPE_CHECKING:
+    from ..debug.context import DebugContext
+    from ..debug.elf.elf import ELFBinaryFile
+
+class CoreTarget(TargetGraphNode):
+    """@brief Target base class for CPU cores."""
+
+    @property
+    def core_number(self) -> int:
+        raise NotImplementedError()
+
+    @property
+    def elf(self) -> Optional["ELFBinaryFile"]:
+        raise NotImplementedError()
+
+    @elf.setter
+    def elf(self, filename: "ELFBinaryFile") -> None:
+        raise NotImplementedError()
+
+    def set_reset_catch(self, reset_type: Target.ResetType) -> None:
+        raise NotImplementedError()
+
+    def clear_reset_catch(self, reset_type: Target.ResetType) -> None:
+        raise NotImplementedError()
+
+    def set_target_context(self, context: "DebugContext") -> None:
+        raise NotImplementedError()

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -18,6 +18,13 @@
 from time import sleep
 import colorama
 import prettytable
+from typing import (Any, List, Mapping, Optional, Sequence, TYPE_CHECKING)
+
+from .session import Session
+from ..probe.aggregator import DebugProbeAggregator
+
+if TYPE_CHECKING:
+    from ..probe.debug_probe import DebugProbe
 
 from .session import Session
 from ..probe.aggregator import DebugProbeAggregator
@@ -25,7 +32,7 @@ from ..probe.aggregator import DebugProbeAggregator
 # Init colorama here since this is currently the only module that uses it.
 colorama.init()
 
-class ConnectHelper(object):
+class ConnectHelper:
     """! @brief Helper class for streamlining the probe discovery and session creation process.
 
     This class provides several static methods that wrap the DebugProbeAggregator methods
@@ -34,7 +41,12 @@ class ConnectHelper(object):
     """
 
     @staticmethod
-    def get_sessions_for_all_connected_probes(blocking=True, unique_id=None, options=None, **kwargs):
+    def get_sessions_for_all_connected_probes(
+            blocking: bool = True,
+            unique_id: Optional[str] = None,
+            options: Optional[Mapping[str, Any]] = None,
+            **kwargs
+            ) -> List[Session]:
         """! @brief Return a list of Session objects for all connected debug probes.
 
         This method is useful for listing detailed information about connected probes, especially
@@ -60,7 +72,11 @@ class ConnectHelper(object):
         return sessions
 
     @staticmethod
-    def get_all_connected_probes(blocking=True, unique_id=None, print_wait_message=True):
+    def get_all_connected_probes(
+            blocking: bool = True,
+            unique_id: Optional[str] = None,
+            print_wait_message: bool = True
+            ) -> List["DebugProbe"]:
         """! @brief Return a list of DebugProbe objects for all connected debug probes.
 
         The returned list of debug probes is always sorted by the combination of the probe's
@@ -100,8 +116,8 @@ class ConnectHelper(object):
         return sortedProbes
 
     @staticmethod
-    def list_connected_probes():
-        """! @brief List the connected debug probes.
+    def list_connected_probes() -> None:
+        """! @brief List the connected debug probes.   
 
         Prints a list of all connected probes to stdout. If no probes are connected, a message
         saying as much is printed instead.
@@ -114,7 +130,11 @@ class ConnectHelper(object):
         print(colorama.Style.RESET_ALL, end='')
 
     @staticmethod
-    def choose_probe(blocking=True, return_first=False, unique_id=None):
+    def choose_probe(
+            blocking: bool = True,
+            return_first: bool = False,
+            unique_id: str = None
+            ) -> Optional["DebugProbe"]:
         """! @brief Return a debug probe possibly chosen by the user.
 
         This method provides an easy to use command line interface for selecting one of the
@@ -164,6 +184,7 @@ class ConnectHelper(object):
 
         # Ask user to select boards if there is more than 1 left
         if len(allProbes) > 1:
+            ch = 0
             ConnectHelper._print_probe_list(allProbes)
             while True:
                 print(colorama.Style.RESET_ALL)
@@ -179,7 +200,7 @@ class ConnectHelper(object):
                     pass
                 if not valid:
                     print(colorama.Fore.YELLOW + "Invalid choice: %s\n" % line)
-                    Session._print_probe_list(allProbes)
+                    ConnectHelper._print_probe_list(allProbes)
                 else:
                     break
             allProbes = allProbes[ch:ch + 1]
@@ -188,8 +209,14 @@ class ConnectHelper(object):
         return allProbes[0]
 
     @staticmethod
-    def session_with_chosen_probe(blocking=True, return_first=False, unique_id=None,
-                    auto_open=True, options=None, **kwargs):
+    def session_with_chosen_probe(
+            blocking: bool = True,
+            return_first: bool = False,
+            unique_id: Optional[str] = None,
+            auto_open: bool = True,
+            options: Optional[Mapping[str, Any]] = None,
+            **kwargs
+            ) -> Optional[Session]:
         """! @brief Create a session with a probe possibly chosen by the user.
 
         This method provides an easy to use command line interface for selecting one of the
@@ -242,7 +269,7 @@ class ConnectHelper(object):
             return Session(probe, auto_open=auto_open, options=options, **kwargs)
 
     @staticmethod
-    def _print_probe_list(probes):
+    def _print_probe_list(probes: Sequence["DebugProbe"]) -> None:
         pt = prettytable.PrettyTable(["#", "Probe", "Unique ID"])
         pt.align = 'l'
         pt.header = True

--- a/pyocd/core/memory_interface.py
+++ b/pyocd/core/memory_interface.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,64 +15,147 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import (Callable, Sequence, Union, cast, overload)
+from typing_extensions import Literal
+
 from ..utility import conversion
 
-class MemoryInterface(object):
+class MemoryInterface:
     """! @brief Interface for memory access."""
 
-    def write_memory(self, addr, data, transfer_size=32):
+    def write_memory(self, addr: int, data: int, transfer_size: int = 32) -> None:
         """! @brief Write a single memory location.
 
         By default the transfer size is a word."""
         raise NotImplementedError()
 
-    def read_memory(self, addr, transfer_size=32, now=True):
+    @overload
+    def read_memory(self, addr: int, transfer_size: int = 32) -> int:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int = 32, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_memory(self, addr: int, transfer_size: int = 32, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Read a memory location.
 
         By default, a word will be read."""
         raise NotImplementedError()
 
-    def write_memory_block32(self, addr, data):
+    def write_memory_block32(self, addr: int, data: Sequence[int]) -> None:
         """! @brief Write an aligned block of 32-bit words."""
         raise NotImplementedError()
 
-    def read_memory_block32(self, addr, size):
+    def read_memory_block32(self, addr: int, size) -> Sequence[int]:
         """! @brief Read an aligned block of 32-bit words."""
         raise NotImplementedError()
 
-    def write64(self, addr, value):
+    def write64(self, addr: int, value: int) -> None:
         """! @brief Shorthand to write a 64-bit word."""
         self.write_memory(addr, value, 64)
 
-    def write32(self, addr, value):
+    def write32(self, addr: int, value: int) -> None:
         """! @brief Shorthand to write a 32-bit word."""
         self.write_memory(addr, value, 32)
 
-    def write16(self, addr, value):
+    def write16(self, addr: int, value: int) -> None:
         """! @brief Shorthand to write a 16-bit halfword."""
         self.write_memory(addr, value, 16)
 
-    def write8(self, addr, value):
+    def write8(self, addr: int, value: int) -> None:
         """! @brief Shorthand to write a byte."""
         self.write_memory(addr, value, 8)
 
-    def read64(self, addr, now=True):
+    @overload
+    def read64(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read64(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read64(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read64(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read64(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Shorthand to read a 64-bit word."""
         return self.read_memory(addr, 64, now)
 
-    def read32(self, addr, now=True):
+    @overload
+    def read32(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read32(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read32(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read32(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read32(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Shorthand to read a 32-bit word."""
         return self.read_memory(addr, 32, now)
 
-    def read16(self, addr, now=True):
+    @overload
+    def read16(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read16(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read16(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read16(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read16(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Shorthand to read a 16-bit halfword."""
         return self.read_memory(addr, 16, now)
 
-    def read8(self, addr, now=True):
+    @overload
+    def read8(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read8(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read8(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read8(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read8(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Shorthand to read a byte."""
         return self.read_memory(addr, 8, now)
 
-    def read_memory_block8(self, addr, size):
+    def read_memory_block8(self, addr: int, size: int) -> Sequence[int]:
         """! @brief Read a block of unaligned bytes in memory.
         @return an array of byte values
         """
@@ -86,7 +170,7 @@ class MemoryInterface(object):
 
         # try to read 16bits data
         if (size > 1) and (addr & 0x02):
-            mem = self.read16(addr)
+            mem = cast(int, self.read16(addr))
             res.append(mem & 0xff)
             res.append((mem >> 8) & 0xff)
             size -= 2
@@ -94,13 +178,13 @@ class MemoryInterface(object):
 
         # try to read aligned block of 32bits
         if (size >= 4):
-            mem = self.read_memory_block32(addr, size // 4)
-            res += conversion.u32le_list_to_byte_list(mem)
-            size -= 4*len(mem)
-            addr += 4*len(mem)
+            data32 = self.read_memory_block32(addr, size // 4)
+            res += conversion.u32le_list_to_byte_list(data32)
+            size -= 4*len(data32)
+            addr += 4*len(data32)
 
         if (size > 1):
-            mem = self.read16(addr)
+            mem = cast(int, self.read16(addr))
             res.append(mem & 0xff)
             res.append((mem >> 8) & 0xff)
             size -= 2
@@ -112,7 +196,7 @@ class MemoryInterface(object):
 
         return res
 
-    def write_memory_block8(self, addr, data):
+    def write_memory_block8(self, addr: int, data: Sequence[int]) -> None:
         """! @brief Write a block of unaligned bytes in memory."""
         size = len(data)
         idx = 0

--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -19,8 +19,13 @@ from enum import Enum
 import collections.abc
 import copy
 from functools import total_ordering
+from typing import (Any, Dict, Iterable, Iterator, List, Optional, TYPE_CHECKING, Sequence, Tuple, Type, Union)
 
 from ..utility.strings import uniquify_name
+
+if TYPE_CHECKING:
+    from ..target.pack.flash_algo import PackFlashAlgo
+    from ..flash.flash import Flash
 
 class MemoryType(Enum):
     """! @brief Known types of memory."""
@@ -30,26 +35,37 @@ class MemoryType(Enum):
     FLASH = 3
     DEVICE = 4
 
-def check_range(start, end=None, length=None, range=None):
-    assert (start is not None) and ((isinstance(start, MemoryRange) or range is not None) or
+def check_range(
+            start: Union[int, "MemoryRangeBase"],
+            end: Optional[int] = None,
+            length: Optional[int] = None,
+            range: Optional["MemoryRangeBase"] = None
+        ) -> Tuple[int, int]:
+    assert (start is not None) and ((isinstance(start, MemoryRangeBase) or range is not None) or
         ((end is not None) ^ (length is not None)))
-    if isinstance(start, MemoryRange):
+    if isinstance(start, MemoryRangeBase):
         range = start
     if range is not None:
-        start = range.start
-        end = range.end
-    elif end is None:
-        end = start + length - 1
-    return start, end
+        actual_start = range.start
+        actual_end = range.end
+    else:
+        assert not isinstance(start, MemoryRangeBase)
+        actual_start = start
+        if end is None:
+            assert length is not None
+            actual_end = actual_start + length - 1
+        else:
+            actual_end = end
+    return actual_start, actual_end
 
 @total_ordering
-class MemoryRangeBase(object):
+class MemoryRangeBase:
     """! @brief Base class for a range of memory.
 
     This base class provides the basic address range support and methods to test for containment
     or intersection with another range.
     """
-    def __init__(self, start=0, end=0, length=None):
+    def __init__(self, start: int = 0, end: int = 0, length: Optional[int] = None) -> None:
         self._start = start
         if length is not None:
             self._end = self._start + length - 1
@@ -58,65 +74,89 @@ class MemoryRangeBase(object):
         assert self._end >= (self._start - 1)
 
     @property
-    def start(self):
+    def start(self) -> int:
         return self._start
 
     @property
-    def end(self):
+    def end(self) -> int:
         return self._end
 
     @property
-    def length(self):
+    def length(self) -> int:
         return self._end - self._start + 1
 
-    def contains_address(self, address):
+    def contains_address(self, address: int) -> bool:
         return (address >= self.start) and (address <= self.end)
 
-    def contains_range(self, start, end=None, length=None, range=None):
+    def contains_range(
+                self,
+                start: Union[int, "MemoryRangeBase"],
+                end: Optional[int] = None,
+                length: Optional[int] = None,
+                range: Optional["MemoryRangeBase"] = None
+            ) -> bool:
         """! @return Whether the given range is fully contained by the region."""
         start, end = check_range(start, end, length, range)
         return self.contains_address(start) and self.contains_address(end)
 
-    def contained_by_range(self, start, end=None, length=None, range=None):
+    def contained_by_range(
+                self,
+                start: Union[int, "MemoryRangeBase"],
+                end: Optional[int] = None,
+                length: Optional[int] = None,
+                range: Optional["MemoryRangeBase"] = None
+            ) -> bool:
         """! @return Whether the region is fully within the bounds of the given range."""
         start, end = check_range(start, end, length, range)
         return start <= self.start and end >= self.end
 
-    def intersects_range(self, start, end=None, length=None, range=None):
+    def intersects_range(
+                self,
+                start: Union[int, "MemoryRangeBase"],
+                end: Optional[int] = None,
+                length: Optional[int] = None,
+                range: Optional["MemoryRangeBase"] = None
+            ) -> bool:
         """! @return Whether the region and the given range intersect at any point."""
         start, end = check_range(start, end, length, range)
         return (start <= self.start and end >= self.start) or (start <= self.end and end >= self.end) \
             or (start >= self.start and end <= self.end)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash("%08x%08x%08x" % (self.start, self.end, self.length))
 
-    def __eq__(self, other):
+    def __eq__(self, other: "MemoryRangeBase") -> bool:
         return self.start == other.start and self.length == other.length
 
-    def __lt__(self, other):
+    def __lt__(self, other: "MemoryRangeBase") -> bool:
         return self.start < other.start or (self.start == other.start and self.length == other.length)
 
 class MemoryRange(MemoryRangeBase):
     """! @brief A range of memory optionally tied to a region."""
-    def __init__(self, start=0, end=0, length=None, region=None):
-        super(MemoryRange, self).__init__(start=start, end=end, length=length)
+    def __init__(
+                self,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                region: Optional["MemoryRegion"] = None
+            ) -> None:
+        super().__init__(start=start, end=end, length=length)
         self._region = region
 
     @property
-    def region(self):
+    def region(self) -> Optional["MemoryRegion"]:
         return self._region
 
-    def __hash__(self):
-        h = super(MemoryRange, self).__hash__()
+    def __hash__(self) -> int:
+        h = super().__hash__()
         if self.region is not None:
             h ^= hash(self.region)
         return h
 
-    def __eq__(self, other):
+    def __eq__(self, other: "MemoryRange") -> bool:
         return self.start == other.start and self.length == other.length and self.region == other.region
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s@0x%x start=0x%x end=0x%x length=0x%x region=%s>" % (self.__class__.__name__,
             id(self), self.start, self.end, self.length, self.region)
 
@@ -156,7 +196,7 @@ class MemoryRegion(MemoryRangeBase):
     """
 
     ## Default attribute values for all memory region types.
-    DEFAULT_ATTRS = {
+    DEFAULT_ATTRS: Dict[str, Any] = {
         'name': lambda r: r.type.name.lower(),
         'access': 'rwx',
         'alias': None,
@@ -178,7 +218,14 @@ class MemoryRegion(MemoryRangeBase):
         'is_nonsecure': lambda r: not r.is_secure,
         }
 
-    def __init__(self, type=MemoryType.OTHER, start=0, end=0, length=None, **attrs):
+    def __init__(
+                self,
+                type: MemoryType = MemoryType.OTHER,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                **attrs: Any
+            ) -> None:
         """! Memory region constructor.
 
         Memory regions are required to have non-zero lengths, unlike memory ranges.
@@ -191,10 +238,10 @@ class MemoryRegion(MemoryRangeBase):
         - is_powered_on_boot
         - is_testable
         """
-        super(MemoryRegion, self).__init__(start=start, end=end, length=length)
+        super().__init__(start=start, end=end, length=length)
         assert self.length > 0, "Memory regions must have a non-zero length."
         assert isinstance(type, MemoryType)
-        self._map = None
+        self._map: Optional[MemoryMap] = None
         self._type = type
         self._attributes = attrs
 
@@ -204,23 +251,23 @@ class MemoryRegion(MemoryRangeBase):
                 self._attributes[k] = v
 
     @property
-    def map(self):
+    def map(self) -> Optional["MemoryMap"]:
         return self._map
 
     @map.setter
-    def map(self, the_map):
+    def map(self, the_map: Optional["MemoryMap"]) -> None:
         self._map = the_map
 
     @property
-    def type(self):
+    def type(self) -> MemoryType:
         return self._type
 
     @property
-    def attributes(self):
+    def attributes(self) -> Dict[str, Any]:
         return self._attributes
 
     @property
-    def alias(self):
+    def alias(self) -> Any:
         # Resolve alias reference.
         alias_value = self._attributes['alias']
         if isinstance(alias_value, str) and self._map is not None:
@@ -232,7 +279,7 @@ class MemoryRegion(MemoryRangeBase):
         else:
             return alias_value
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Any:
         try:
             v = self._attributes[name]
         except KeyError:
@@ -243,7 +290,7 @@ class MemoryRegion(MemoryRangeBase):
                 v = v(self)
             return v
 
-    def _get_attributes_for_clone(self):
+    def _get_attributes_for_clone(self) -> Dict[str, Any]:
         """@brief Return a dict containing all the attributes of this region.
 
         This method must be overridden by subclasses to include in the returned dict any instance attributes
@@ -251,32 +298,38 @@ class MemoryRegion(MemoryRangeBase):
         """
         return dict(start=self.start, length=self.length, **self._attributes)
 
-    def clone_with_changes(self, **modified_attrs):
+    def clone_with_changes(self, **modified_attrs: Any) -> Any: # Have to return Any because Self isn't available yet.
         """@brief Create a duplicate this region with some of its attributes modified."""
         new_attrs = self._get_attributes_for_clone()
         new_attrs.update(modified_attrs)
 
         return self.__class__(**new_attrs)
 
-    def __copy__(self):
+    def __copy__(self) -> Any:
         return self.clone_with_changes()
 
     # Need to redefine __hash__ since we redefine __eq__.
     __hash__ = MemoryRangeBase.__hash__
 
-    def __eq__(self, other):
+    def __eq__(self, other: "MemoryRegion") -> bool:
         # Include type and attributes in equality comparison.
         return self.start == other.start and self.length == other.length \
             and self.type == other.type and self.attributes == other.attributes
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s@0x%x name=%s type=%s start=0x%x end=0x%x length=0x%x access=%s>" % (self.__class__.__name__, id(self), self.name, self.type, self.start, self.end, self.length, self.access)
 
 class RamRegion(MemoryRegion):
     """! @brief Contiguous region of RAM."""
-    def __init__(self, start=0, end=0, length=None, **attrs):
+    def __init__(
+                self,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                **attrs: Any
+            ) -> None:
         attrs['type'] = MemoryType.RAM
-        super(RamRegion, self).__init__(start=start, end=end, length=length, **attrs)
+        super().__init__(start=start, end=end, length=length, **attrs)
 
 class RomRegion(MemoryRegion):
     """! @brief Contiguous region of ROM."""
@@ -287,9 +340,15 @@ class RomRegion(MemoryRegion):
         'access': 'rx', # ROM is by definition not writable.
         })
 
-    def __init__(self, start=0, end=0, length=None, **attrs):
+    def __init__(
+                self,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                **attrs: Any
+            ) -> None:
         attrs['type'] = MemoryType.ROM
-        super(RomRegion, self).__init__(start=start, end=end, length=length, **attrs)
+        super().__init__(start=start, end=end, length=length, **attrs)
 
 class DefaultFlashWeights:
     """! @brief Default weights for flash programming operations."""
@@ -337,13 +396,24 @@ class FlashRegion(MemoryRegion):
         'are_erased_sectors_readable': True,
         })
 
-    def __init__(self, start=0, end=0, length=None, **attrs):
+    _algo: Optional[Dict[str, Any]]
+    _flm: Optional[Union[str, "PackFlashAlgo"]]
+    _flash: Optional["Flash"]
+    _flash_class: Type["Flash"]
+
+    def __init__(
+                self,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                **attrs: Any
+            ) -> None:
         # Import locally to prevent import loops.
         from ..flash.flash import Flash
 
         assert ('blocksize' in attrs) or ('sector_size' in attrs) or ('flm' in attrs)
         attrs['type'] = MemoryType.FLASH
-        super(FlashRegion, self).__init__(start=start, end=end, length=length, **attrs)
+        super().__init__(start=start, end=end, length=length, **attrs)
         self._algo = attrs.get('algo', None)
         self._flm = attrs.get('flm', None)
         self._flash = None
@@ -369,38 +439,38 @@ class FlashRegion(MemoryRegion):
             pass
 
     @property
-    def algo(self):
+    def algo(self) -> Optional[Dict[str, Any]]:
         return self._algo
 
     @algo.setter
-    def algo(self, flash_algo):
+    def algo(self, flash_algo: Dict[str, Any]) -> None:
         self._algo = flash_algo
 
     @property
-    def flm(self):
+    def flm(self) -> Optional[Union[str, "PackFlashAlgo"]]:
         return self._flm
 
     @flm.setter
-    def flm(self, flm_path):
+    def flm(self, flm_path: str) -> None:
         self._flm = flm_path
 
     @property
-    def flash_class(self):
+    def flash_class(self) -> Type["Flash"]:
         return self._flash_class
 
     @flash_class.setter
-    def flash_class(self, klass):
+    def flash_class(self, klass: Type["Flash"]) -> None:
         self._flash_class = klass
 
     @property
-    def flash(self):
+    def flash(self) -> Optional["Flash"]:
         return self._flash
 
     @flash.setter
-    def flash(self, flash_instance):
+    def flash(self, flash_instance: "Flash") -> None:
         self._flash = flash_instance
 
-    def is_data_erased(self, d):
+    def is_data_erased(self, d: Iterable[int]) -> bool:
         """! @brief Helper method to check if a block of data is erased.
         @param self
         @param d List of data or bytearray.
@@ -413,7 +483,7 @@ class FlashRegion(MemoryRegion):
                 return False
         return True
 
-    def _get_attributes_for_clone(self):
+    def _get_attributes_for_clone(self) -> Dict[str, Any]:
         """@brief Return a dict containing all the attributes of this region."""
         d = super()._get_attributes_for_clone()
         d.update(
@@ -426,12 +496,12 @@ class FlashRegion(MemoryRegion):
     # Need to redefine __hash__ since we redefine __eq__.
     __hash__ = MemoryRegion.__hash__
 
-    def __eq__(self, other):
+    def __eq__(self, other: "FlashRegion") -> bool:
         # Include flash algo, class, and flm in equality test.
-        return super(FlashRegion, self).__eq__(other) and self.algo == other.algo and \
+        return super().__eq__(other) and self.algo == other.algo and \
                 self.flash_class == other.flash_class and self.flm == other.flm
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s@0x%x name=%s type=%s start=0x%x end=0x%x length=0x%x access=%s blocksize=0x%x>" % (
                 self.__class__.__name__, id(self), self.name, self.type, self.start, self.end,
                 self.length, self.access, self.blocksize)
@@ -447,12 +517,18 @@ class DeviceRegion(MemoryRegion):
         'is_testable': False,
         })
 
-    def __init__(self, start=0, end=0, length=None, **attrs):
+    def __init__(
+                self,
+                start: int = 0,
+                end: int = 0,
+                length: Optional[int] = None,
+                **attrs: Any
+            ) -> None:
         attrs['type'] = MemoryType.DEVICE
-        super(DeviceRegion, self).__init__(start=start, end=end, length=length, **attrs)
+        super().__init__(start=start, end=end, length=length, **attrs)
 
 ## @brief Map from memory type to class.
-MEMORY_TYPE_CLASS_MAP = {
+MEMORY_TYPE_CLASS_MAP: Dict[MemoryType, Type[MemoryRegion]] = {
         MemoryType.OTHER:   MemoryRegion,
         MemoryType.RAM:     RamRegion,
         MemoryType.ROM:     RomRegion,
@@ -486,7 +562,9 @@ class MemoryMap(collections.abc.Sequence):
     MemoryMap objects implement the collections.abc.Sequence interface.
     """
 
-    def __init__(self, *more_regions):
+    _regions: List[MemoryRegion]
+
+    def __init__(self, *more_regions: Union[Sequence[MemoryRegion], MemoryRegion]) -> None:
         """! @brief Constructor.
 
         All parameters passed to the constructor are assumed to be MemoryRegion instances, and
@@ -499,7 +577,7 @@ class MemoryMap(collections.abc.Sequence):
         self.add_regions(*more_regions)
 
     @property
-    def regions(self):
+    def regions(self) -> List[MemoryRegion]:
         """! @brief List of all memory regions.
 
         Regions in the returned list are sorted by start address.
@@ -507,11 +585,11 @@ class MemoryMap(collections.abc.Sequence):
         return self._regions
 
     @property
-    def region_count(self):
+    def region_count(self) -> int:
         """! @brief Number of memory regions in the map."""
         return len(self._regions)
 
-    def clone(self):
+    def clone(self) -> "MemoryMap":
         """! @brief Create a duplicate of the memory map.
 
         The duplicate memory map contains shallow copies of each of the regions. This is intended
@@ -520,7 +598,7 @@ class MemoryMap(collections.abc.Sequence):
         """
         return MemoryMap(*[copy.copy(r) for r in self.regions])
 
-    def add_regions(self, *more_regions):
+    def add_regions(self, *more_regions: Union[Sequence[MemoryRegion], MemoryRegion]) -> None:
         """! @brief Add multiple regions to the memory map.
 
         There are two options for passing the list of regions to be added. The first is to pass
@@ -534,15 +612,16 @@ class MemoryMap(collections.abc.Sequence):
             passed as separate parameters.
         """
         if len(more_regions):
-            if isinstance(more_regions[0], (list, tuple)):
-                regionsToAdd = more_regions[0]
+            if isinstance(more_regions[0], collections.abc.Sequence):
+                regions_to_add = more_regions[0]
             else:
-                regionsToAdd = more_regions
+                regions_to_add = more_regions
 
-            for newRegion in regionsToAdd:
-                self.add_region(newRegion)
+            for new_region in regions_to_add:
+                assert isinstance(new_region, MemoryRegion)
+                self.add_region(new_region)
 
-    def add_region(self, new_region):
+    def add_region(self, new_region: MemoryRegion) -> None:
         """! @brief Add one new region to the map.
 
         The region list is resorted after adding the provided region.
@@ -560,7 +639,7 @@ class MemoryMap(collections.abc.Sequence):
         self._regions.append(new_region)
         self._regions.sort()
 
-    def remove_region(self, region):
+    def remove_region(self, region: MemoryRegion) -> None:
         """! @brief Removes a memory region from the map.
         @param self
         @param region The region to remove. The region to remove is matched by identity, not value,
@@ -570,7 +649,7 @@ class MemoryMap(collections.abc.Sequence):
             if r is region:
                 del self._regions[i]
 
-    def get_boot_memory(self):
+    def get_boot_memory(self) -> Optional[MemoryRegion]:
         """! @brief Returns the first region marked as boot memory.
 
         @param self
@@ -581,7 +660,7 @@ class MemoryMap(collections.abc.Sequence):
                 return r
         return None
 
-    def get_region_for_address(self, address):
+    def get_region_for_address(self, address: int) -> Optional[MemoryRegion]:
         """! @brief Returns the first region containing the given address.
 
         @param self
@@ -593,7 +672,7 @@ class MemoryMap(collections.abc.Sequence):
                 return r
         return None
 
-    def is_valid_address(self, address):
+    def is_valid_address(self, address: int) -> bool:
         """! @brief Determines whether an address is contained by any region.
 
         @param self
@@ -602,7 +681,13 @@ class MemoryMap(collections.abc.Sequence):
         """
         return self.get_region_for_address(address) is not None
 
-    def get_contained_regions(self, start, end=None, length=None, range=None):
+    def get_contained_regions(
+                self,
+                start: Union[int, "MemoryRangeBase"],
+                end: Optional[int] = None,
+                length: Optional[int] = None,
+                range: Optional["MemoryRangeBase"] = None
+            ) -> List[MemoryRegion]:
         """! @brief Get all regions fully contained by an address range.
 
         @param self
@@ -616,7 +701,13 @@ class MemoryMap(collections.abc.Sequence):
         start, end = check_range(start, end, length, range)
         return [r for r in self._regions if r.contained_by_range(start, end)]
 
-    def get_intersecting_regions(self, start, end=None, length=None, range=None):
+    def get_intersecting_regions(
+                self,
+                start: Union[int, "MemoryRangeBase"],
+                end: Optional[int] = None,
+                length: Optional[int] = None,
+                range: Optional["MemoryRangeBase"] = None
+            ) -> List[MemoryRegion]:
         """! @brief Get all regions intersected by an address range.
 
         @param self
@@ -630,7 +721,7 @@ class MemoryMap(collections.abc.Sequence):
         start, end = check_range(start, end, length, range)
         return [r for r in self._regions if r.intersects_range(start, end)]
 
-    def iter_matching_regions(self, **kwargs):
+    def iter_matching_regions(self, **kwargs: Any) -> Iterator[MemoryRegion]:
         """! @brief Iterate over regions matching given criteria.
 
         Useful attributes to match on include 'type', 'name', 'is_default', and others.
@@ -654,7 +745,7 @@ class MemoryMap(collections.abc.Sequence):
 
             yield r
 
-    def get_first_matching_region(self, **kwargs):
+    def get_first_matching_region(self, **kwargs: Any) -> Optional[MemoryRegion]:
         """! @brief Get the first region matching a given memory type.
 
         The region of given type with the lowest start address is returned. If there are no regions
@@ -668,7 +759,7 @@ class MemoryMap(collections.abc.Sequence):
             return r
         return None
 
-    def get_default_region_of_type(self, type):
+    def get_default_region_of_type(self, type: MemoryType) -> Optional[MemoryRegion]:
         """! @brief Get the default region of a given memory type.
 
         If there are multiple regions of the specified type marked as default, then the one with
@@ -681,29 +772,32 @@ class MemoryMap(collections.abc.Sequence):
         """
         return self.get_first_matching_region(type=type, is_default=True)
 
-    def __eq__(self, other):
+    def __eq__(self, other: "MemoryMap") -> bool:
         return isinstance(other, MemoryMap) and (self._regions == other._regions)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[MemoryRegion]:
         """! @brief Enable iteration over the memory map."""
         return iter(self._regions)
 
-    def __reversed__(self):
+    def __reversed__(self) -> Iterator[MemoryRegion]:
         """! @brief Reverse iteration over the memory map."""
         return reversed(self._regions)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Union[int, str]) -> MemoryRegion:
         """! @brief Return a region indexed by name or number."""
         if isinstance(key, str):
-            return self.get_first_matching_region(name=key)
+            result = self.get_first_matching_region(name=key)
+            if result is None:
+                raise IndexError(key)
+            return result
         else:
             return self._regions[key]
 
-    def __len__(self):
+    def __len__(self) -> int:
         """! @brief Return the number of regions."""
         return len(self._regions)
 
-    def __contains__(self, key):
+    def __contains__(self, key: Union[int, str, MemoryRegion]) -> bool:
         if isinstance(key, int):
             return self.is_valid_address(key)
         elif isinstance(key, str):
@@ -711,7 +805,7 @@ class MemoryMap(collections.abc.Sequence):
         else:
             return key in self._regions
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<MemoryMap@0x%08x regions=%s>" % (id(self), repr(self._regions))
 
 

--- a/pyocd/core/options_manager.py
+++ b/pyocd/core/options_manager.py
@@ -17,26 +17,29 @@
 
 import logging
 from functools import partial
-from collections import namedtuple
+from typing import (Any, Callable, Dict, List, Mapping, NamedTuple, Optional)
 
 from .options import OPTIONS_INFO
 from ..utility.notification import Notifier
 
 LOG = logging.getLogger(__name__)
 
-## @brief Data for an option value change notification.
-#
-# Instances of this class are used for the data attribute of the @ref
-# pyocd.utility.notification.Notification "Notification" sent to subscribers when an option's value
-# is changed.
-#
-# An instance of this class has two attributes:
-# - `new_value`: The new, current value of the option.
-# - `old_value`: The previous value of the option.
-OptionChangeInfo = namedtuple('OptionChangeInfo', 'new_value old_value')
+class OptionChangeInfo(NamedTuple):
+    """@brief Data for an option value change notification.
+
+    Instances of this class are used for the data attribute of the @ref
+    pyocd.utility.notification.Notification "Notification" sent to subscribers when an option's value
+    is changed.
+
+    An instance of this class has two attributes:
+    - `new_value`: The new, current value of the option.
+    - `old_value`: The previous value of the option.
+    """
+    new_value: Any
+    old_value: Any
 
 class OptionsManager(Notifier):
-    """! @brief Handles session option management for a session.
+    """@brief Handles session option management for a session.
 
     The options manager supports multiple layers of option priority. When an option's value is
     accessed, the highest priority layer that contains a value for the option is used. This design
@@ -50,13 +53,17 @@ class OptionsManager(Notifier):
     old value is the option's default.
     """
 
-    def __init__(self):
+    LayerType = Mapping[str, Any]
+
+    _layers: List[Dict[str, Any]]
+
+    def __init__(self) -> None:
         """! @brief Option manager constructor.
         """
-        super(OptionsManager, self).__init__()
+        super().__init__()
         self._layers = []
 
-    def _update_layers(self, new_options, update_operation):
+    def _update_layers(self, new_options: Optional[LayerType], update_operation: Callable[[LayerType], None]) -> None:
         """! @brief Internal method to add a new layer dictionary.
 
         @param self
@@ -72,7 +79,7 @@ class OptionsManager(Notifier):
         new_values = {name: self.get(name) for name in filtered_options.keys()}
         self._notify_changes(previous_values, new_values)
 
-    def add_front(self, new_options):
+    def add_front(self, new_options: Optional[LayerType]) -> None:
         """! @brief Add a new highest priority layer of option values.
 
         @param self
@@ -80,7 +87,7 @@ class OptionsManager(Notifier):
         """
         self._update_layers(new_options, partial(self._layers.insert, 0))
 
-    def add_back(self, new_options):
+    def add_back(self, new_options: Optional[LayerType]) -> None:
         """! @brief Add a new lowest priority layer of option values.
 
         @param self
@@ -88,7 +95,7 @@ class OptionsManager(Notifier):
         """
         self._update_layers(new_options, self._layers.append)
 
-    def _convert_options(self, new_options):
+    def _convert_options(self, new_options: LayerType) -> LayerType:
         """! @brief Prepare a dictionary of session options for use by the manager.
 
         1. Strip dictionary entries with a value of None.
@@ -104,7 +111,7 @@ class OptionsManager(Notifier):
                 output[name] = value
         return output
 
-    def is_set(self, key):
+    def is_set(self, key: str) -> bool:
         """! @brief Return whether a value is set for the specified option.
 
         This method returns True as long as any layer has a value set for the option, even if the
@@ -116,46 +123,46 @@ class OptionsManager(Notifier):
                 return True
         return False
 
-    def get_default(self, key):
+    def get_default(self, key: str) -> Any:
         """! @brief Return the default value for the specified option."""
         if key in OPTIONS_INFO:
             return OPTIONS_INFO[key].default
         else:
             return None
 
-    def get(self, key):
+    def get(self, key: str) -> Any:
         """! @brief Return the highest priority value for the option, or its default."""
         for layer in self._layers:
             if key in layer:
                 return layer[key]
         return self.get_default(key)
 
-    def set(self, key, value):
+    def set(self, key: str, value: Any) -> None:
         """! @brief Set an option in the current highest priority layer."""
         self.update({key: value})
 
-    def update(self, new_options):
+    def update(self, new_options: LayerType) -> None:
         """! @brief Set multiple options in the current highest priority layer."""
         filtered_options = self._convert_options(new_options)
         previous_values = {name: self.get(name) for name in filtered_options.keys()}
         self._layers[0].update(filtered_options)
         self._notify_changes(previous_values, filtered_options)
 
-    def _notify_changes(self, previous, options):
+    def _notify_changes(self, previous: LayerType, options: LayerType) -> None:
         """! @brief Send notifications that the specified options have changed."""
         for name, new_value in options.items():
             previous_value = previous[name]
             if new_value != previous_value:
                 self.notify(name, data=OptionChangeInfo(new_value, previous_value))
 
-    def __contains__(self, key):
+    def __contains__(self, key: str) -> bool:
         """! @brief Returns whether the named option has a non-default value."""
         return self.is_set(key)
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str) -> Any:
         """! @brief Return the highest priority value for the option, or its default."""
         return self.get(key)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         """! @brief Set an option in the current highest priority layer."""
         self.set(key, value)

--- a/pyocd/core/plugin.py
+++ b/pyocd/core/plugin.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +17,21 @@
 
 import pkg_resources
 import logging
+from typing import (
+    Any,
+    Dict,
+    List,
+    )
 
 from .._version import version as pyocd_version
-from .options import add_option_set
+from .options import (
+    add_option_set,
+    OptionInfo,
+    )
 
 LOG = logging.getLogger(__name__)
 
-class Plugin(object):
+class Plugin:
     """! @brief Class that describes a plugin for pyOCD.
 
     Each plugin vends a subclass of Plugin that describes itself and provides meta-actions.
@@ -32,11 +41,11 @@ class Plugin(object):
     will always load, and does nothing when loaded.
     """
 
-    def should_load(self):
+    def should_load(self) -> bool:
         """! @brief Whether the plugin should be loaded."""
         return True
 
-    def load(self):
+    def load(self) -> Any:
         """! @brief Load the plugin and return the plugin implementation.
 
         This method can perform any actions required to load the plugin beyond simply returning
@@ -47,15 +56,15 @@ class Plugin(object):
         pass
 
     @property
-    def options(self):
+    def options(self) -> List[OptionInfo]:
         """! @brief A list of options added by the plugin.
         @return List of @ref pyocd.core.options.OptionInfo "OptionInfo" objects.
         """
         return []
 
     @property
-    def version(self):
-        """! @brief Current version of the plugin.
+    def version(self) -> str:
+        """! @brief Current release version of the plugin.
 
         The default implementation returns pyOCD's version.
 
@@ -64,16 +73,16 @@ class Plugin(object):
         return pyocd_version
 
     @property
-    def name(self):
+    def name(self) -> str:
         """! @brief Name of the plugin."""
         raise NotImplementedError()
 
     @property
-    def description(self):
+    def description(self) -> str:
         """! @brief Short description of the plugin."""
         return ""
 
-def load_plugin_classes_of_type(plugin_group, plugin_dict, base_class):
+def load_plugin_classes_of_type(plugin_group: str, plugin_dict: Dict[str, Any], base_class: type) -> None:
     """! @brief Helper method to load plugins.
 
     Plugins are expected to return an implementation class from their Plugin.load() method. This

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,18 +16,27 @@
 # limitations under the License.
 
 import logging
+from typing import (Callable, Dict, List, Optional, overload, Sequence, Union, TYPE_CHECKING)
+from typing_extensions import Literal
 
-from .target import Target
+from .target import (Target, TargetGraphNode)
+from .core_target import CoreTarget
 from ..flash.eraser import FlashEraser
 from ..debug.cache import CachingDebugContext
 from ..debug.elf.elf import ELFBinaryFile
 from ..debug.elf.elf_reader import ElfReaderContext
-from ..utility.graph import GraphNode
 from ..utility.sequencer import CallSequence
+
+if TYPE_CHECKING:
+    from .session import Session
+    from .memory_map import MemoryMap
+    from .core_registers import (CoreRegistersIndex, CoreRegisterNameOrNumberType, CoreRegisterValueType)
+    from ..debug.context import DebugContext
+    from ..debug.breakpoints.provider import Breakpoint
 
 LOG = logging.getLogger(__name__)
 
-class SoCTarget(Target, GraphNode):
+class SoCTarget(TargetGraphNode):
     """! @brief Represents a microcontroller system-on-chip.
 
     An instance of this class is the root of the chip-level object graph. It has child
@@ -41,40 +51,53 @@ class SoCTarget(Target, GraphNode):
 
     VENDOR = "Generic"
 
-    def __init__(self, session, memory_map=None):
-        Target.__init__(self, session, memory_map)
-        GraphNode.__init__(self)
-        self.vendor = self.VENDOR
-        self.part_families = getattr(self, 'PART_FAMILIES', [])
-        self.part_number = getattr(self, 'PART_NUMBER', self.__class__.__name__)
-        self._cores = {}
-        self._selected_core = None
+    def __init__(self, session: "Session", memory_map: Optional["MemoryMap"] = None) -> None:
+        super().__init__(session, memory_map)
+        self.vendor: str = self.VENDOR
+        self.part_families: List[str] = getattr(self, 'PART_FAMILIES', [])
+        self.part_number: str = getattr(self, 'PART_NUMBER', self.__class__.__name__)
+        self._cores: Dict[int, CoreTarget] = {}
+        self._selected_core: int = -1
         self._new_core_num = 0
         self._elf = None
 
     @property
-    def cores(self):
+    def cores(self) -> Dict[int, CoreTarget]:
         return self._cores
 
     @property
-    def selected_core(self):
-        if self._selected_core is None:
+    def selected_core(self) -> Optional[CoreTarget]:
+        """@brief Get the selected CPU core object."""
+        if self._selected_core == -1:
             return None
         return self.cores[self._selected_core]
 
     @selected_core.setter
-    def selected_core(self, core_number):
+    def selected_core(self, core_number: int) -> None:  # type:ignore # core_number int type is not the same
+                                                                      # as selected_core property return type
+        """@brief Set the selected CPU core object."""
         if core_number not in self.cores:
-            raise ValueError("invalid core number %d" % core_number)
+            raise ValueError("invalid core number %d" % core_number) # TODO should be a KeyError
         LOG.debug("selected core #%d" % core_number)
         self._selected_core = core_number
 
     @property
-    def elf(self):
+    def selected_core_or_raise(self) -> CoreTarget:
+        """@brief Get the selected CPU core object.
+
+        Like selected_core but will raise an exception if no core is selected rather than returning None.
+        @exception KeyError The selected_core property is None.
+        """
+        if self._selected_core == -1:
+            raise KeyError("SoCTarget has no selected core")
+        return self.cores[self._selected_core]
+
+    @property
+    def elf(self) -> Optional[ELFBinaryFile]:
         return self._elf
 
     @elf.setter
-    def elf(self, filename):
+    def elf(self, filename: str) -> None: # type:ignore # filename str type is not same as elf property return type
         if filename is None:
             self._elf = None
         else:
@@ -86,27 +109,28 @@ class SoCTarget(Target, GraphNode):
                             ElfReaderContext(self.cores[core_number].get_target_context(), self._elf))
 
     @property
-    def supported_security_states(self):
-        return self.selected_core.supported_security_states
+    def supported_security_states(self) -> Sequence[Target.SecurityState]:
+        return self.selected_core_or_raise.supported_security_states
 
     @property
-    def core_registers(self):
-        return self.selected_core.core_registers
+    def core_registers(self) -> "CoreRegistersIndex":
+        return self.selected_core_or_raise.core_registers
 
-    def add_core(self, core):
+    def add_core(self, core: CoreTarget) -> None:
         core.delegate = self.delegate
         core.set_target_context(CachingDebugContext(core))
         self.cores[core.core_number] = core
         self.add_child(core)
 
-        if self._selected_core is None:
-            self._selected_core = core.core_number
+        # Select first added core.
+        if self.selected_core is None:
+            self.selected_core = core.core_number
 
-    def create_init_sequence(self):
+    def create_init_sequence(self) -> CallSequence:
         # Return an empty call sequence. The subclass must override this.
         return CallSequence()
 
-    def init(self):
+    def init(self) -> None:
         # If we don't have a delegate installed yet but there is a session delegate, use it.
         if (self.delegate is None) and (self.session.delegate is not None):
             self.delegate = self.session.delegate
@@ -117,14 +141,14 @@ class SoCTarget(Target, GraphNode):
         seq.invoke()
         self.call_delegate('did_init_target', target=self)
 
-    def post_connect_hook(self):
+    def post_connect_hook(self) -> None:
         """! @brief Hook function called after post_connect init task.
 
         This hook lets the target subclass configure the target as necessary.
         """
         pass
 
-    def disconnect(self, resume=True):
+    def disconnect(self, resume: bool = True) -> None:
         self.session.notify(Target.Event.PRE_DISCONNECT, self)
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
@@ -132,109 +156,128 @@ class SoCTarget(Target, GraphNode):
         self.call_delegate('did_disconnect', target=self, resume=resume)
 
     @property
-    def run_token(self):
-        return self.selected_core.run_token
+    def run_token(self) -> int:
+        return self.selected_core_or_raise.run_token
 
-    def halt(self):
-        return self.selected_core.halt()
+    def halt(self) -> None:
+        return self.selected_core_or_raise.halt()
 
-    def step(self, disable_interrupts=True, start=0, end=0, hook_cb=None):
-        return self.selected_core.step(disable_interrupts, start, end, hook_cb)
+    def step(self, disable_interrupts: bool = True, start: int = 0, end: int = 0,
+            hook_cb: Optional[Callable[[], bool]] = None) -> None:
+        return self.selected_core_or_raise.step(disable_interrupts, start, end, hook_cb)
 
-    def resume(self):
-        return self.selected_core.resume()
+    def resume(self) -> None:
+        return self.selected_core_or_raise.resume()
 
-    def mass_erase(self):
+    def mass_erase(self) -> None:
         if not self.call_delegate('mass_erase', target=self):
             # The default mass erase implementation is to simply perform a chip erase.
             FlashEraser(self.session, FlashEraser.Mode.CHIP).erase()
-        return True
 
-    def write_memory(self, addr, value, transfer_size=32):
-        return self.selected_core.write_memory(addr, value, transfer_size)
+    def write_memory(self, addr: int, data: int, transfer_size: int = 32) -> None:
+        return self.selected_core_or_raise.write_memory(addr, data, transfer_size)
 
-    def read_memory(self, addr, transfer_size=32, now=True):
-        return self.selected_core.read_memory(addr, transfer_size, now)
+    @overload
+    def read_memory(self, addr: int, transfer_size: int = 32) -> int:
+        ...
 
-    def write_memory_block8(self, addr, value):
-        return self.selected_core.write_memory_block8(addr, value)
+    @overload
+    def read_memory(self, addr: int, transfer_size: int = 32, now: Literal[True] = True) -> int:
+        ...
 
-    def write_memory_block32(self, addr, data):
-        return self.selected_core.write_memory_block32(addr, data)
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: Literal[False]) -> Callable[[], int]:
+        ...
 
-    def read_memory_block8(self, addr, size):
-        return self.selected_core.read_memory_block8(addr, size)
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
 
-    def read_memory_block32(self, addr, size):
-        return self.selected_core.read_memory_block32(addr, size)
+    def read_memory(self, addr: int, transfer_size: int = 32, now: bool = True) -> Union[int, Callable[[], int]]:
+        return self.selected_core_or_raise.read_memory(addr, transfer_size, now)
 
-    def read_core_register(self, id):
-        return self.selected_core.read_core_register(id)
+    def write_memory_block8(self, addr: int, data: Sequence[int]) -> None:
+        return self.selected_core_or_raise.write_memory_block8(addr, data)
 
-    def write_core_register(self, id, data):
-        return self.selected_core.write_core_register(id, data)
+    def write_memory_block32(self, addr: int, data: Sequence[int]) -> None:
+        return self.selected_core_or_raise.write_memory_block32(addr, data)
 
-    def read_core_register_raw(self, reg):
-        return self.selected_core.read_core_register_raw(reg)
+    def read_memory_block8(self, addr: int, size: int) -> Sequence[int]:
+        return self.selected_core_or_raise.read_memory_block8(addr, size)
 
-    def read_core_registers_raw(self, reg_list):
-        return self.selected_core.read_core_registers_raw(reg_list)
+    def read_memory_block32(self, addr: int, size) -> Sequence[int]:
+        return self.selected_core_or_raise.read_memory_block32(addr, size)
 
-    def write_core_register_raw(self, reg, data):
-        self.selected_core.write_core_register_raw(reg, data)
+    def read_core_register(self, id: "CoreRegisterNameOrNumberType") -> "CoreRegisterValueType":
+        return self.selected_core_or_raise.read_core_register(id)
 
-    def write_core_registers_raw(self, reg_list, data_list):
-        self.selected_core.write_core_registers_raw(reg_list, data_list)
+    def write_core_register(self, id: "CoreRegisterNameOrNumberType", data: "CoreRegisterValueType") -> None:
+        return self.selected_core_or_raise.write_core_register(id, data)
 
-    def find_breakpoint(self, addr):
-        return self.selected_core.find_breakpoint(addr)
+    def read_core_register_raw(self, reg: "CoreRegisterNameOrNumberType") -> int:
+        return self.selected_core_or_raise.read_core_register_raw(reg)
 
-    def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
-        return self.selected_core.set_breakpoint(addr, type)
+    def read_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"]) -> List[int]:
+        return self.selected_core_or_raise.read_core_registers_raw(reg_list)
 
-    def get_breakpoint_type(self, addr):
-        return self.selected_core.get_breakpoint_type(addr)
+    def write_core_register_raw(self, reg: "CoreRegisterNameOrNumberType", data: int) -> None:
+        self.selected_core_or_raise.write_core_register_raw(reg, data)
 
-    def remove_breakpoint(self, addr):
-        return self.selected_core.remove_breakpoint(addr)
+    def write_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"], data_list: Sequence[int]) -> None:
+        self.selected_core_or_raise.write_core_registers_raw(reg_list, data_list)
 
-    def set_watchpoint(self, addr, size, type):
-        return self.selected_core.set_watchpoint(addr, size, type)
+    def find_breakpoint(self, addr: int) -> Optional["Breakpoint"]:
+        return self.selected_core_or_raise.find_breakpoint(addr)
 
-    def remove_watchpoint(self, addr, size, type):
-        return self.selected_core.remove_watchpoint(addr, size, type)
+    def set_breakpoint(self, addr: int, type: Target.BreakpointType = Target.BreakpointType.AUTO) -> bool:
+        return self.selected_core_or_raise.set_breakpoint(addr, type)
 
-    def reset(self, reset_type=None):
+    def get_breakpoint_type(self, addr: int) -> Optional[Target.BreakpointType]:
+        return self.selected_core_or_raise.get_breakpoint_type(addr)
+
+    def remove_breakpoint(self, addr: int) -> None:
+        return self.selected_core_or_raise.remove_breakpoint(addr)
+
+    def set_watchpoint(self, addr: int, size: int, type: Target.WatchpointType) -> bool:
+        return self.selected_core_or_raise.set_watchpoint(addr, size, type)
+
+    def remove_watchpoint(self, addr: int, size: int, type: Target.WatchpointType) -> None:
+        return self.selected_core_or_raise.remove_watchpoint(addr, size, type)
+
+    def reset(self, reset_type: Optional[Target.ResetType] = None) -> None:
         # Use the probe to reset to perform a hardware reset if there is not a core.
         if self.selected_core is None:
             # Use the probe to reset. (We can't use the DP here because that's a class layering violation;
             # the DP is only created by the CoreSightTarget subclass.)
+            assert self.session.probe
             self.session.probe.reset()
             return
-        self.selected_core.reset(reset_type)
+        self.selected_core_or_raise.reset(reset_type)
 
-    def reset_and_halt(self, reset_type=None):
-        return self.selected_core.reset_and_halt(reset_type)
+    def reset_and_halt(self, reset_type: Optional[Target.ResetType] = None) -> None:
+        return self.selected_core_or_raise.reset_and_halt(reset_type)
 
-    def get_state(self):
-        return self.selected_core.get_state()
+    def get_state(self) -> Target.State:
+        return self.selected_core_or_raise.get_state()
 
-    def get_security_state(self):
-        return self.selected_core.get_security_state()
+    def get_security_state(self) -> Target.SecurityState:
+        return self.selected_core_or_raise.get_security_state()
 
-    def get_halt_reason(self):
-        return self.selected_core.get_halt_reason()
+    def get_halt_reason(self) -> Target.HaltReason:
+        return self.selected_core_or_raise.get_halt_reason()
 
-    def set_vector_catch(self, enableMask):
-        return self.selected_core.set_vector_catch(enableMask)
+    def set_vector_catch(self, enable_mask: int) -> None:
+        return self.selected_core_or_raise.set_vector_catch(enable_mask)
 
-    def get_vector_catch(self):
-        return self.selected_core.get_vector_catch()
+    def get_vector_catch(self) -> int:
+        return self.selected_core_or_raise.get_vector_catch()
 
-    def get_target_context(self, core=None):
-        if core is None:
-            core = self._selected_core
-        return self.cores[core].get_target_context()
+    def get_target_context(self, core: Optional[int] = None) -> "DebugContext":
+        if core is not None:
+            core_obj = self.cores[core]
+        else:
+            core_obj = self.selected_core_or_raise
+        return core_obj.get_target_context()
 
     def trace_start(self):
         self.call_delegate('trace_start', target=self, mode=0)

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) Chris Reed
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,9 +44,15 @@ class SoCTarget(TargetGraphNode):
     to control the device, access memory, adjust breakpoints, and so on.
 
     For single core devices, the SoCTarget has mostly equivalent functionality to
-    the Target object for the core. Multicore devices work differently. This class tracks
+    the CoreTarget object for the core. Multicore devices work differently. This class tracks
     a "selected core", to which all actions are directed. The selected core can be changed
     at any time. You may also directly access specific cores and perform operations on them.
+
+    SoCTarget subclasses must restrict usage of the DebugProbe instance in their constructor, ideally not
+    using it at all. This is required in order to be able to gather information about targets for commands
+    such as `pyocd json` and `pyocd list`. These commands create a session with the probe set to an instance
+    of StubProbe, which is a subclass of DebugProbe with the minimal implementation necessary to support
+    session creation but not opening.
     """
 
     VENDOR = "Generic"

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -16,9 +16,20 @@
 # limitations under the License.
 
 from enum import Enum
+from typing import (Any, Callable, List, Optional, Sequence, TYPE_CHECKING)
 
 from .memory_interface import MemoryInterface
 from .memory_map import MemoryMap
+from ..utility.graph import GraphNode
+
+if TYPE_CHECKING:
+    from .session import Session
+    from .core_registers import (CoreRegistersIndex, CoreRegisterNameOrNumberType, CoreRegisterValueType)
+    from ..debug.breakpoints.provider import Breakpoint
+    from ..debug.context import DebugContext
+    from ..debug.svd.loader import SVDFile
+    from ..debug.svd.model import SVDDevice
+    from ..utility.sequencer import CallSequence
 
 class Target(MemoryInterface):
 
@@ -174,31 +185,31 @@ class Target(MemoryInterface):
         ## PMU event. v8.1-M only.
         PMU = 7
 
-    def __init__(self, session, memory_map=None):
+    def __init__(self, session: "Session", memory_map: Optional[MemoryMap] = None) -> None:
         self._session = session
-        self._delegate = None
+        self._delegate: Any = None
         # Make a target-specific copy of the memory map. This is safe to do without locking
         # because the memory map may not be mutated until target initialization.
         self.memory_map = memory_map.clone() if memory_map else MemoryMap()
-        self._svd_location = None
-        self._svd_device = None
+        self._svd_location: Optional[SVDFile] = None
+        self._svd_device: Optional[SVDDevice] = None
 
     @property
-    def session(self):
+    def session(self) -> "Session":
         return self._session
 
     @property
-    def delegate(self):
+    def delegate(self) -> Any:
         return self._delegate
 
     @delegate.setter
-    def delegate(self, the_delegate):
+    def delegate(self, the_delegate: Any) -> None:
         self._delegate = the_delegate
 
-    def delegate_implements(self, method_name):
+    def delegate_implements(self, method_name: str) -> bool:
         return (self._delegate is not None) and (hasattr(self._delegate, method_name))
 
-    def call_delegate(self, method_name, *args, **kwargs):
+    def call_delegate(self, method_name: str, *args, **kwargs) -> None:
         if self.delegate_implements(method_name):
             return getattr(self._delegate, method_name)(*args, **kwargs)
         else:
@@ -206,113 +217,122 @@ class Target(MemoryInterface):
             return None
 
     @property
-    def svd_device(self):
+    def svd_device(self) -> Optional["SVDDevice"]:
         return self._svd_device
 
     @property
-    def supported_security_states(self):
+    def supported_security_states(self) -> Sequence[SecurityState]:
         raise NotImplementedError()
 
     @property
-    def core_registers(self):
+    def core_registers(self) -> "CoreRegistersIndex":
         raise NotImplementedError()
 
-    def is_locked(self):
+    def is_locked(self) -> bool:
         return False
 
-    def create_init_sequence(self):
+    def create_init_sequence(self) -> "CallSequence":
         raise NotImplementedError()
 
-    def init(self):
+    def init(self) -> None:
         raise NotImplementedError()
 
-    def disconnect(self, resume=True):
+    def disconnect(self, resume: bool = True) -> None:
         pass
 
-    def flush(self):
-        self.session.probe.flush()
+    def flush(self) -> None:
+        if self.session.probe:
+            self.session.probe.flush()
 
-    def halt(self):
+    def halt(self) -> None:
         raise NotImplementedError()
 
-    def step(self, disable_interrupts=True, start=0, end=0, hook_cb=None):
+    def step(self, disable_interrupts: bool = True, start: int = 0, end: int = 0,
+            hook_cb: Optional[Callable[[], bool]] = None) -> None:
         raise NotImplementedError()
 
-    def resume(self):
+    def resume(self) -> None:
         raise NotImplementedError()
 
-    def mass_erase(self):
+    def mass_erase(self) -> None:
         raise NotImplementedError()
 
-    def read_core_register(self, id):
+    def read_core_register(self, id: "CoreRegisterNameOrNumberType") -> "CoreRegisterValueType":
         raise NotImplementedError()
 
-    def write_core_register(self, id, data):
+    def write_core_register(self, id: "CoreRegisterNameOrNumberType", data: "CoreRegisterValueType") -> None:
         raise NotImplementedError()
 
-    def read_core_register_raw(self, reg):
+    def read_core_register_raw(self, reg: "CoreRegisterNameOrNumberType") -> int:
         raise NotImplementedError()
 
-    def read_core_registers_raw(self, reg_list):
+    def read_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"]) -> List[int]:
         raise NotImplementedError()
 
-    def write_core_register_raw(self, reg, data):
+    def write_core_register_raw(self, reg: "CoreRegisterNameOrNumberType", data: int) -> None:
         raise NotImplementedError()
 
-    def write_core_registers_raw(self, reg_list, data_list):
+    def write_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"], data_list: Sequence[int]) -> None:
         raise NotImplementedError()
 
-    def find_breakpoint(self, addr):
+    def find_breakpoint(self, addr: int) -> Optional["Breakpoint"]:
         raise NotImplementedError()
 
-    def set_breakpoint(self, addr, type=BreakpointType.AUTO):
+    def set_breakpoint(self, addr: int, type: BreakpointType = BreakpointType.AUTO) -> bool:
         raise NotImplementedError()
 
-    def get_breakpoint_type(self, addr):
+    def get_breakpoint_type(self, addr: int) -> Optional[BreakpointType]:
         raise NotImplementedError()
 
-    def remove_breakpoint(self, addr):
+    def remove_breakpoint(self, addr: int) -> None:
         raise NotImplementedError()
 
-    def set_watchpoint(self, addr, size, type):
+    def set_watchpoint(self, addr: int, size: int, type: WatchpointType) -> bool:
         raise NotImplementedError()
 
-    def remove_watchpoint(self, addr, size, type):
+    def remove_watchpoint(self, addr: int, size: int, type: WatchpointType) -> None:
         raise NotImplementedError()
 
-    def reset(self, reset_type=None):
+    def reset(self, reset_type: Optional[ResetType] = None) -> None:
         raise NotImplementedError()
 
-    def reset_and_halt(self, reset_type=None):
+    def reset_and_halt(self, reset_type: Optional[ResetType] = None) -> None:
         raise NotImplementedError()
 
-    def get_state(self):
+    def get_state(self) -> State:
         raise NotImplementedError()
 
-    def get_security_state(self):
+    def get_security_state(self) -> SecurityState:
         raise NotImplementedError()
 
-    def get_halt_reason(self):
+    def get_halt_reason(self) -> HaltReason:
         raise NotImplementedError()
 
     @property
-    def run_token(self):
+    def run_token(self) -> int:
         return 0
 
-    def is_running(self):
+    def is_running(self) -> bool:
         return self.get_state() == Target.State.RUNNING
 
-    def is_halted(self):
+    def is_halted(self) -> bool:
         return self.get_state() == Target.State.HALTED
 
-    def get_memory_map(self):
+    def get_memory_map(self) -> MemoryMap:
         return self.memory_map
 
-    def set_vector_catch(self, enableMask):
+    def set_vector_catch(self, enable_mask: int) -> None:
         raise NotImplementedError()
 
-    def get_vector_catch(self):
+    def get_vector_catch(self) -> int:
         raise NotImplementedError()
 
-    def get_target_context(self, core=None):
+    def get_target_context(self, core: Optional[int] = None) -> "DebugContext":
         raise NotImplementedError()
+
+class TargetGraphNode(Target, GraphNode):
+    """@brief Abstract class for a target that is a graph node."""
+
+    def __init__(self, session: "Session", memory_map: Optional[MemoryMap] = None) -> None:
+        Target.__init__(self, session, memory_map)
+        GraphNode.__init__(self)

--- a/pyocd/core/target_delegate.py
+++ b/pyocd/core/target_delegate.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2019 Arm Limited
+# COpyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,17 +15,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class TargetDelegateInterface(object):
+from typing import (Optional, TYPE_CHECKING)
+
+if TYPE_CHECKING:
+    from .session import Session
+    from .soc_target import SoCTarget
+    from .target import Target
+    from ..board.board import Board
+    from ..utility.sequencer import CallSequence
+
+## @brief Return type for some delegate methods.
+#  
+# For certain delegate method, the delegate can reply with a boolean or None, where True means that
+# it handled the actions and no further action is to be performed, and False or None means to continue
+# processing.
+DelegateResult = Optional[bool]
+
+class TargetDelegateInterface:
     """! @brief Abstract class defining the delegate interface for targets.
 
     Note that delegates don't actually have to derive from this class due to Python's
-    dynamic method dispatching.
+    dynamic method dispatching. The primary purpose of this class is for documentation
+    and type checking.
     """
 
-    def __init__(self, session):
+    def __init__(self, session: "Session") -> None:
         self._session = session
 
-    def will_connect(self, board):
+    def will_connect(self, board: "Board") -> None:
         """! @brief Pre-init hook for the board.
         @param self
         @param board A Board instance that is about to be initialized.
@@ -32,7 +50,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def did_connect(self, board):
+    def did_connect(self, board: "Board") -> None:
         """! @brief Post-initialization hook for the board.
         @param self
         @param board A Board instance.
@@ -40,25 +58,25 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def will_init_target(self, target, init_sequence):
+    def will_init_target(self, target: "SoCTarget", init_sequence: "CallSequence") -> None:
         """! @brief Hook to review and modify init call sequence prior to execution.
         @param self
-        @param target A CoreSightTarget object about to be initialized.
+        @param target An SoCTarget object about to be initialized.
         @param init_sequence The CallSequence that will be invoked. Because call sequences are
             mutable, this parameter can be modified before return to change the init calls.
         @return Ignored.
         """
         pass
 
-    def did_init_target(self, target):
+    def did_init_target(self, target: "SoCTarget") -> None:
         """! @brief Post-initialization hook.
         @param self
-        @param target A CoreSightTarget.
+        @param target An SoCTarget.
         @return Ignored.
         """
         pass
 
-    def will_start_debug_core(self, core):
+    def will_start_debug_core(self, core: "Target") -> DelegateResult:
         """! @brief Hook to enable debug for the given core.
         @param self
         @param core A CortexM object about to be initialized.
@@ -67,7 +85,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def did_start_debug_core(self, core):
+    def did_start_debug_core(self, core: "Target") -> None:
         """! @brief Post-initialization hook.
         @param self
         @param core A CortexM object.
@@ -75,7 +93,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def will_stop_debug_core(self, core):
+    def will_stop_debug_core(self, core: "Target") -> DelegateResult:
         """! @brief Pre-cleanup hook for the core.
         @param self
         @param core A CortexM object.
@@ -84,7 +102,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def did_stop_debug_core(self, core):
+    def did_stop_debug_core(self, core: "Target") -> None:
         """! @brief Post-cleanup hook for the core.
         @param self
         @param core A CortexM object.
@@ -92,7 +110,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def will_disconnect(self, target, resume):
+    def will_disconnect(self, target: "SoCTarget", resume: bool) -> None:
         """! @brief Pre-disconnect hook.
         @param self
         @param target Either a CoreSightTarget or CortexM object.
@@ -101,7 +119,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def did_disconnect(self, target, resume):
+    def did_disconnect(self, target: "SoCTarget", resume: bool) -> None:
         """! @brief Post-disconnect hook.
         @param self
         @param target Either a CoreSightTarget or CortexM object.
@@ -109,7 +127,7 @@ class TargetDelegateInterface(object):
         @return Ignored."""
         pass
 
-    def will_reset(self, core, reset_type):
+    def will_reset(self, core: "Target", reset_type: "Target.ResetType") -> DelegateResult:
         """! @brief Pre-reset hook.
         @param self
         @param core A CortexM instance.
@@ -119,7 +137,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def did_reset(self, core, reset_type):
+    def did_reset(self, core: "Target", reset_type: "Target.ResetType") -> None:
         """! @brief Post-reset hook.
         @param self
         @param core A CortexM instance.
@@ -128,7 +146,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def set_reset_catch(self, core, reset_type):
+    def set_reset_catch(self, core: "Target", reset_type: "Target.ResetType") -> DelegateResult:
         """! @brief Hook to prepare target for halting on reset.
         @param self
         @param core A CortexM instance.
@@ -138,7 +156,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def clear_reset_catch(self, core, reset_type):
+    def clear_reset_catch(self, core: "Target", reset_type: "Target.ResetType") -> None:
         """! @brief Hook to clean up target after a reset and halt.
         @param self
         @param core A CortexM instance.
@@ -147,7 +165,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def mass_erase(self, target):
+    def mass_erase(self, target: "SoCTarget") -> DelegateResult:
         """! @brief Hook to override mass erase.
         @param self
         @param target A CoreSightTarget object.
@@ -157,7 +175,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def trace_start(self, target, mode):
+    def trace_start(self, target: "SoCTarget", mode: int) -> None:
         """! @brief Hook to prepare for tracing the target.
         @param self
         @param target A CoreSightTarget object.
@@ -166,7 +184,7 @@ class TargetDelegateInterface(object):
         """
         pass
 
-    def trace_stop(self, target, mode):
+    def trace_stop(self, target: "SoCTarget", mode: int) -> None:
         """! @brief Hook to clean up after tracing the target.
         @param self
         @param target A CoreSightTarget object.

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -242,6 +242,17 @@ class CoreSightTarget(SoCTarget):
                 LOG.error("No cores were discovered!")
             else:
                 raise exceptions.DebugError("No cores were discovered!")
+
+    def disconnect(self, resume: bool = True) -> None:
+        # Override this from SoCTarget so we can call power_down_debug() on the DP, which is
+        # created in this class and thus not (safely) accessible to SoCTarget.
+        self.session.notify(Target.Event.PRE_DISCONNECT, self)
+        self.call_delegate('will_disconnect', target=self, resume=resume)
+        for core in self.cores.values():
+            core.disconnect(resume)
+        self.dp.power_down_debug()
+        self.call_delegate('did_disconnect', target=self, resume=resume)
+
     @property
     def irq_table(self):
         if (self._irq_table is None):

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -18,15 +18,22 @@
 import logging
 from inspect import getfullargspec
 from pathlib import PurePath
+from typing import (Callable, Dict, Optional, TYPE_CHECKING, cast)
 
 from ..core.target import Target
-from ..core.memory_map import (MemoryType, RamRegion, DeviceRegion, MemoryMap)
+from ..core.memory_map import (FlashRegion, MemoryType, RamRegion, DeviceRegion, MemoryMap)
 from ..core.soc_target import SoCTarget
 from ..core import exceptions
 from . import (dap, discovery)
 from ..debug.svd.loader import SVDLoader
 from ..utility.sequencer import CallSequence
 from ..target.pack.flash_algo import PackFlashAlgo
+
+if TYPE_CHECKING:
+    from ..core.session import Session
+    from ..core.memory_map import MemoryMap
+    from .ap import (APAddressBase, AccessPort)
+    from ..debug.svd.model import SVDDevice
 
 LOG = logging.getLogger(__name__)
 
@@ -36,31 +43,32 @@ class CoreSightTarget(SoCTarget):
     This class adds Arm CoreSight-specific discovery and initialization code to SoCTarget.
     """
 
-    def __init__(self, session, memory_map=None):
+    def __init__(self, session: "Session", memory_map: Optional["MemoryMap"] = None) -> None:
         # Supply a default memory map.
         if (memory_map is None) or (memory_map.region_count == 0):
             memory_map = self._create_default_cortex_m_memory_map()
             LOG.debug("Using default Cortex-M memory map (no memory map supplied)")
 
-        super(CoreSightTarget, self).__init__(session, memory_map)
+        super().__init__(session, memory_map)
+        assert session.probe
         self.dp = dap.DebugPort(session.probe, self)
-        self._svd_load_thread = None
-        self._irq_table = None
-        self._discoverer = None
+        self._svd_load_thread: Optional[SVDLoader] = None
+        self._irq_table: Optional[Dict[int, str]] = None
+        self._discoverer: Optional[Callable] = None
 
     @property
-    def aps(self):
+    def aps(self) -> Dict["APAddressBase", "AccessPort"]:
         return self.dp.aps
 
     @property
-    def svd_device(self):
+    def svd_device(self) -> Optional["SVDDevice"]:
         """! @brief Waits for SVD file to complete loading before returning."""
         if not self._svd_device and self._svd_load_thread:
             LOG.debug("Waiting for SVD load to complete")
             self._svd_device = self._svd_load_thread.device
         return self._svd_device
 
-    def _create_default_cortex_m_memory_map(self):
+    def _create_default_cortex_m_memory_map(self) -> MemoryMap:
         """! @brief Create a MemoryMap for the Cortex-M system address map."""
         return MemoryMap(
                 RamRegion(name="Code",          start=0x00000000, length=0x20000000, access='rwx'),
@@ -73,7 +81,7 @@ class CoreSightTarget(SoCTarget):
                 DeviceRegion(name="PPB",        start=0xE0000000, length=0x20000000, access='rw'),
                 )
 
-    def load_svd(self):
+    def load_svd(self) -> None:
         def svd_load_completed_cb(svdDevice):
             self._svd_device = svdDevice
             self._svd_load_thread = None
@@ -83,13 +91,13 @@ class CoreSightTarget(SoCTarget):
             self._svd_load_thread = SVDLoader(self._svd_location, svd_load_completed_cb)
             self._svd_load_thread.load()
 
-    def create_init_sequence(self):
+    def create_init_sequence(self) -> CallSequence:
         seq = CallSequence(
             ('load_svd',            self.load_svd),
             ('pre_connect',         self.pre_connect),
             ('dp_init',             self.dp.create_connect_sequence),
             ('create_discoverer',   self.create_discoverer),
-            ('discovery',           lambda : self._discoverer.discover()),
+            ('discovery',           lambda : self._discoverer.discover() if self._discoverer else None),
             ('check_for_cores',     self.check_for_cores),
             ('halt_on_connect',     self.perform_halt_on_connect),
             ('post_connect',        self.post_connect),
@@ -100,7 +108,7 @@ class CoreSightTarget(SoCTarget):
 
         return seq
 
-    def disconnect(self, resume=True):
+    def disconnect(self, resume: bool = True) -> None:
         """! @brief Disconnect from the target.
 
         Same as SoCTarget.disconnect(), except that it asks the DebugPort to power down.
@@ -112,7 +120,7 @@ class CoreSightTarget(SoCTarget):
         self.dp.disconnect()
         self.call_delegate('did_disconnect', target=self, resume=resume)
 
-    def create_discoverer(self):
+    def create_discoverer(self) -> None:
         """! @brief Init task to create the discovery object.
 
         Instantiates the appropriate @ref pyocd.coresight.discovery.CoreSightDiscovery
@@ -120,7 +128,7 @@ class CoreSightTarget(SoCTarget):
         """
         self._discoverer = discovery.ADI_DISCOVERY_CLASS_MAP[self.dp.adi_version](self)
 
-    def pre_connect(self):
+    def pre_connect(self) -> None:
         """! @brief Handle some of the connect modes.
 
         This init task performs a connect pre-reset or asserts reset if the connect mode is
@@ -134,7 +142,7 @@ class CoreSightTarget(SoCTarget):
             LOG.info("Asserting reset prior to connect")
             self.dp.assert_reset(True)
 
-    def perform_halt_on_connect(self):
+    def perform_halt_on_connect(self) -> None:
         """! @brief Halt cores.
 
         This init task performs a connect pre-reset or asserts reset if the connect mode is
@@ -148,14 +156,14 @@ class CoreSightTarget(SoCTarget):
             for core in self.cores.values():
                 try:
                     if mode == 'under-reset':
-                        core.set_reset_catch()
+                        core.set_reset_catch(Target.ResetType.HW)
                     else:
                         core.halt()
                 except exceptions.Error as err:
                     LOG.warning("Could not halt core #%d: %s", core.core_number, err,
                         exc_info=self.session.log_tracebacks)
 
-    def post_connect(self):
+    def post_connect(self) -> None:
         """! @brief Handle cleaning up some of the connect modes.
 
         This init task de-asserts reset if the connect mode is under-reset.
@@ -169,12 +177,12 @@ class CoreSightTarget(SoCTarget):
             # Apply to all cores.
             for core in self.cores.values():
                 try:
-                    core.clear_reset_catch()
+                    core.clear_reset_catch(Target.ResetType.HW)
                 except exceptions.Error as err:
                     LOG.warning("Could not halt core #%d: %s", core.core_number, err,
                         exc_info=self.session.log_tracebacks)
 
-    def create_flash(self):
+    def create_flash(self) -> None:
         """! @brief Instantiates flash objects for memory regions.
 
         This init task iterates over flash memory regions and for each one creates the Flash
@@ -182,11 +190,12 @@ class CoreSightTarget(SoCTarget):
         to construct the flash object.
         """
         for region in self.memory_map.iter_matching_regions(type=MemoryType.FLASH):
+            region = cast(FlashRegion, region)
             # If the region doesn't have an algo dict but does have an FLM file, try to load
             # the FLM and create the algo dict.
             if (region.algo is None) and (region.flm is not None):
                 if isinstance(region.flm, (str, PurePath)):
-                    flm_path = self.session.find_user_file(None, [region.flm])
+                    flm_path = self.session.find_user_file(None, [str(region.flm)])
                     if flm_path is not None:
                         LOG.info("creating flash algo from: %s", flm_path)
                         pack_algo = PackFlashAlgo(flm_path)
@@ -226,7 +235,7 @@ class CoreSightTarget(SoCTarget):
                     LOG.warning("flash region '%s' has no flash algo" % region.name)
                     continue
             else:
-                obj = klass(self)
+                obj = klass(self) # type:ignore
 
             # Set the region in the flash instance.
             obj.region = region
@@ -234,7 +243,7 @@ class CoreSightTarget(SoCTarget):
             # Store the flash object back into the memory region.
             region.flash = obj
 
-    def check_for_cores(self):
+    def check_for_cores(self) -> None:
         """! @brief Init task: verify that at least one core was discovered."""
         if not len(self.cores):
             # Allow the user to override the exception to enable uses like chip bringup.
@@ -243,18 +252,8 @@ class CoreSightTarget(SoCTarget):
             else:
                 raise exceptions.DebugError("No cores were discovered!")
 
-    def disconnect(self, resume: bool = True) -> None:
-        # Override this from SoCTarget so we can call power_down_debug() on the DP, which is
-        # created in this class and thus not (safely) accessible to SoCTarget.
-        self.session.notify(Target.Event.PRE_DISCONNECT, self)
-        self.call_delegate('will_disconnect', target=self, resume=resume)
-        for core in self.cores.values():
-            core.disconnect(resume)
-        self.dp.power_down_debug()
-        self.call_delegate('did_disconnect', target=self, resume=resume)
-
     @property
-    def irq_table(self):
+    def irq_table(self) -> Dict[int, str]:
         if (self._irq_table is None):
             if (self.svd_device is not None) and (self.svd_device.peripherals is not None):
                 peripherals = [

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -19,6 +19,7 @@ import logging
 from time import sleep
 
 from ..core.target import Target
+from ..core.core_target import CoreTarget
 from ..core import exceptions
 from ..core.core_registers import CoreRegistersIndex
 from ..utility import (cmdline, timeout)
@@ -35,7 +36,7 @@ from ..debug.breakpoints.software import SoftwareBreakpointProvider
 
 LOG = logging.getLogger(__name__)
 
-class CortexM(Target, CoreSightCoreComponent):
+class CortexM(CoreTarget, CoreSightCoreComponent):
     """! @brief CoreSight component for a v6-M or v7-M Cortex-M core.
 
     This class has basic functions to access a Cortex-M core:

--- a/pyocd/coresight/cortex_m_core_registers.py
+++ b/pyocd/coresight/cortex_m_core_registers.py
@@ -16,8 +16,12 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING, cast
 
 from ..core.core_registers import CoreRegisterInfo
+
+if TYPE_CHECKING:
+    from ..core.core_registers import CoreRegisterNameOrNumberType
 
 LOG = logging.getLogger(__name__)
 
@@ -32,7 +36,8 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
     For most registers, the index is the value written to the DCRSR register to read or write the
     core register. Other core registers not directly supported by DCRSR have special index values that
     are interpreted by the helper methods on this class and the core register read/write code in CortexM
-    and its subclasses.
+    and its subclasses. These artificial register index values and how they are interpreted are documented
+    in the register definitions in CoreRegisterGroups.
     """
 
     ## Map of register name to info.
@@ -42,7 +47,7 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
     _INDEX_MAP = {}
 
     @classmethod
-    def register_name_to_index(cls, reg):
+    def register_name_to_index(cls, reg: "CoreRegisterNameOrNumberType") -> int:
         """! @brief Convert a register name to integer register index.
         @param reg Either a register name or internal register number.
         @return Internal register number.
@@ -55,23 +60,32 @@ class CortexMCoreRegisterInfo(CoreRegisterInfo):
                 raise KeyError('unknown core register name %s' % reg) from err
         return reg
 
+    @classmethod
+    def get(cls, reg: "CoreRegisterNameOrNumberType") -> "CortexMCoreRegisterInfo":
+        """! @brief Return the CoreRegisterInfo instance for a register.
+        @param reg Either a register name or internal register number.
+        @return CoreRegisterInfo
+        @exception KeyError
+        """
+        return cast(CortexMCoreRegisterInfo, super().get(reg))
+
     @property
-    def is_fpu_register(self):
+    def is_fpu_register(self) -> bool:
         """! @brief Returns true for FPSCR, SP, or DP registers."""
         return self.index == 33 or self.is_float_register
 
     @property
-    def is_cfbp_subregister(self):
+    def is_cfbp_subregister(self) -> bool:
         """! @brief Whether the register is one of those combined into CFBP by the DCSR."""
         return -4 <= self.index <= -1
 
     @property
-    def is_psr_subregister(self):
+    def is_psr_subregister(self) -> bool:
         """! @brief Whether the register is a combination of xPSR fields."""
         return 0x100 <= self.index <= 0x107
 
     @property
-    def psr_mask(self):
+    def psr_mask(self) -> int:
         """! @brief Generate a PSR mask based on bottom 3 bits of a MRS SYSm value"""
         mask = 0
         if (self.index & 1) != 0:
@@ -252,6 +266,6 @@ CortexMCoreRegisterInfo.add_to_map(CoreRegisterGroups.M_PROFILE_COMMON
             + CoreRegisterGroups.V81M_MVE_ONLY
             + CoreRegisterGroups.VFP_V5)
 
-def index_for_reg(name):
+def index_for_reg(name: str) -> int:
     """! @brief Utility to easily convert register name to index."""
     return CortexMCoreRegisterInfo.get(name).index

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -17,7 +17,8 @@
 
 import logging
 from enum import Enum
-from typing import NamedTuple
+from typing import (Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, TYPE_CHECKING, Union, overload)
+from typing_extensions import Literal
 
 from ..core import (exceptions, memory_interface)
 from ..core.target import Target
@@ -26,6 +27,11 @@ from ..probe.swj import SWJSequenceSender
 from .ap import APSEL_APBANKSEL
 from ..utility.sequencer import CallSequence
 from ..utility.timeout import Timeout
+
+if TYPE_CHECKING:
+    from .ap import (APAddressBase, AccessPort)
+    from ..core.session import Session
+    from ..utility.notification import Notification
 
 LOG = logging.getLogger(__name__)
 
@@ -117,21 +123,21 @@ class DPConnector:
     attempts at sending the SWJ sequence to select the wire protocol and read the DP IDR register.
     """
 
-    def __init__(self, probe):
+    def __init__(self, probe: DebugProbe) -> None:
         self._probe = probe
-        self._session = probe.session
-        self._idr = None
+        self._idr = DPIDR(0, 0, 0, 0, 0)
 
         # Make sure we have a session, since we get the session from the probe and probes have their session set
         # after creation.
-        assert self._session is not None, "DPConnector requires the probe to have a session"
+        assert probe.session is not None, "DPConnector requires the probe to have a session"
+        self._session = probe.session
 
     @property
-    def idr(self):
+    def idr(self) -> DPIDR:
         """! @brief DPIDR instance containing values read from the DP IDR register."""
         return self._idr
 
-    def _get_protocol(self, protocol):
+    def _get_protocol(self, protocol: Optional[DebugProbe.Protocol]) -> DebugProbe.Protocol:
         # Convert protocol from setting if not passed as parameter.
         if protocol is None:
             protocol_name = self._session.options.get('dap_protocol').strip().lower()
@@ -140,7 +146,7 @@ class DPConnector:
                 raise exceptions.DebugError("requested wire protocol %s not supported by the debug probe" % protocol.name)
         return protocol
 
-    def connect(self, protocol=None):
+    def connect(self, protocol: Optional[DebugProbe.Protocol] = None) -> None:
         """! @brief Establish a connection to the DP.
 
         This method causes the debug probe to connect using the wire protocol.
@@ -163,23 +169,25 @@ class DPConnector:
             already_connected = current_wire_protocol is not None
 
             if already_connected:
+                assert current_wire_protocol
                 self._check_protocol(current_wire_protocol, protocol)
             else:
                 self._connect_probe(protocol)
 
             protocol = self._probe.wire_protocol
+            assert protocol
             self._connect_dp(protocol)
         finally:
             self._probe.unlock()
 
-    def _check_protocol(self, current_wire_protocol, protocol):
+    def _check_protocol(self, current_wire_protocol: DebugProbe.Protocol, protocol: DebugProbe.Protocol) -> None:
         # Warn about mismatched current and requested wire protocols.
         if (protocol is not current_wire_protocol) and (protocol is not DebugProbe.Protocol.DEFAULT):
             LOG.warning("Cannot use %s; already connected with %s", protocol.name, current_wire_protocol.name)
         else:
             LOG.debug("Already connected with %s", current_wire_protocol.name)
 
-    def _connect_probe(self, protocol):
+    def _connect_probe(self, protocol: DebugProbe.Protocol) -> None:
         # Debug log with the selected protocol.
         if protocol is not DebugProbe.Protocol.DEFAULT:
             LOG.debug("Using %s wire protocol", protocol.name)
@@ -189,10 +197,11 @@ class DPConnector:
 
         # Log the actual protocol if selected was default.
         if protocol is DebugProbe.Protocol.DEFAULT:
-            protocol = self._probe.wire_protocol
-            LOG.debug("Default wire protocol selected; using %s", protocol.name)
+            actual_protocol = self._probe.wire_protocol
+            assert actual_protocol
+            LOG.debug("Default wire protocol selected; using %s", actual_protocol.name)
 
-    def _connect_dp(self, protocol):
+    def _connect_dp(self, protocol: DebugProbe.Protocol) -> None:
         # Get SWJ settings.
         use_dormant = self._session.options.get('dap_swj_use_dormant')
         send_swj = self._session.options.get('dap_swj_enable') \
@@ -251,7 +260,7 @@ class DebugPort:
     ## Number of times to try to read DP registers after hw reset before attempting reconnect.
     _RESET_RECOVERY_ATTEMPTS_BEFORE_RECONNECT = 1
 
-    def __init__(self, probe, target):
+    def __init__(self, probe: DebugProbe, target: Target) -> None:
         """! @brief Constructor.
         @param self The DebugPort object.
         @param probe The @ref pyocd.probe.debug_probe.DebugProbe "DebugProbe" object. The probe is assumed to not
@@ -261,70 +270,71 @@ class DebugPort:
         """
         self._probe = probe
         self.target = target
+        assert target.session
         self._session = target.session
-        self.valid_aps = None
-        self.dpidr = None
-        self.aps = {}
-        self._access_number = 0
-        self._cached_dp_select = None
-        self._protocol = None
-        self._probe_managed_ap_select = False
-        self._probe_managed_dpbanksel = False
-        self._probe_supports_dpbanksel = False
-        self._probe_supports_apv2_addresses = False
-        self._have_probe_capabilities = False
-        self._did_check_version = False
-        self._log_dp_info = True
+        self.valid_aps: Optional[List["APAddressBase"]] = None
+        self.dpidr = DPIDR(0, 0, 0, 0, 0)
+        self.aps: Dict["APAddressBase", "AccessPort"] = {}
+        self._access_number: int = 0
+        self._cached_dp_select: Optional[int] = None
+        self._protocol: Optional[DebugProbe.Protocol] = None
+        self._probe_managed_ap_select: bool = False
+        self._probe_managed_dpbanksel: bool = False
+        self._probe_supports_dpbanksel: bool = False
+        self._probe_supports_apv2_addresses: bool = False
+        self._have_probe_capabilities: bool = False
+        self._did_check_version: bool = False
+        self._log_dp_info: bool = True
 
         # DPv3 attributes
-        self._is_dpv3 = False
-        self._addr_size = None
-        self._addr_mask = None
-        self._errmode = None
-        self._base_addr = None
-        self._apacc_mem_interface = None
+        self._is_dpv3: bool = False
+        self._addr_size: int = -1
+        self._addr_mask: int = -1
+        self._errmode: int = -1
+        self._base_addr: int = -1
+        self._apacc_mem_interface: Optional[APAccessMemoryInterface] = None
 
         # Subscribe to reset events.
         self._session.subscribe(self._reset_did_occur, (Target.Event.PRE_RESET, Target.Event.POST_RESET))
 
     @property
-    def probe(self):
+    def probe(self) -> DebugProbe:
         return self._probe
 
     @property
-    def session(self):
+    def session(self) -> "Session":
         return self._session
 
     @property
-    def adi_version(self):
+    def adi_version(self) -> ADIVersion:
         return ADIVersion.ADIv6 if self._is_dpv3 else ADIVersion.ADIv5
 
     @property
-    def base_address(self):
+    def base_address(self) -> int:
         """! @brief Base address of the first component for an ADIv6 system."""
         return self._base_addr
 
     @property
-    def apacc_memory_interface(self):
+    def apacc_memory_interface(self) -> "APAccessMemoryInterface":
         """! @brief Memory interface for performing APACC transactions."""
         if self._apacc_mem_interface is None:
             self._apacc_mem_interface = APAccessMemoryInterface(self)
         return self._apacc_mem_interface
 
     @property
-    def next_access_number(self):
+    def next_access_number(self) -> int:
         self._access_number += 1
         return self._access_number
 
-    def lock(self):
+    def lock(self) -> None:
         """! @brief Lock the DP from access by other threads."""
         self.probe.lock()
 
-    def unlock(self):
+    def unlock(self) -> None:
         """! @brief Unlock the DP."""
         self.probe.unlock()
 
-    def connect(self, protocol=None):
+    def connect(self, protocol: Optional[DebugProbe.Protocol] = None) -> None:
         """! @brief Connect to the target.
 
         This method causes the debug probe to connect using the selected wire protocol. The probe
@@ -340,14 +350,14 @@ class DebugPort:
         self._protocol = protocol
         self.create_connect_sequence().invoke()
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         """! @brief Disconnect from target.
 
         DP debug is powered down. See power_down_debug().
         """
         self.power_down_debug()
 
-    def create_connect_sequence(self):
+    def create_connect_sequence(self) -> CallSequence:
         """! @brief Returns call sequence to connect to the target.
 
         Returns a @ref pyocd.utility.sequence.CallSequence CallSequence that will connect to the
@@ -359,7 +369,7 @@ class DebugPort:
         @param self
         @return @ref pyocd.utility.sequence.CallSequence CallSequence
         """
-        seq = [
+        seq: List[Tuple[str, Callable]] = [
             ('lock_probe',          self.probe.lock),
             ]
         if not self._have_probe_capabilities:
@@ -380,7 +390,7 @@ class DebugPort:
             ]
         return CallSequence(*seq)
 
-    def _get_probe_capabilities(self):
+    def _get_probe_capabilities(self) -> None:
         """! @brief Examine the probe's capabilities."""
         caps = self._probe.capabilities
         self._probe_managed_ap_select = (DebugProbe.Capability.MANAGED_AP_SELECTION in caps)
@@ -389,7 +399,7 @@ class DebugPort:
         self._probe_supports_apv2_addresses = (DebugProbe.Capability.APv2_ADDRESSES in caps)
         self._have_probe_capabilities = True
 
-    def _connect(self):
+    def _connect(self) -> None:
         # Attempt to connect.
         connector = DPConnector(self.probe)
         connector.connect(self._protocol)
@@ -400,7 +410,7 @@ class DebugPort:
             "DP IDR = 0x%08x (v%d%s rev%d)", self.dpidr.idr, self.dpidr.version,
             " MINDP" if self.dpidr.mindp else "", self.dpidr.revision)
 
-    def _check_version(self):
+    def _check_version(self) -> None:
         self._is_dpv3 = (self.dpidr.version == 3)
         if self._is_dpv3:
             # Check that the probe will be able to access ADIv6 APs.
@@ -440,13 +450,29 @@ class DebugPort:
             self._handle_error(error, self.next_access_number)
             raise
 
-    def read_reg(self, addr, now=True):
+    @overload
+    def read_reg(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read_reg(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_reg(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_reg(self, addr: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_reg(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         return self.read_dp(addr, now)
 
-    def write_reg(self, addr, data):
+    def write_reg(self, addr: int, data: int) -> None:
         self.write_dp(addr, data)
 
-    def power_up_debug(self):
+    def power_up_debug(self) -> bool:
         """! @brief Assert DP power requests.
 
         Request both debug and system power be enabled, and wait until the request is acked.
@@ -467,7 +493,7 @@ class DebugPort:
 
         return True
 
-    def power_down_debug(self):
+    def power_down_debug(self) -> bool:
         """! @brief Deassert DP power requests.
 
         ADIv6 says that we must not clear CSYSPWRUPREQ and CDBGPWRUPREQ at the same time.
@@ -501,11 +527,11 @@ class DebugPort:
 
         return True
 
-    def _invalidate_cache(self):
+    def _invalidate_cache(self) -> None:
         """! @brief Invalidate cached DP registers."""
         self._cached_dp_select = None
 
-    def _reset_did_occur(self, notification):
+    def _reset_did_occur(self, notification: "Notification") -> None:
         """! @brief Handles reset notifications to invalidate register cache.
 
         The cache is cleared on all resets just to be safe. On most devices, warm resets do not reset
@@ -513,7 +539,7 @@ class DebugPort:
         """
         self._invalidate_cache()
 
-    def post_reset_recovery(self):
+    def post_reset_recovery(self) -> None:
         """! @brief Wait for the target to recover from reset, with auto-reconnect if needed."""
         # Check if we can access DP registers. If this times out, then reconnect the DP and retry.
         with Timeout(self.session.options.get('reset.dap_recover.timeout'),
@@ -547,7 +573,7 @@ class DebugPort:
             else:
                 LOG.error("DAP is not accessible after reset followed by attempted reconnect")
 
-    def reset(self, *, send_notifications=True):
+    def reset(self, *, send_notifications: bool = True) -> None:
         """! @brief Hardware reset.
 
         Pre- and post-reset notifications are sent.
@@ -570,7 +596,7 @@ class DebugPort:
         if send_notifications:
             self.session.notify(Target.Event.POST_RESET, self)
 
-    def assert_reset(self, asserted, *, send_notifications=True):
+    def assert_reset(self, asserted: bool, *, send_notifications: bool = True) -> None:
         """! @brief Assert or deassert the hardware reset signal.
 
         A pre-reset notification is sent before asserting reset, whereas a post-reset notification is sent
@@ -594,7 +620,7 @@ class DebugPort:
         if send_notifications and not asserted and is_asserted:
             self.session.notify(Target.Event.POST_RESET, self)
 
-    def is_reset_asserted(self):
+    def is_reset_asserted(self) -> bool:
         """! @brief Returns the current state of the nRESET signal.
 
         This method can be called before the DebugPort is initalized.
@@ -604,14 +630,14 @@ class DebugPort:
         """
         return self.probe.is_reset_asserted()
 
-    def set_clock(self, frequency):
+    def set_clock(self, frequency: float) -> None:
         """! @brief Change the wire protocol's clock frequency.
         @param self This object.
         @param frequency New wire protocol frequency in Hertz.
         """
         self.probe.set_clock(frequency)
 
-    def _write_dp_select(self, mask, value):
+    def _write_dp_select(self, mask: int, value: int) -> None:
         """! @brief Modify part of the DP SELECT register and write if cache is stale.
 
         The DP lock must already be acquired before calling this method.
@@ -628,7 +654,7 @@ class DebugPort:
         self.write_dp(DP_SELECT, select)
         self._cached_dp_select = select
 
-    def _set_dpbanksel(self, addr, is_write):
+    def _set_dpbanksel(self, addr: int, is_write: bool) -> bool:
         """! @brief Updates the DPBANKSEL field of the SELECT register as required.
 
         Several DP registers (most, actually) ignore DPBANKSEL. If one of those is being
@@ -671,7 +697,23 @@ class DebugPort:
         else:
             return False
 
-    def read_dp(self, addr, now=True):
+    @overload
+    def read_dp(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_dp(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         if (addr & DPADDR_MASK) % 4 != 0:
             raise ValueError("DP address must be word aligned")
         num = self.next_access_number
@@ -692,7 +734,7 @@ class DebugPort:
             raise
 
         # Read callback returned for async reads.
-        def read_dp_cb():
+        def read_dp_cb() -> int:
             try:
                 result = result_cb()
                 TRACE.debug("read_dp:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
@@ -711,7 +753,7 @@ class DebugPort:
             TRACE.debug("read_dp:%06d (addr=0x%08x) -> ...", num, addr)
             return read_dp_cb
 
-    def write_dp(self, addr, data):
+    def write_dp(self, addr: int, data: int) -> None:
         if (addr & DPADDR_MASK) % 4 != 0:
             raise ValueError("DP address must be word aligned")
         num = self.next_access_number
@@ -730,9 +772,7 @@ class DebugPort:
             if did_lock:
                 self.unlock()
 
-        return True
-
-    def _select_ap(self, addr):
+    def _select_ap(self, addr: int) -> bool:
         """! @brief Write DP_SELECT to choose the given AP.
 
         Handles the case where the debug probe manages selecting an AP itself, in which case we
@@ -755,7 +795,7 @@ class DebugPort:
             assert False, "invalid ADI version"
         return True
 
-    def write_ap(self, addr, data):
+    def write_ap(self, addr: int, data: int) -> None:
         assert isinstance(addr, int)
         num = self.next_access_number
         did_lock = False
@@ -771,9 +811,23 @@ class DebugPort:
             if did_lock:
                 self.unlock()
 
-        return True
+    @overload
+    def read_ap(self, addr: int) -> int:
+        ...
 
-    def read_ap(self, addr, now=True):
+    @overload
+    def read_ap(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_ap(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_ap(self, addr: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_ap(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         assert isinstance(addr, int)
         num = self.next_access_number
         did_lock = False
@@ -792,7 +846,7 @@ class DebugPort:
             raise
 
         # Read callback returned for async reads.
-        def read_ap_cb():
+        def read_ap_cb() -> int:
             try:
                 result = result_cb()
                 TRACE.debug("read_ap:%06d %s(addr=0x%08x) -> 0x%08x", num, "" if now else "...", addr, result)
@@ -811,7 +865,7 @@ class DebugPort:
             TRACE.debug("read_ap:%06d (addr=0x%08x) -> ...", num, addr)
             return read_ap_cb
 
-    def write_ap_multiple(self, addr, values):
+    def write_ap_multiple(self, addr: int, values: Sequence[int]) -> None:
         assert isinstance(addr, int)
         num = self.next_access_number
         did_lock = False
@@ -827,7 +881,24 @@ class DebugPort:
             if did_lock:
                 self.unlock()
 
-    def read_ap_multiple(self, addr, count=1, now=True):
+    @overload
+    def read_ap_multiple(self, addr: int, count: int = 1) -> Sequence[int]:
+        ...
+
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: Literal[True] = True) -> Sequence[int]:
+        ...
+
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: Literal[False]) -> Callable[[], Sequence[int]]:
+        ...
+
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: bool) -> Union[Sequence[int], Callable[[], Sequence[int]]]:
+        ...
+
+    def read_ap_multiple(self, addr: int, count: int = 1, now: bool = True) \
+             -> Union[Sequence[int], Callable[[], Sequence[int]]]:
         assert isinstance(addr, int)
         num = self.next_access_number
         did_lock = False
@@ -845,7 +916,7 @@ class DebugPort:
             raise
 
         # Need to wrap the deferred callback to convert exceptions.
-        def read_ap_multiple_cb():
+        def read_ap_multiple_cb() -> Sequence[int]:
             try:
                 return result_cb()
             except exceptions.TargetError as error:
@@ -861,7 +932,7 @@ class DebugPort:
         else:
             return read_ap_multiple_cb
 
-    def _handle_error(self, error, num):
+    def _handle_error(self, error: Exception, num: int) -> None:
         TRACE.debug("error:%06d %s", num, error)
         # Clear sticky error for fault errors.
         if isinstance(error, exceptions.TransferFaultError):
@@ -872,7 +943,7 @@ class DebugPort:
             # attempting to reset debug logic.
             self.write_reg(DP_ABORT, ABORT_DAPABORT)
 
-    def clear_sticky_err(self):
+    def clear_sticky_err(self) -> None:
         self._invalidate_cache()
         mode = self.probe.wire_protocol
         if mode == DebugProbe.Protocol.SWD:
@@ -896,7 +967,7 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
     Only 32-bit transfers are supported.
     """
 
-    def __init__(self, dp, ap_address=None):
+    def __init__(self, dp: DebugPort, ap_address: Optional["APAddressBase"] = None) -> None:
         """! @brief Constructor.
 
         @param self
@@ -912,17 +983,17 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
             self._offset = 0
 
     @property
-    def dp(self):
+    def dp(self) -> DebugPort:
         return self._dp
 
     @property
-    def short_description(self):
+    def short_description(self) -> str:
         if self._ap_address is None:
             return "Root Component"
         else:
             return "Root Component ({})".format(self._ap_address)
 
-    def write_memory(self, addr, data, transfer_size=32):
+    def write_memory(self, addr: int, data: int, transfer_size: int = 32) -> None:
         """! @brief Write a single memory location.
 
         By default the transfer size is a word."""
@@ -931,7 +1002,23 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
 
         return self._dp.write_ap(self._offset + addr, data)
 
-    def read_memory(self, addr, transfer_size=32, now=True):
+    @overload
+    def read_memory(self, addr: int, transfer_size: int) -> int:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_memory(self, addr: int, transfer_size: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_memory(self, addr: int, transfer_size: int = 32, now: bool = True) -> Union[int, Callable[[], int]]:
         """! @brief Read a memory location.
 
         By default, a word will be read."""
@@ -940,14 +1027,14 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
 
         return self._dp.read_ap(self._offset + addr, now)
 
-    def write_memory_block32(self, addr, data):
+    def write_memory_block32(self, addr: int, data: Sequence[int]) -> None:
         """! @brief Write an aligned block of 32-bit words."""
         addr += self._offset
         for word in data:
-            self._dp.write_ap(addr, data)
+            self._dp.write_ap(addr, word)
             addr += 4
 
-    def read_memory_block32(self, addr, size):
+    def read_memory_block32(self, addr: int, size) -> Sequence[int]:
         """! @brief Read an aligned block of 32-bit words."""
         addr += self._offset
         result_cbs = [self._dp.read_ap(addr + i * 4, now=False) for i in range(size)]

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Cypress Semiconductor Corporation
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,7 @@
 
 import logging
 
-from .component import CoreSightCoreComponent
+from .component import CoreSightComponent
 from ..core.target import Target
 from ..core.core_registers import CoreRegistersIndex
 
@@ -25,7 +26,7 @@ LOG = logging.getLogger(__name__)
 DEAD_VALUE = 0
 
 
-class GenericMemAPTarget(Target, CoreSightCoreComponent):
+class GenericMemAPTarget(Target, CoreSightComponent):
     """! @brief This target represents ARM debug Access Port without a CPU
 
     It may be used to access the address space of the target via Access Ports
@@ -42,7 +43,7 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
 
     def __init__(self, session, ap, memory_map=None, core_num=0, cmpid=None, address=None):
         Target.__init__(self, session, memory_map)
-        CoreSightCoreComponent.__init__(self, ap, cmpid, address)
+        CoreSightComponent.__init__(self, ap, cmpid, address)
         self.core_number = core_num
         self.core_type = DEAD_VALUE
         self._core_registers = CoreRegistersIndex()

--- a/pyocd/debug/breakpoints/manager.py
+++ b/pyocd/debug/breakpoints/manager.py
@@ -17,18 +17,24 @@
 
 import logging
 from copy import copy
+from typing import (Dict, List, TYPE_CHECKING, Iterable, MutableSequence, Optional, Sequence, Tuple)
 
 from .provider import Breakpoint
 from ...core.target import Target
 
+if TYPE_CHECKING:
+    from .provider import BreakpointProvider
+    from ...core.core_target import CoreTarget
+    from ...utility.notification import Notification
+
 LOG = logging.getLogger(__name__)
 
 class UnrealizedBreakpoint(Breakpoint):
-    """! @brief Breakpoint class used until a breakpoint's type is decided."""
+    """@brief Breakpoint class used until a breakpoint's type is decided."""
     pass
 
-class BreakpointManager(object):
-    """! @brief Manages all breakpoints for one core.
+class BreakpointManager:
+    """@brief Manages all breakpoints for one core.
 
     The most important function of the breakpoint manager is to decide which breakpoint provider
     to use when a breakpoint is added. The caller can request a particular breakpoint type, but
@@ -45,29 +51,29 @@ class BreakpointManager(object):
     ## Number of hardware breakpoints to try to keep available.
     MIN_HW_BREAKPOINTS = 0
 
-    def __init__(self, core):
-        self._breakpoints = {}
-        self._updated_breakpoints = {}
+    def __init__(self, core: "CoreTarget") -> None:
+        self._breakpoints: Dict[int, Breakpoint] = {}
+        self._updated_breakpoints: Dict[int, Breakpoint] = {}
         self._session = core.session
         self._core = core
-        self._fpb = None
-        self._providers = {}
-        self._ignore_notifications = False
+        self._fpb: Optional["BreakpointProvider"] = None
+        self._providers: Dict[Target.BreakpointType, "BreakpointProvider"] = {}
+        self._ignore_notifications: bool = False
 
         # Subscribe to some notifications.
         self._session.subscribe(self._pre_run_handler, Target.Event.PRE_RUN)
         self._session.subscribe(self._pre_disconnect_handler, Target.Event.PRE_DISCONNECT)
 
-    def add_provider(self, provider):
+    def add_provider(self, provider: "BreakpointProvider") -> None:
         self._providers[provider.bp_type] = provider
         if provider.bp_type == Target.BreakpointType.HW:
             self._fpb = provider
 
-    def get_breakpoints(self):
+    def get_breakpoints(self) -> Iterable[int]:
         """! @brief Return a list of all breakpoint addresses."""
         return self._breakpoints.keys()
 
-    def find_breakpoint(self, addr):
+    def find_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         return self._updated_breakpoints.get(addr, None)
 
     def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
@@ -103,7 +109,7 @@ class BreakpointManager(object):
         self._updated_breakpoints[addr] = bp
         return True
 
-    def _check_added_breakpoint(self, bp):
+    def _check_added_breakpoint(self, bp: Breakpoint) -> bool:
         """! @brief Check whether a new breakpoint is likely to actually be added when we flush.
 
         First, software breakpoints are assumed to always be addable. For hardware breakpoints,
@@ -133,7 +139,7 @@ class BreakpointManager(object):
 
         return free_hw_bp_count > self.MIN_HW_BREAKPOINTS
 
-    def remove_breakpoint(self, addr):
+    def remove_breakpoint(self, addr: int) -> None:
         """! @brief Remove a breakpoint at a specific location."""
         try:
             LOG.debug("remove bkpt at 0x%x", addr)
@@ -146,7 +152,7 @@ class BreakpointManager(object):
         except KeyError:
             LOG.debug("Tried to remove breakpoint 0x%08x that wasn't set" % addr)
 
-    def _get_updated_breakpoints(self):
+    def _get_updated_breakpoints(self) -> Tuple[List[Breakpoint], List[Breakpoint]]:
         """! @brief Compute added and removed breakpoints since last flush.
         @return Bi-tuple of (added breakpoint list, removed breakpoint list).
         """
@@ -166,7 +172,7 @@ class BreakpointManager(object):
         # Return the list of pages to update.
         return added, removed
 
-    def _select_breakpoint_type(self, bp, allow_all_hw_bps):
+    def _select_breakpoint_type(self, bp: Breakpoint, allow_all_hw_bps: bool) -> Optional[Target.BreakpointType]:
         type = bp.type
 
         # Look up the memory type for the requested address.
@@ -223,7 +229,7 @@ class BreakpointManager(object):
         LOG.debug("selected bkpt type %s for addr 0x%x", type.name, bp.addr)
         return type
 
-    def flush(self, is_step=False):
+    def flush(self, is_step: bool = False) -> None:
         try:
             # Ignore any notifications while we modify breakpoints.
             self._ignore_notifications = True
@@ -267,45 +273,45 @@ class BreakpointManager(object):
         finally:
             self._ignore_notifications = False
 
-    def get_breakpoint_type(self, addr):
+    def get_breakpoint_type(self, addr: int) -> Optional[Target.BreakpointType]:
         bp = self.find_breakpoint(addr)
         return bp.type if (bp is not None) else None
 
-    def filter_memory(self, addr, size, data):
+    def filter_memory(self, addr: int, size: int, data: int) -> int:
         for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             data = provider.filter_memory(addr, size, data)
         return data
 
-    def filter_memory_unaligned_8(self, addr, size, data):
+    def filter_memory_unaligned_8(self, addr: int, size: int, data: MutableSequence[int]) -> Sequence[int]:
         for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             for i, d in enumerate(data):
                 data[i] = provider.filter_memory(addr + i, 8, d)
         return data
 
-    def filter_memory_aligned_32(self, addr, size, data):
+    def filter_memory_aligned_32(self, addr: int, size: int, data: MutableSequence[int]) -> Sequence[int]:
         for provider in [p for p in self._providers.values() if p.do_filter_memory]:
             for i, d in enumerate(data):
                 data[i] = provider.filter_memory(addr + i, 32, d)
         return data
 
-    def remove_all_breakpoints(self):
+    def remove_all_breakpoints(self) -> None:
         """! @brief Remove all breakpoints immediately."""
         for bp in self._breakpoints.values():
             bp.provider.remove_breakpoint(bp)
         self._breakpoints = {}
         self._flush_all()
 
-    def _flush_all(self):
+    def _flush_all(self) -> None:
         # Flush all providers.
         for provider in self._providers.values():
             provider.flush()
 
-    def _pre_run_handler(self, notification):
+    def _pre_run_handler(self, notification: "Notification") -> None:
         if not self._ignore_notifications:
             is_step = notification.data == Target.RunType.STEP
             self.flush(is_step)
 
-    def _pre_disconnect_handler(self, notification):
+    def _pre_disconnect_handler(self, notification: "Notification") -> None:
         pass
 
 

--- a/pyocd/debug/breakpoints/provider.py
+++ b/pyocd/debug/breakpoints/provider.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2017 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,48 +15,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from ...core.target import Target
 
-class Breakpoint(object):
+class Breakpoint:
     def __init__(self, provider):
-        self.type = Target.BreakpointType.HW
-        self.enabled = False
-        self.addr = 0
-        self.original_instr = 0
-        self.provider = provider
+        self.type: Target.BreakpointType = Target.BreakpointType.HW
+        self.enabled: bool = False
+        self.addr: int = 0
+        self.original_instr: int = 0
+        self.provider: BreakpointProvider = provider
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<%s@0x%08x type=%s addr=0x%08x>" % (self.__class__.__name__, id(self), self.type.name, self.addr)
 
-class BreakpointProvider(object):
-    """! @brief Abstract base class for breakpoint providers."""
-    def init(self):
+class BreakpointProvider:
+    """@brief Abstract base class for breakpoint providers."""
+    def init(self) -> None:
         raise NotImplementedError()
 
-    def bp_type(self):
-        return 0
+    @property
+    def bp_type(self) -> Target.BreakpointType:
+        raise NotImplementedError()
 
     @property
-    def do_filter_memory(self):
+    def do_filter_memory(self) -> bool:
         return False
 
     @property
-    def available_breakpoints(self):
+    def available_breakpoints(self) -> int:
         raise NotImplementedError()
 
-    def find_breakpoint(self, addr):
+    def can_support_address(self, addr: int) -> bool:
         raise NotImplementedError()
 
-    def set_breakpoint(self, addr):
+    def find_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         raise NotImplementedError()
 
-    def remove_breakpoint(self, bp):
+    def set_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         raise NotImplementedError()
 
-    def filter_memory(self, addr, size, data):
+    def remove_breakpoint(self, bp: Breakpoint) -> None:
+        raise NotImplementedError()
+
+    def filter_memory(self, addr: int, size: int, data: int) -> int:
         return data
 
-    def flush(self):
+    def flush(self) -> None:
         pass
 
 

--- a/pyocd/debug/breakpoints/software.py
+++ b/pyocd/debug/breakpoints/software.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,15 +15,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+from typing import (Dict, Optional, TYPE_CHECKING)
+
 from .provider import (Breakpoint, BreakpointProvider)
 from ...core import exceptions
 from ...core.target import Target
-import logging
+
+if TYPE_CHECKING:
+    from ...core.core_target import CoreTarget
 
 LOG = logging.getLogger(__name__)
 
 class SoftwareBreakpoint(Breakpoint):
-    def __init__(self, provider):
+    def __init__(self, provider: BreakpointProvider) -> None:
         super(SoftwareBreakpoint, self).__init__(provider)
         self.type = Target.BreakpointType.SW
 
@@ -30,31 +36,35 @@ class SoftwareBreakpointProvider(BreakpointProvider):
     ## BKPT #0 instruction.
     BKPT_INSTR = 0xbe00
 
-    def __init__(self, core):
+    def __init__(self, core: "CoreTarget") -> None:
         super(SoftwareBreakpointProvider, self).__init__()
         self._core = core
-        self._breakpoints = {}
+        self._breakpoints: Dict[int, SoftwareBreakpoint] = {}
 
-    def init(self):
+    def init(self) -> None:
         pass
 
     @property
-    def bp_type(self):
+    def bp_type(self) -> Target.BreakpointType:
         return Target.BreakpointType.SW
 
     @property
-    def do_filter_memory(self):
+    def do_filter_memory(self) -> bool:
         return True
 
     @property
-    def available_breakpoints(self):
+    def available_breakpoints(self) -> int:
         return -1
 
-    def find_breakpoint(self, addr):
+    def can_support_address(self, addr: int) -> bool:
+        region = self._core.memory_map.get_region_for_address(addr)
+        return (region is not None) and region.is_writable
+
+    def find_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         return self._breakpoints.get(addr, None)
 
-    def set_breakpoint(self, addr):
-        assert self._core.memory_map.get_region_for_address(addr).is_ram
+    def set_breakpoint(self, addr: int) -> Optional[Breakpoint]:
+        assert self.can_support_address(addr)
         assert (addr & 1) == 0
 
         try:
@@ -77,7 +87,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
             LOG.debug("Failed to set sw bp at 0x%x" % addr)
             return None
 
-    def remove_breakpoint(self, bp):
+    def remove_breakpoint(self, bp: Breakpoint) -> None:
         assert bp is not None and isinstance(bp, Breakpoint)
 
         try:
@@ -89,7 +99,7 @@ class SoftwareBreakpointProvider(BreakpointProvider):
         except exceptions.TransferError:
             LOG.debug("Failed to remove sw bp at 0x%x" % bp.addr)
 
-    def filter_memory(self, addr, size, data):
+    def filter_memory(self, addr: int, size: int, data: int) -> int:
         for bp in self._breakpoints.values():
             if size == 8:
                 if bp.addr == addr:

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -125,14 +125,14 @@ class FileProgrammer(object):
         is_path = isinstance(file_or_path, str)
 
         # Check for valid path first.
-        if is_path and not os.path.isfile(file_or_path): # type: ignore (type checker doesn't use is_path)
+        if is_path and not os.path.isfile(file_or_path): # type: ignore # (type checker doesn't use is_path)
             raise FileNotFoundError(errno.ENOENT, "No such file: '{}'".format(file_or_path))
 
         # If no format provided, use the file's extension.
         if not file_format:
             if is_path:
                 # Extract the extension from the path.
-                file_format = os.path.splitext(file_or_path)[1][1:] # type: ignore (type checker doesn't use is_path)
+                file_format = os.path.splitext(file_or_path)[1][1:] # type: ignore # (type checker doesn't use is_path)
 
                 # Explicitly check for no extension.
                 if file_format == '':

--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 import logging
-import six
 from xml.etree import ElementTree
 from itertools import groupby
 
@@ -107,7 +106,7 @@ class GDBDebugContextFacade(object):
             if reg_value is None:
                 r = b"xx" * round_up_div(reg.bitsize, 8)
             else:
-                r = six.b(conversion.uint_to_hex_le(reg_value, reg.bitsize))
+                r = conversion.uint_to_hex_le(reg_value, reg.bitsize).encode()
             resp += r
             LOG.debug("GDB get_reg_context: %s = %s -> %s", reg.name,
                     "None" if (reg_value is None) else ("0x%08X" % reg_value), r)
@@ -167,7 +166,7 @@ class GDBDebugContextFacade(object):
 
         try:
             reg_value = self._context.read_core_register_raw(reg.name)
-            resp = six.b(conversion.uint_to_hex_le(reg_value, reg.bitsize))
+            resp = conversion.uint_to_hex_le(reg_value, reg.bitsize).encode()
             LOG.debug("GDB reg: %s = 0x%X", reg.name, reg_value)
         except exceptions.CoreRegisterAccessError:
             # Return x's if the register read failed.
@@ -183,9 +182,9 @@ class GDBDebugContextFacade(object):
         - The current value of the important registers (sp, lr, pc).
         """
         if force_signal is not None:
-            response = six.b('T' + conversion.byte_to_hex2(force_signal))
+            response = ('T' + conversion.byte_to_hex2(force_signal)).encode()
         else:
-            response = six.b('T' + conversion.byte_to_hex2(self.get_signal_value()))
+            response = ('T' + conversion.byte_to_hex2(self.get_signal_value())).encode()
 
         # Append fp(r7), sp(r13), lr(r14), pc(r15)
         response += self._get_reg_index_value_pairs(['r7', 'sp', 'lr', 'pc'])
@@ -230,7 +229,7 @@ class GDBDebugContextFacade(object):
                 encoded_reg = "xx" * round_up_div(reg.bitsize, 8)
             else:
                 encoded_reg = conversion.uint_to_hex_le(reg_value, reg.bitsize)
-            result += six.b(conversion.byte_to_hex2(reg.gdb_regnum) + ':' + encoded_reg + ';')
+            result += (conversion.byte_to_hex2(reg.gdb_regnum) + ':' + encoded_reg + ';').encode()
         return result
 
     def get_memory_map_xml(self):

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -19,7 +19,6 @@ import logging
 import threading
 from time import sleep
 import sys
-import six
 import io
 from xml.etree.ElementTree import (Element, SubElement, tostring)
 from typing import (Dict, List, Optional)
@@ -934,7 +933,7 @@ class GDBServer(threading.Thread):
 
             # Build our list of features.
             features = [b'qXfer:features:read+', b'QStartNoAckMode+', b'qXfer:threads:read+', b'QNonStop+']
-            features.append(b'PacketSize=' + six.b(hex(self.packet_size))[2:])
+            features.append(b'PacketSize=' + (hex(self.packet_size).encode())[2:])
             if self.target_facade.get_memory_map_xml() is not None:
                 features.append(b'qXfer:memory-map:read+')
             resp = b';'.join(features)

--- a/pyocd/gdbserver/packet_io.py
+++ b/pyocd/gdbserver/packet_io.py
@@ -18,7 +18,6 @@
 import logging
 import threading
 import socket
-import six
 import queue
 
 CTRL_C = b'\x03'
@@ -31,8 +30,8 @@ TRACE_ACK.setLevel(logging.CRITICAL)
 TRACE_PACKETS = LOG.getChild("trace.packet")
 TRACE_PACKETS.setLevel(logging.CRITICAL)
 
-def checksum(data):
-    return ("%02x" % (sum(six.iterbytes(data)) % 256)).encode()
+def checksum(data: bytes) -> bytes:
+    return ("%02x" % (sum(data) % 256)).encode()
 
 class ConnectionClosedException(Exception):
     """! @brief Exception used to signal the GDB server connection closed."""

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -17,7 +17,10 @@
 
 from time import sleep
 import logging
-from typing import (Dict, Tuple)
+from typing import (Callable, Collection, Dict, List, Optional, overload, Sequence, Set, TYPE_CHECKING, Tuple, Union)
+from typing_extensions import Literal
+
+from pyocd.probe.pydapaccess.dap_access_api import DAPAccessIntf
 
 from .debug_probe import DebugProbe
 from ..core import exceptions
@@ -25,6 +28,9 @@ from ..core.plugin import Plugin
 from .pydapaccess import DAPAccess
 from ..board.mbed_board import MbedBoard
 from ..board.board_ids import BOARD_ID_TO_INFO
+
+if TYPE_CHECKING:
+    from ..board.board import Board
 
 LOG = logging.getLogger(__name__)
 TRACE = LOG.getChild("trace")
@@ -44,10 +50,12 @@ class CMSISDAPProbe(DebugProbe):
     #
     # Note that Protocol.DEFAULT gets mapped to PORT.SWD. We need a concrete port type because some
     # non-reference CMSIS-DAP implementations do not accept the default port type.
-    PORT_MAP = {
+    _PROTOCOL_TO_PORT: Dict[DebugProbe.Protocol, DAPAccess.PORT] = {
         DebugProbe.Protocol.DEFAULT: DAPAccess.PORT.SWD,
         DebugProbe.Protocol.SWD: DAPAccess.PORT.SWD,
         DebugProbe.Protocol.JTAG: DAPAccess.PORT.JTAG,
+        }
+    _PORT_TO_PROTOCOL: Dict[DAPAccess.PORT, DebugProbe.Protocol] = {
         DAPAccess.PORT.DEFAULT: DebugProbe.Protocol.DEFAULT,
         DAPAccess.PORT.SWD: DebugProbe.Protocol.SWD,
         DAPAccess.PORT.JTAG: DebugProbe.Protocol.JTAG,
@@ -77,14 +85,14 @@ class CMSISDAPProbe(DebugProbe):
     DAPLINK_VIDPID = (0x0d28, 0x0204)
 
     @classmethod
-    def get_all_connected_probes(cls, unique_id=None, is_explicit=False):
+    def get_all_connected_probes(cls, unique_id: str = None, is_explicit: bool = False) -> Sequence["DebugProbe"]:
         try:
             return [cls(dev) for dev in DAPAccess.get_connected_devices()]
         except DAPAccess.Error as exc:
             raise cls._convert_exception(exc) from exc
 
     @classmethod
-    def get_probe_with_id(cls, unique_id, is_explicit=False):
+    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional["DebugProbe"]:
         try:
             dap_access = DAPAccess.get_device(unique_id)
             if dap_access is not None:
@@ -94,16 +102,16 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise cls._convert_exception(exc) from exc
 
-    def __init__(self, device):
+    def __init__(self, device: DAPAccessIntf) -> None:
         super(CMSISDAPProbe, self).__init__()
         self._link = device
-        self._supported_protocols = None
-        self._protocol = None
+        self._supported_protocols: List[DebugProbe.Protocol] = []
+        self._protocol: Optional[DebugProbe.Protocol] = None
         self._is_open = False
-        self._caps = set()
+        self._caps: Set[DebugProbe.Capability] = set()
 
     @property
-    def board_id(self):
+    def board_id(self) -> Optional[str]:
         """! @brief Unique identifier for the board.
 
         Only board IDs for DAPLink firmware are supported. We can't assume other
@@ -118,7 +126,7 @@ class CMSISDAPProbe(DebugProbe):
             return None
 
     @property
-    def description(self):
+    def description(self) -> str:
         try:
             # self.board_id may be None.
             board_info = BOARD_ID_TO_INFO[self.board_id]
@@ -128,35 +136,35 @@ class CMSISDAPProbe(DebugProbe):
             return "{0} [{1}]".format(board_info.name, board_info.target)
 
     @property
-    def vendor_name(self):
+    def vendor_name(self) -> str:
         return self._link.vendor_name
 
     @property
-    def product_name(self):
+    def product_name(self) -> str:
         return self._link.product_name
 
     @property
-    def supported_wire_protocols(self):
+    def supported_wire_protocols(self) -> Collection[DebugProbe.Protocol]:
         """! @brief Only valid after opening."""
         return self._supported_protocols
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         return self._link.get_unique_id()
 
     @property
-    def wire_protocol(self):
+    def wire_protocol(self) -> Optional[DebugProbe.Protocol]:
         return self._protocol
 
     @property
-    def is_open(self):
+    def is_open(self) -> bool:
         return self._is_open
 
     @property
-    def capabilities(self):
+    def capabilities(self) -> Set[DebugProbe.Capability]:
         return self._caps
 
-    def create_associated_board(self):
+    def create_associated_board(self) -> Optional["Board"]:
         assert self.session is not None
 
         # Only support associated Mbed boards for DAPLink firmware. We can't assume other
@@ -167,7 +175,8 @@ class CMSISDAPProbe(DebugProbe):
         else:
             return None
 
-    def open(self):
+    def open(self) -> None:
+        assert self.session
         try:
             TRACE.debug("trace: open")
 
@@ -196,7 +205,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def close(self):
+    def close(self) -> None:
         try:
             TRACE.debug("trace: close")
 
@@ -208,7 +217,7 @@ class CMSISDAPProbe(DebugProbe):
     # ------------------------------------------- #
     #          Target control functions
     # ------------------------------------------- #
-    def connect(self, protocol=None):
+    def connect(self, protocol: Optional[DebugProbe.Protocol] = None) -> None:
         TRACE.debug("trace: connect(%s)", protocol.name if (protocol is not None) else "None")
 
         # Convert protocol to port enum.
@@ -216,7 +225,8 @@ class CMSISDAPProbe(DebugProbe):
         # We must get a non-default port, since some CMSIS-DAP implementations do not accept the default
         # port. Note that the conversion of the default port type is contained in the PORT_MAP dict so it
         # is one location.
-        port = self.PORT_MAP.get(protocol, self.PORT_MAP[DebugProbe.Protocol.DEFAULT])
+        port = (self._PROTOCOL_TO_PORT.get(protocol)
+                if protocol else self._PROTOCOL_TO_PORT[DebugProbe.Protocol.DEFAULT])
         assert port is not DAPAccess.PORT.DEFAULT
 
         try:
@@ -226,9 +236,9 @@ class CMSISDAPProbe(DebugProbe):
 
         # Read the current mode and save it.
         actualMode = self._link.get_swj_mode()
-        self._protocol = self.PORT_MAP[actualMode]
+        self._protocol = self._PORT_TO_PROTOCOL[actualMode]
 
-    def swj_sequence(self, length, bits):
+    def swj_sequence(self, length: int, bits: int) -> None:
         TRACE.debug("trace: swj_sequence(length=%i, bits=%x)", length, bits)
 
         try:
@@ -236,15 +246,15 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def swd_sequence(self, sequences):
+    def swd_sequence(self, sequences: Sequence[Union[Tuple[int], Tuple[int, int]]]) -> Tuple[int, Sequence[bytes]]:
         TRACE.debug("trace: swd_sequence(sequences=%r)", sequences)
 
         try:
-            self._link.swd_sequence(sequences)
+            return self._link.swd_sequence(sequences)
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def jtag_sequence(self, cycles, tms, read_tdo, tdi):
+    def jtag_sequence(self, cycles: int, tms: int, read_tdo: bool, tdi: int) -> Optional[int]:
         TRACE.debug("trace: jtag_sequence(cycles=%i, tms=%x, read_tdo=%s, tdi=%x)", cycles, tms, read_tdo, tdi)
 
         try:
@@ -252,7 +262,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         TRACE.debug("trace: disconnect")
 
         try:
@@ -261,7 +271,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def set_clock(self, frequency):
+    def set_clock(self, frequency: float) -> None:
         TRACE.debug("trace: set_clock(freq=%i)", frequency)
 
         try:
@@ -269,7 +279,8 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def reset(self):
+    def reset(self) -> None:
+        assert self.session
         TRACE.debug("trace: reset")
 
         try:
@@ -280,7 +291,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def assert_reset(self, asserted):
+    def assert_reset(self, asserted: bool) -> None:
         TRACE.debug("trace: assert_reset(%s)", asserted)
 
         try:
@@ -288,7 +299,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def is_reset_asserted(self):
+    def is_reset_asserted(self) -> bool:
         try:
             result = self._link.is_reset_asserted()
             TRACE.debug("trace: is_reset_asserted -> %s", result)
@@ -296,7 +307,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def flush(self):
+    def flush(self) -> None:
         TRACE.debug("trace: flush")
 
         try:
@@ -309,7 +320,23 @@ class CMSISDAPProbe(DebugProbe):
     #          DAP Access functions
     # ------------------------------------------- #
 
-    def read_dp(self, addr, now=True):
+    @overload
+    def read_dp(self, addr: int) -> int:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_dp(self, addr: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_dp(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         reg_id = self.REG_ADDR_TO_ID_MAP[self.DP, addr]
 
         try:
@@ -336,7 +363,7 @@ class CMSISDAPProbe(DebugProbe):
         else:
             return read_dp_result_callback
 
-    def write_dp(self, addr, data):
+    def write_dp(self, addr: int, data: int) -> None:
         reg_id = self.REG_ADDR_TO_ID_MAP[self.DP, addr]
 
         # Write the DP register.
@@ -347,9 +374,23 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: write_dp(addr=%#010x, data=%#010x) -> error(%s)", addr, data, error)
             raise self._convert_exception(error) from error
 
-        return True
+    @overload
+    def read_ap(self, addr: int) -> int:
+        ...
 
-    def read_ap(self, addr, now=True):
+    @overload
+    def read_ap(self, addr: int, now: Literal[True] = True) -> int:
+        ...
+
+    @overload
+    def read_ap(self, addr: int, now: Literal[False]) -> Callable[[], int]:
+        ...
+
+    @overload
+    def read_ap(self, addr: int, now: bool) -> Union[int, Callable[[], int]]:
+        ...
+
+    def read_ap(self, addr: int, now: bool = True) -> Union[int, Callable[[], int]]:
         assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
@@ -376,7 +417,7 @@ class CMSISDAPProbe(DebugProbe):
         else:
             return read_ap_result_callback
 
-    def write_ap(self, addr, data):
+    def write_ap(self, addr: int, data) -> None:
         assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
@@ -388,9 +429,24 @@ class CMSISDAPProbe(DebugProbe):
             TRACE.debug("trace: write_ap(addr=%#010x, data=%#010x) -> error(%s)", addr, data, error)
             raise self._convert_exception(error) from error
 
-        return True
+    @overload
+    def read_ap_multiple(self, addr: int, count: int = 1) -> Sequence[int]:
+        ...
 
-    def read_ap_multiple(self, addr, count=1, now=True):
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: Literal[True] = True) -> Sequence[int]:
+        ...
+
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: Literal[False]) -> Callable[[], Sequence[int]]:
+        ...
+
+    @overload
+    def read_ap_multiple(self, addr: int, count: int, now: bool) -> Union[Sequence[int], Callable[[], Sequence[int]]]:
+        ...
+
+    def read_ap_multiple(self, addr: int, count: int = 1, now: bool = True) \
+             -> Union[Sequence[int], Callable[[], Sequence[int]]]:
         assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
@@ -420,7 +476,7 @@ class CMSISDAPProbe(DebugProbe):
         else:
             return read_ap_repeat_callback
 
-    def write_ap_multiple(self, addr, values):
+    def write_ap_multiple(self, addr: int, values) -> None:
         assert isinstance(addr, int)
         ap_reg = self.REG_ADDR_TO_ID_MAP[self.AP, (addr & self.A32)]
 
@@ -437,7 +493,7 @@ class CMSISDAPProbe(DebugProbe):
     #          SWO functions
     # ------------------------------------------- #
 
-    def swo_start(self, baudrate):
+    def swo_start(self, baudrate: float) -> None:
         TRACE.debug("trace: swo_start(baud=%i)", baudrate)
 
         try:
@@ -446,7 +502,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def swo_stop(self):
+    def swo_stop(self) -> None:
         TRACE.debug("trace: swo_stop")
 
         try:
@@ -454,7 +510,7 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 
-    def swo_read(self):
+    def swo_read(self) -> bytearray:
         try:
             data = self._link.swo_read()
             TRACE.debug("trace: swo_read -> %i bytes", len(data))
@@ -463,7 +519,7 @@ class CMSISDAPProbe(DebugProbe):
             raise self._convert_exception(exc) from exc
 
     @staticmethod
-    def _convert_exception(exc):
+    def _convert_exception(exc: Exception) -> Exception:
         if isinstance(exc, DAPAccess.TransferFaultError):
             return exceptions.TransferFaultError(*exc.args)
         elif isinstance(exc, DAPAccess.TransferTimeoutError):

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -16,7 +16,7 @@
 
 
 from enum import Enum
-
+from typing import (Tuple, Sequence)
 
 class DAPAccessIntf(object):
 
@@ -188,7 +188,7 @@ class DAPAccessIntf(object):
         """
         raise NotImplementedError()
 
-    def swd_sequence(self, sequences):
+    def swd_sequence(self, sequences) -> Tuple[int, Sequence[bytes]]:
         """! @brief Send a sequences of bits on the SWDIO signal.
 
         This method sends the DAP_SWD_Sequence CMSIS-DAP command.
@@ -205,6 +205,7 @@ class DAPAccessIntf(object):
         @return A 2-tuple of the response status, and a sequence of bytes objects, one for each input
             sequence. The length of the bytes object is (<TCK-count> + 7) / 8. Bits are in LSB first order.
         """
+        raise NotImplementedError()
 
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):
         """! @brief Send JTAG sequence.

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -839,7 +839,7 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
     @locked
     def swd_sequence(self, sequences):
         self.flush()
-        self._protocol.swd_sequence(sequences)
+        return self._protocol.swd_sequence(sequences)
 
     @locked
     def jtag_sequence(self, cycles, tms, read_tdo, tdi):

--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -19,7 +19,10 @@
 import usb.util
 from hashlib import sha1
 from base64 import b32encode
-from typing import (List, Union)
+from typing import (List, Tuple, Union, TYPE_CHECKING)
+
+if TYPE_CHECKING:
+    from usb.core import Interface
 
 # USB class codes.
 USB_CLASS_COMPOSITE = 0x00
@@ -35,21 +38,23 @@ CMSIS_DAP_USB_CLASSES = [
 
 CMSIS_DAP_HID_USAGE_PAGE = 0xff00
 
+VidPidPair = Tuple[int, int]
+
 # Known USB VID/PID pairs.
-ARM_DAPLINK_ID = (0x0d28, 0x0204) # Arm DAPLink firmware
-ATMEL_ICE_ID = (0x03eb, 0x2141) # Atmel-ICE
-CYPRESS_KITPROG1_2_ID = (0x04b4, 0xf138) # Cypress KitProg1, KitProg2 in CMSIS-DAP mode
-CYPRESS_MINIPROG4_BULK_ID = (0x04b4, 0xf151) # Cypress MiniProg4 bulk
-CYPRESS_MINIPROG4_HID_ID = (0x04b4, 0xf152) # Cypress MiniProg4 HID
-CYPRESS_KITPROG3_HID_ID = (0x04b4, 0xf154) # Cypress KitProg3 HID
-CYPRESS_KITPROG3_BULKD_ID = (0x04b4, 0xf155) # Cypress KitProg3 bulk
-CYPRESS_KITPROG3_BULK_2_UART_ID = (0x04b4, 0xf166) # Cypress KitProg3 bulk with 2x UART
-KEIL_ULINKPLUS_ID = (0xc251, 0x2750) # Keil ULINKplus
-NXP_LPCLINK2_ID = (0x1fc9, 0x0090) # NXP LPC-LinkII
-NXP_MCULINK_ID = (0x1fc9, 0x0143) # NXP MCU-Link
+ARM_DAPLINK_ID: VidPidPair = (0x0d28, 0x0204) # Arm DAPLink firmware
+ATMEL_ICE_ID: VidPidPair = (0x03eb, 0x2141) # Atmel-ICE
+CYPRESS_KITPROG1_2_ID: VidPidPair = (0x04b4, 0xf138) # Cypress KitProg1, KitProg2 in CMSIS-DAP mode
+CYPRESS_MINIPROG4_BULK_ID: VidPidPair = (0x04b4, 0xf151) # Cypress MiniProg4 bulk
+CYPRESS_MINIPROG4_HID_ID: VidPidPair = (0x04b4, 0xf152) # Cypress MiniProg4 HID
+CYPRESS_KITPROG3_HID_ID: VidPidPair = (0x04b4, 0xf154) # Cypress KitProg3 HID
+CYPRESS_KITPROG3_BULKD_ID: VidPidPair = (0x04b4, 0xf155) # Cypress KitProg3 bulk
+CYPRESS_KITPROG3_BULK_2_UART_ID: VidPidPair = (0x04b4, 0xf166) # Cypress KitProg3 bulk with 2x UART
+KEIL_ULINKPLUS_ID: VidPidPair = (0xc251, 0x2750) # Keil ULINKplus
+NXP_LPCLINK2_ID: VidPidPair = (0x1fc9, 0x0090) # NXP LPC-LinkII
+NXP_MCULINK_ID: VidPidPair = (0x1fc9, 0x0143) # NXP MCU-Link
 
 ## List of VID/PID pairs for known CMSIS-DAP USB devices.
-KNOWN_CMSIS_DAP_IDS = [
+KNOWN_CMSIS_DAP_IDS: List[VidPidPair] = [
     ARM_DAPLINK_ID,
     ATMEL_ICE_ID,
     CYPRESS_KITPROG1_2_ID,
@@ -65,17 +70,17 @@ KNOWN_CMSIS_DAP_IDS = [
 
 ## List of VID/PID pairs for CMSIS-DAP probes that have multiple HID interfaces that must be
 # filtered by usage page. Currently these are only NXP probes.
-CMSIS_DAP_IDS_TO_FILTER_BY_USAGE_PAGE = [
+CMSIS_DAP_IDS_TO_FILTER_BY_USAGE_PAGE: List[VidPidPair] = [
     NXP_LPCLINK2_ID,
     NXP_MCULINK_ID,
     ]
 
-def is_known_cmsis_dap_vid_pid(vid, pid):
-    """! @brief Test whether a VID/PID pair belong to a known CMSIS-DAP device."""
+def is_known_cmsis_dap_vid_pid(vid: int, pid: int) -> bool:
+    """@brief Test whether a VID/PID pair belong to a known CMSIS-DAP device."""
     return (vid, pid) in KNOWN_CMSIS_DAP_IDS
 
-def filter_device_by_class(vid, pid, device_class):
-    """! @brief Test whether the device should be ignored by comparing bDeviceClass.
+def filter_device_by_class(vid: int, pid: int, device_class: int) -> bool:
+    """@brief Test whether the device should be ignored by comparing bDeviceClass.
 
     This function checks the device's bDeviceClass to determine whether it is likely to be
     a CMSIS-DAP device. It uses the vid and pid for device-specific quirks.
@@ -92,8 +97,8 @@ def filter_device_by_class(vid, pid, device_class):
     # Any other class indicates the device is not CMSIS-DAP.
     return True
 
-def filter_device_by_usage_page(vid, pid, usage_page):
-    """! @brief Test whether the device should be ignored by comparing the HID usage page.
+def filter_device_by_usage_page(vid: int, pid: int, usage_page: int) -> bool:
+    """@brief Test whether the device should be ignored by comparing the HID usage page.
 
     This function performs device-specific tests to determine whether the device is a CMSIS-DAP
     interface. The only current test is for the NXP LPC-Link2, which has extra HID interfaces with
@@ -106,14 +111,14 @@ def filter_device_by_usage_page(vid, pid, usage_page):
     return ((vid, pid) in CMSIS_DAP_IDS_TO_FILTER_BY_USAGE_PAGE) \
         and (usage_page != CMSIS_DAP_HID_USAGE_PAGE)
 
-def check_ep(interface, ep_index, ep_dir, ep_type):
-    """! @brief Tests an endpoint type and direction."""
+def check_ep(interface: "Interface", ep_index: int, ep_dir: int, ep_type: int) -> bool:
+    """@brief Tests an endpoint type and direction."""
     ep = interface[ep_index]
-    return (usb.util.endpoint_direction(ep.bEndpointAddress) == ep_dir) \
-        and (usb.util.endpoint_type(ep.bmAttributes) == ep_type)
+    return ((usb.util.endpoint_direction(ep.bEndpointAddress) == ep_dir) # type:ignore
+        and (usb.util.endpoint_type(ep.bmAttributes) == ep_type)) # type:ignore
 
 def generate_device_unique_id(vid: int, pid: int, *locations: List[Union[int, str]]) -> str:
-    """! @brief Generate a semi-stable unique ID from USB device properties.
+    """@brief Generate a semi-stable unique ID from USB device properties.
 
     This function is intended to be used in cases where a device does not provide a serial number
     string. pyocd still needs a valid unique ID so the device can be selected from amongst multiple

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -46,8 +46,7 @@ _IS_DARWIN = (platform.system() == 'Darwin')
 _IS_WINDOWS = (platform.system() == 'Windows')
 
 class HidApiUSB(Interface):
-    """! @brief CMSIS-DAP USB interface class using hidapi backend.
-    """
+    """@brief CMSIS-DAP USB interface class using hidapi backend."""
 
     isAvailable = IS_AVAILABLE
 
@@ -105,7 +104,7 @@ class HidApiUSB(Interface):
 
     @staticmethod
     def get_all_connected_interfaces():
-        """! @brief Returns all the connected devices with CMSIS-DAP in the name.
+        """@brief Returns all the connected devices with CMSIS-DAP in the name.
 
         returns an array of HidApiUSB (Interface) objects
         """
@@ -152,8 +151,7 @@ class HidApiUSB(Interface):
         return boards
 
     def write(self, data):
-        """! @brief Write data on the OUT endpoint associated to the HID interface
-        """
+        """@brief Write data on the OUT endpoint associated to the HID interface"""
         if TRACE.isEnabledFor(logging.DEBUG):
             TRACE.debug("  USB OUT> (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
         data.extend([0] * (self.packet_size - len(data)))
@@ -162,8 +160,7 @@ class HidApiUSB(Interface):
         self.device.write([0] + data)
 
     def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
-        """! @brief Read data on the IN endpoint associated to the HID interface
-        """
+        """@brief Read data on the IN endpoint associated to the HID interface"""
         # Windows doesn't use the read thread, so read directly.
         if _IS_WINDOWS:
             read_data = self.device.read(self.packet_size)
@@ -194,10 +191,8 @@ class HidApiUSB(Interface):
 
         return self.received_data.popleft()
 
-
     def close(self):
-        """! @brief Close the interface
-        """
+        """@brief Close the interface"""
         assert not self.closed_event.is_set()
 
         LOG.debug("closing interface")

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,11 @@
 # limitations under the License.
 
 
-class Interface(object):
+class Interface:
+
+    @staticmethod
+    def get_all_connected_interfaces():
+        raise NotImplementedError()
 
     DEFAULT_READ_TIMEOUT = 20
 
@@ -38,16 +43,19 @@ class Interface(object):
         return False
 
     def open(self):
-        return
+        raise NotImplementedError()
 
     def close(self):
-        return
+        raise NotImplementedError()
 
     def write(self, data):
-        return
+        raise NotImplementedError()
 
     def read(self, timeout=DEFAULT_READ_TIMEOUT):
-        return
+        raise NotImplementedError()
+
+    def read_swo(self):
+        raise NotImplementedError()
 
     def get_info(self):
         return self.vendor_name + " " + \

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2006-2021 Arm Limited
 # Copyright (c) 2020 Patrick Huesmann
 # Copyright (c) 2021 mentha
-# Copyright (c) Chris Reed
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -46,15 +46,14 @@ else:
     IS_AVAILABLE = True
 
 class PyUSB(Interface):
-    """! @brief CMSIS-DAP USB interface class using pyusb for the backend.
-    """
+    """@brief CMSIS-DAP USB interface class using pyusb for the backend."""
 
     isAvailable = IS_AVAILABLE
 
     did_show_no_libusb_warning = False
 
     def __init__(self):
-        super(PyUSB, self).__init__()
+        super().__init__()
         self.ep_out = None
         self.ep_in = None
         self.dev = None
@@ -156,7 +155,7 @@ class PyUSB(Interface):
 
     @staticmethod
     def get_all_connected_interfaces():
-        """! @brief Returns all the connected CMSIS-DAP devices.
+        """@brief Returns all the connected CMSIS-DAP devices.
 
         returns an array of PyUSB (Interface) objects
         """
@@ -184,8 +183,7 @@ class PyUSB(Interface):
         return boards
 
     def write(self, data):
-        """! @brief Write data on the OUT endpoint associated to the HID interface
-        """
+        """@brief Write data on the OUT endpoint associated to the HID interface"""
 
         report_size = self.packet_size
         if self.ep_out:
@@ -211,8 +209,7 @@ class PyUSB(Interface):
         self.ep_out.write(data)
 
     def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
-        """! @brief Read data on the IN endpoint associated to the HID interface
-        """
+        """@brief Read data on the IN endpoint associated to the HID interface"""
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
         with Timeout(timeout, sleeptime=0.0001) as t_o:
             while t_o.check():
@@ -234,8 +231,7 @@ class PyUSB(Interface):
         return self.rcv_data.pop(0)
 
     def close(self):
-        """! @brief Close the interface
-        """
+        """@brief Close the interface"""
         assert self.closed is False
 
         LOG.debug("closing interface")
@@ -259,8 +255,8 @@ class PyUSB(Interface):
         self.kernel_driver_was_attached = False
         self.thread = None
 
-class MatchCmsisDapv1Interface(object):
-    """! @brief Match class for finding CMSIS-DAPv1 interface.
+class MatchCmsisDapv1Interface:
+    """@brief Match class for finding CMSIS-DAPv1 interface.
 
     This match class performs several tests on the provided USB interface descriptor, to
     determine whether it is a CMSIS-DAPv1 interface. These requirements must be met by the
@@ -274,11 +270,11 @@ class MatchCmsisDapv1Interface(object):
     """
 
     def __init__(self, hid_interface_count):
-        """! @brief Constructor."""
+        """@brief Constructor."""
         self._hid_count = hid_interface_count
 
     def __call__(self, interface):
-        """! @brief Return True if this is a CMSIS-DAPv1 interface."""
+        """@brief Return True if this is a CMSIS-DAPv1 interface."""
         try:
             if self._hid_count > 1:
                 interface_name = usb.util.get_string(interface.device, interface.iInterface)
@@ -327,15 +323,15 @@ class MatchCmsisDapv1Interface(object):
             # IndexError can be raised if an endpoint is missing.
             return False
 
-class FindDap(object):
-    """! @brief CMSIS-DAP match class to be used with usb.core.find"""
+class FindDap:
+    """@brief CMSIS-DAP match class to be used with usb.core.find"""
 
     def __init__(self, serial=None):
-        """! @brief Create a new FindDap object with an optional serial number"""
+        """@brief Create a new FindDap object with an optional serial number"""
         self._serial = serial
 
     def __call__(self, dev):
-        """! @brief Return True if this is a DAP device, False otherwise"""
+        """@brief Return True if this is a DAP device, False otherwise"""
         # Check if the device class is a valid one for CMSIS-DAP.
         if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -1,7 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2019-2021 Arm Limited
 # Copyright (c) 2021 mentha
-# Copyright (c) Chris Reed
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,14 +47,12 @@ else:
     IS_AVAILABLE = True
 
 class PyUSBv2(Interface):
-    """!
-    @brief CMSIS-DAPv2 interface using pyUSB.
-    """
+    """@brief CMSIS-DAPv2 interface using pyUSB."""
 
     isAvailable = IS_AVAILABLE
 
     def __init__(self):
-        super(PyUSBv2, self).__init__()
+        super().__init__()
         self.ep_out = None
         self.ep_in = None
         self.ep_swo = None
@@ -186,7 +184,7 @@ class PyUSBv2(Interface):
 
     @staticmethod
     def get_all_connected_interfaces():
-        """! @brief Returns all the connected devices with a CMSIS-DAPv2 interface."""
+        """@brief Returns all the connected devices with a CMSIS-DAPv2 interface."""
         # find all cmsis-dap devices
         try:
             all_devices = libusb_package.find(find_all=True, custom_match=HasCmsisDapv2Interface())
@@ -209,7 +207,7 @@ class PyUSBv2(Interface):
         return boards
 
     def write(self, data):
-        """! @brief Write data on the OUT endpoint."""
+        """@brief Write data on the OUT endpoint."""
 
         if self.ep_out:
             if (len(data) > 0) and (len(data) < self.packet_size) and (len(data) % self.ep_out.wMaxPacketSize == 0):
@@ -223,7 +221,7 @@ class PyUSBv2(Interface):
         self.ep_out.write(data)
 
     def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
-        """! @brief Read data on the IN endpoint."""
+        """@brief Read data on the IN endpoint."""
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
         with Timeout(timeout, sleeptime=0.0001) as t_o:
             while t_o.check():
@@ -252,7 +250,7 @@ class PyUSBv2(Interface):
         return data
 
     def close(self):
-        """! @brief Close the USB interface."""
+        """@brief Close the USB interface."""
         assert self.closed is False
 
         if self.is_swo_running:
@@ -274,7 +272,7 @@ class PyUSBv2(Interface):
         self.thread = None
 
 def _match_cmsis_dap_v2_interface(interface):
-    """! @brief Returns true for a CMSIS-DAP v2 interface.
+    """@brief Returns true for a CMSIS-DAP v2 interface.
 
     This match function performs several tests on the provided USB interface descriptor, to
     determine whether it is a CMSIS-DAPv2 interface. These requirements must be met by the
@@ -326,15 +324,15 @@ def _match_cmsis_dap_v2_interface(interface):
         # IndexError can be raised if an endpoint is missing.
         return False
 
-class HasCmsisDapv2Interface(object):
-    """! @brief CMSIS-DAPv2 match class to be used with usb.core.find"""
+class HasCmsisDapv2Interface:
+    """@brief CMSIS-DAPv2 match class to be used with usb.core.find"""
 
     def __init__(self, serial=None):
-        """! @brief Create a new FindDap object with an optional serial number"""
+        """@brief Create a new FindDap object with an optional serial number"""
         self._serial = serial
 
     def __call__(self, dev):
-        """! @brief Return True if this is a CMSIS-DAPv2 device, False otherwise"""
+        """@brief Return True if this is a CMSIS-DAPv2 device, False otherwise"""
         # Check if the device class is a valid one for CMSIS-DAP.
         if filter_device_by_class(dev.idVendor, dev.idProduct, dev.bDeviceClass):
             return False

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -40,13 +40,12 @@ else:
     IS_AVAILABLE = True
 
 class PyWinUSB(Interface):
-    """! @brief CMSIS-DAP USB interface class using pyWinUSB for the backend.
-    """
+    """@brief CMSIS-DAP USB interface class using pyWinUSB for the backend."""
 
     isAvailable = IS_AVAILABLE
 
     def __init__(self):
-        super(PyWinUSB, self).__init__()
+        super().__init__()
         # Vendor page and usage_id = 2
         self.report = None
         # deque used here instead of synchronized Queue
@@ -98,8 +97,7 @@ class PyWinUSB(Interface):
 
     @staticmethod
     def get_all_connected_interfaces():
-        """! @brief Returns all the connected CMSIS-DAP devices
-        """
+        """@brief Returns all the connected CMSIS-DAP devices"""
         all_devices = hid.find_all_hid_devices()
 
         # find devices with good vid/pid
@@ -142,8 +140,7 @@ class PyWinUSB(Interface):
         return boards
 
     def write(self, data):
-        """! @brief Write data on the OUT endpoint associated to the HID interface
-        """
+        """@brief Write data on the OUT endpoint associated to the HID interface"""
         if TRACE.isEnabledFor(logging.DEBUG):
             TRACE.debug("  USB OUT> (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
 
@@ -151,8 +148,7 @@ class PyWinUSB(Interface):
         self.report.send([0] + data)
 
     def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
-        """! @brief Read data on the IN endpoint associated to the HID interface
-        """
+        """@brief Read data on the IN endpoint associated to the HID interface"""
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
         with Timeout(timeout, sleeptime=0.0001) as t_o:
             while t_o.check():
@@ -177,7 +173,6 @@ class PyWinUSB(Interface):
         return self.rcv_data.popleft()
 
     def close(self):
-        """! @brief Close the interface
-        """
+        """@brief Close the interface"""
         LOG.debug("closing interface")
         self.device.close()

--- a/pyocd/probe/stlink/detect/base.py
+++ b/pyocd/probe/stlink/detect/base.py
@@ -20,12 +20,10 @@ from io import open
 from os import listdir
 from os.path import join, exists, isdir
 import logging
-import six
 
 LOG = logging.getLogger(__name__)
 
-@six.add_metaclass(ABCMeta)
-class StlinkDetectBase(object):
+class StlinkDetectBase(object, metaclass=ABCMeta):
     """ Base class for stlink detection, defines public interface for
     mbed-enabled stlink devices detection for various hosts
     """

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -279,7 +279,7 @@ class STLink(object):
             response = self._device.transfer(cmd, readSize=52)
             self._check_status(response[0:2])
 
-            freqs = conversion.byte_list_to_u32le_list(response[4:52])
+            freqs = list(conversion.byte_list_to_u32le_list(response[4:52]))
             currentFreq = freqs.pop(0)
             freqCount = freqs.pop(0)
             return currentFreq, freqs[:freqCount]

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -17,7 +17,6 @@
 
 import logging
 import struct
-import six
 import threading
 from enum import Enum
 from typing import Optional
@@ -363,7 +362,7 @@ class STLink(object):
                 thisTransferSize = min(size, max)
 
                 cmd = [Commands.JTAG_COMMAND, memcmd]
-                cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
+                cmd.extend(struct.pack('<IHB', addr, thisTransferSize, apsel))
                 result += self._device.transfer(cmd, readSize=thisTransferSize)
 
                 addr += thisTransferSize
@@ -397,7 +396,7 @@ class STLink(object):
                 thisTransferData = data[:thisTransferSize]
 
                 cmd = [Commands.JTAG_COMMAND, memcmd]
-                cmd.extend(six.iterbytes(struct.pack('<IHB', addr, thisTransferSize, apsel)))
+                cmd.extend(struct.pack('<IHB', addr, thisTransferSize, apsel))
                 self._device.transfer(cmd, writeData=thisTransferData)
 
                 addr += thisTransferSize
@@ -471,7 +470,7 @@ class STLink(object):
 
         with self._lock:
             cmd = [Commands.JTAG_COMMAND, Commands.JTAG_READ_DAP_REG]
-            cmd.extend(six.iterbytes(struct.pack('<HH', port, addr)))
+            cmd.extend(struct.pack('<HH', port, addr))
             response = self._device.transfer(cmd, readSize=8)
             self._check_status(response[:2])
             value, = struct.unpack('<I', response[4:8])
@@ -484,7 +483,7 @@ class STLink(object):
 
         with self._lock:
             cmd = [Commands.JTAG_COMMAND, Commands.JTAG_WRITE_DAP_REG]
-            cmd.extend(six.iterbytes(struct.pack('<HHI', port, addr, value)))
+            cmd.extend(struct.pack('<HHI', port, addr, value))
             response = self._device.transfer(cmd, readSize=2)
             self._check_status(response)
 
@@ -492,7 +491,7 @@ class STLink(object):
         with self._lock:
             bufferSize = 4096
             cmd = [Commands.JTAG_COMMAND, Commands.SWV_START_TRACE_RECEPTION]
-            cmd.extend(six.iterbytes(struct.pack('<HI', bufferSize, baudrate)))
+            cmd.extend(struct.pack('<HI', bufferSize, baudrate))
             response = self._device.transfer(cmd, readSize=2)
             self._check_status(response)
 

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -17,7 +17,7 @@
 import argparse
 import logging
 import prettytable
-from typing import (List, Optional)
+from typing import (List, Optional, Type)
 
 from ..utility.cmdline import convert_frequency
 
@@ -29,7 +29,7 @@ class SubcommandBase:
     HELP: str = ""
     EPILOG: Optional[str] = None
     DEFAULT_LOG_LEVEL = logging.INFO
-    SUBCOMMANDS: List["SubcommandBase"] = []
+    SUBCOMMANDS: List[Type["SubcommandBase"]] = []
 
     ## Class attribute to store the built subcommand argument parser.
     parser: Optional[argparse.ArgumentParser] = None

--- a/pyocd/target/family/__init__.py
+++ b/pyocd/target/family/__init__.py
@@ -16,15 +16,18 @@
 # limitations under the License.
 
 import re
-from collections import namedtuple
+from typing import (Any, NamedTuple, Pattern)
 
 from . import target_imxrt
 from . import target_kinetis
 from . import target_lpc5500
 from . import target_nRF52
 
-## @brief Container for family matching information.
-FamilyInfo = namedtuple("FamilyInfo", "vendor matches klass")
+class FamilyInfo(NamedTuple):
+    """@brief Container for family matching information."""
+    vendor: str
+    matches: Pattern[str]
+    klass: Any
 
 ## @brief Lookup table to convert from CMSIS-Pack family names to a family class.
 #

--- a/pyocd/target/family/target_imxrt.py
+++ b/pyocd/target/family/target_imxrt.py
@@ -28,7 +28,7 @@ class IMXRT(CoreSightTarget):
     VENDOR = "NXP"
 
     def create_init_sequence(self):
-        seq = super(IMXRT, self).create_init_sequence()
+        seq = super().create_init_sequence()
         seq.wrap_task('discovery',
             lambda seq: seq.replace_task('create_cores', self.create_cores)
             )
@@ -63,7 +63,7 @@ class CortexM7_IMXRT(CortexM):
     }
 
     def __init__(self, *args, **kwargs):
-        super(CortexM7_IMXRT, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.get_boot_mode()
 
     def get_boot_mode(self):
@@ -134,11 +134,11 @@ class CortexM7_IMXRT(CortexM):
         # normal reset catch
         LOG.debug("normal_set_reset_catch")
         self.did_normal_reset_catch = True
-        super(CortexM7_IMXRT, self).set_reset_catch()
+        super().set_reset_catch(reset_type)
 
     def clear_reset_catch(self, reset_type=None):
         if self.did_normal_reset_catch:
-            super(CortexM7_IMXRT, self).clear_reset_catch()
+            super().clear_reset_catch(reset_type)
         else:
             # Disable Reset Vector Catch in DEMCR
             value = self.read_memory(CortexM.DEMCR)

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -22,7 +22,7 @@ from xml.etree.ElementTree import (ElementTree, Element)
 import zipfile
 import logging
 import io
-from typing import (Any, Dict, Iterator, Optional)
+from typing import (Any, Callable, Dict, List, IO, Iterator, Optional, Tuple, TypeVar, Union)
 
 from .flash_algo import PackFlashAlgo
 from ...core import exceptions
@@ -35,14 +35,14 @@ class MalformedCmsisPackError(exceptions.TargetSupportError):
     """! @brief Exception raised for errors parsing a CMSIS-Pack."""
     pass
 
-class _DeviceInfo(object):
+class _DeviceInfo:
     """! @brief Simple container class to hold XML elements describing a device."""
-    def __init__(self, **kwargs):
-        self.element = kwargs.get('element', None)
-        self.families = kwargs.get('families', [])
-        self.memories = kwargs.get('memories', [])
-        self.algos = kwargs.get('algos', [])
-        self.debugs = kwargs.get('debugs', [])
+    def __init__(self, element: Element, **kwargs):
+        self.element: Element = element
+        self.families: List[str] = kwargs.get('families', [])
+        self.memories: List[Element] = kwargs.get('memories', [])
+        self.algos: List[Element] = kwargs.get('algos', [])
+        self.debugs: List[Element] = kwargs.get('debugs', [])
 
 def _get_part_number_from_element(element: Element) -> str:
     """! @brief Extract the part number from a device or variant XML element."""
@@ -54,7 +54,7 @@ def _get_part_number_from_element(element: Element) -> str:
     else:
         raise ValueError("element is neither device nor variant")
 
-class CmsisPack(object):
+class CmsisPack:
     """! @brief Wraps a CMSIS Device Family Pack.
 
     This class provides a top-level interface for extracting device information from CMSIS-Packs.
@@ -71,7 +71,7 @@ class CmsisPack(object):
     defined device and passes those to CmsisPackDevice. It is then CmsisPackDevice that performs
     the parsing of each element type into pyOCD-compatible data.
     """
-    def __init__(self, file_or_path):
+    def __init__(self, file_or_path: Union[str, zipfile.ZipFile, IO[bytes]]) -> None:
         """! @brief Constructor.
 
         Opens the CMSIS-Pack and builds instances of CmsisPackDevice for all the devices
@@ -104,21 +104,21 @@ class CmsisPack(object):
             self._pdsc = CmsisPackDescription(self, pdscFile)
 
     @property
-    def filename(self):
+    def filename(self) -> Optional[str]:
         """! @brief Accessor for the filename or path of the .pack file."""
         return self._pack_file.filename
 
     @property
-    def pdsc(self):
+    def pdsc(self) -> "CmsisPackDescription":
         """! @brief Accessor for the CmsisPackDescription instance for the pack's PDSC file."""
         return self._pdsc
 
     @property
-    def devices(self):
+    def devices(self) -> List["CmsisPackDevice"]:
         """! @brief A list of CmsisPackDevice objects for every part number defined in the pack."""
         return self._pdsc.devices
 
-    def get_file(self, filename):
+    def get_file(self, filename) -> IO[bytes]:
         """! @brief Return file-like object for a file within the pack.
 
         @param self
@@ -130,8 +130,11 @@ class CmsisPack(object):
         filename = filename.replace('\\', '/')
         return io.BytesIO(self._pack_file.read(filename))
 
-class CmsisPackDescription(object):
-    def __init__(self, pack, pdsc_file):
+class CmsisPackDescription:
+    """@brief Parser for the PDSC XML file describing a CMSIS-Pack.
+    """
+
+    def __init__(self, pack: CmsisPack, pdsc_file: IO) -> None:
         """! @brief Constructor.
 
         @param self This object.
@@ -143,8 +146,8 @@ class CmsisPackDescription(object):
         # Convert PDSC into an ElementTree.
         self._pdsc = ElementTree(file=pdsc_file)
 
-        self._state_stack = []
-        self._devices = []
+        self._state_stack: List[_DeviceInfo] = []
+        self._devices: List["CmsisPackDevice"] = []
 
         # Remember if we have already warned about overlapping memory regions
         # so we can limit these to one warning per DFP
@@ -155,19 +158,19 @@ class CmsisPackDescription(object):
             self._parse_devices(family)
 
     @property
-    def pack(self):
+    def pack(self) -> CmsisPack:
         """! @brief Reference to the containing CmsisPack object."""
         return self._pack
 
     @property
-    def devices(self):
+    def devices(self) -> List["CmsisPackDevice"]:
         """! @brief A list of CmsisPackDevice objects for every part number defined in the pack."""
         return self._devices
 
-    def _parse_devices(self, parent):
+    def _parse_devices(self, parent: Element) -> None:
         # Extract device description elements we care about.
         newState = _DeviceInfo(element=parent)
-        children = []
+        children: List[Element] = []
         for elem in parent:
             if elem.tag == 'memory':
                 newState.memories.append(elem)
@@ -201,7 +204,8 @@ class CmsisPackDescription(object):
 
         self._state_stack.pop()
 
-    def _extract_families(self):
+    def _extract_families(self) -> List[str]:
+        """! @brief Generate list of family names for a device."""
         families = []
         for state in self._state_stack:
             elem = state.element
@@ -211,7 +215,24 @@ class CmsisPackDescription(object):
                 families += [elem.attrib['DsubFamily']]
         return families
 
-    def _extract_items(self, state_info_name, filter):
+    ## Typevar used for _extract_items().
+    V = TypeVar('V')
+
+    def _extract_items(self, state_info_name: str, filter: Callable[[Dict[Any, V], Element], None]) -> List[V]:
+        """! @brief Generic extractor utility.
+
+        Iterates over saved elements for the specified device state info for each level of the
+        device state stack, from outer to inner, calling the provided filter callback each
+        iteration. A dictionary object is created and repeatedly passed to the filter callback, so
+        state can be stored across calls to the filter.
+
+        The general idea is that the filter callback extracts some identifying information from the
+        element it is given and uses that as a key in the dictionary. When the filter is called for
+        more deeply nested elements, those elements will override the any previously examined
+        elements with the same identifier.
+
+        @return All values from the dictionary.
+        """
         map = {}
         for state in self._state_stack:
             for elem in getattr(state, state_info_name):
@@ -221,8 +242,16 @@ class CmsisPackDescription(object):
                     LOG.debug("error parsing CMSIS-Pack: " + str(err))
         return list(map.values())
 
-    def _extract_memories(self):
-        def get_start_and_size(elem):
+    def _extract_memories(self) -> List[Element]:
+        """! @brief Extract memory elements.
+
+        The unique identifier is a bi-tuple of the memory's name, which is either the 'name' or 'id' attribute,
+        in that order, plus the pname. If neither attribute exists, the region base and size are turned into
+        a string.
+
+        In addition to the name based filtering, memory regions are checked to prevent overlaps.
+        """
+        def get_start_and_size(elem: Element) -> Tuple[int, int]:
             try:
                 start = int(elem.attrib['start'], base=0)
                 size = int(elem.attrib['size'], base=0)
@@ -230,7 +259,8 @@ class CmsisPackDescription(object):
                 LOG.warning("memory region missing address")
                 raise
             return (start, size)
-        def filter(map, elem):
+
+        def filter(map: Dict, elem: Element) -> None:
             # Inner memory regions are allowed to override outer memory
             # regions. If this is not done properly via name/id, we must make
             # sure not to report overlapping memory regions to gdb since it
@@ -276,12 +306,19 @@ class CmsisPackDescription(object):
 
         return self._extract_items('memories', filter)
 
-    def _extract_algos(self):
-        def filter(map, elem):
+    def _extract_algos(self) -> List[Element]:
+        """! @brief Extract algorithm elements.
+
+        The unique identifier is the algorithm's memory address range.
+
+        Any algorithm elements with a 'style' attribuet not set to 'Keil' (case-insensitive) are
+        skipped.
+        """
+        def filter(map: Dict, elem: Element) -> None:
             # We only support Keil FLM style flash algorithms (for now).
-            if ('style' in elem.attrib) and (elem.attrib['style'] != 'Keil'):
+            if ('style' in elem.attrib) and (elem.attrib['style'].lower() != 'keil'):
                 LOG.debug("skipping non-Keil flash algorithm")
-                return None, None
+                return
 
             # Both start and size are required.
             start = int(elem.attrib['start'], base=0)
@@ -293,8 +330,17 @@ class CmsisPackDescription(object):
 
         return self._extract_items('algos', filter)
 
-    def _extract_debugs(self):
-        def filter(map, elem):
+    def _extract_debugs(self) -> List[Element]:
+        """! @brief Extract debug elements.
+
+        If the debug element does not have a 'Pname' element, its identifier is set to "*" to
+        represent that it applies to all processors.
+
+        Otherwise, the identifier is the element's 'Pname' attribute combined with 'Punit' if
+        present. When 'Pname' is detected and a "*" key is in the map, the map is cleared before
+        adding the current element.
+        """
+        def filter(map: Dict, elem: Element) -> None:
             if 'Pname' in elem.attrib:
                 name = elem.attrib['Pname']
                 unit = elem.attrib.get('Punit', 0)
@@ -311,7 +357,7 @@ class CmsisPackDescription(object):
 
         return self._extract_items('debugs', filter)
 
-def _get_bool_attribute(elem, name, default=False):
+def _get_bool_attribute(elem: Element, name: str, default: bool = False) -> bool:
     """! @brief Extract an XML attribute with a boolean value.
 
     Supports "true"/"false" or "1"/"0" as the attribute values. Leading and trailing whitespace
@@ -333,7 +379,7 @@ def _get_bool_attribute(elem, name, default=False):
         else:
             return default
 
-class CmsisPackDevice(object):
+class CmsisPackDevice:
     """! @brief Wraps a device defined in a CMSIS Device Family Pack.
 
     Responsible for converting the XML elements that describe the device into objects
@@ -343,21 +389,21 @@ class CmsisPackDevice(object):
     the PDSC.
     """
 
-    def __init__(self, pack, device_info):
+    def __init__(self, pack: CmsisPack, device_info: _DeviceInfo):
         """! @brief Constructor.
         @param self
         @param pack The CmsisPack object that contains this device.
         @param device_info A _DeviceInfo object with the XML elements that describe this device.
         """
-        self._pack = pack
-        self._info = device_info
-        self._part = _get_part_number_from_element(device_info.element)
-        self._regions = []
-        self._saw_startup = False
-        self._default_ram = None
-        self._memory_map = None
+        self._pack: CmsisPack = pack
+        self._info: _DeviceInfo = device_info
+        self._part: str = _get_part_number_from_element(device_info.element)
+        self._regions: List[MemoryRegion] = []
+        self._saw_startup: bool = False
+        self._default_ram: Optional[MemoryRegion] = None
+        self._memory_map: Optional[MemoryMap] = None
 
-    def _build_memory_regions(self):
+    def _build_memory_regions(self) -> None:
         """! @brief Creates memory region instances for the device.
 
         For each `<memory>` element in the device info, a memory region object is created and
@@ -428,7 +474,7 @@ class CmsisPackDevice(object):
                 return region
         return None
 
-    def _build_flash_regions(self):
+    def _build_flash_regions(self) -> None:
         """! @brief Converts ROM memory regions to flash regions.
 
         Each ROM region in the `_regions` attribute is converted to a flash region if a matching
@@ -454,8 +500,9 @@ class CmsisPackDevice(object):
                 continue
 
             # Look for matching flash algo.
-            algo_element = self._find_matching_algo(region)
-            if algo_element is None:
+            try:
+                algo_element = self._find_matching_algo(region)
+            except KeyError:
                 # Must be a mask ROM or non-programmable flash.
                 continue
 
@@ -577,7 +624,7 @@ class CmsisPackDevice(object):
                             is_testable=region.is_testable,
                             alias=region.alias)
 
-    def _find_matching_algo(self, region):
+    def _find_matching_algo(self, region: MemoryRegion) -> Element:
         """! @brief Searches for a flash algo covering the regions's address range.'"""
         for algo in self._info.algos:
             # Both start and size are required attributes.
@@ -588,7 +635,7 @@ class CmsisPackDevice(object):
             # Check if the region indicated by start..size fits within the algo.
             if (algoStart <= region.start <= algoEnd) and (algoStart <= region.end <= algoEnd):
                 return algo
-        return None
+        raise KeyError("no matching flash algorithm")
 
     def _load_flash_algo(self, filename: str) -> Optional[PackFlashAlgo]:
         """! @brief Return the PackFlashAlgo instance for the given flash algo filename."""
@@ -602,12 +649,12 @@ class CmsisPackDevice(object):
         return None
 
     @property
-    def pack(self):
+    def pack(self) -> CmsisPack:
         """! @brief The CmsisPack object that defines this device."""
         return self._pack
 
     @property
-    def part_number(self):
+    def part_number(self) -> str:
         """! @brief Part number for this device.
 
         This value comes from either the `Dname` or `Dvariant` attribute, depending on whether the
@@ -616,17 +663,17 @@ class CmsisPackDevice(object):
         return self._part
 
     @property
-    def vendor(self):
+    def vendor(self) -> str:
         """! @brief Vendor or manufacturer name."""
         return self._info.families[0].split(':')[0]
 
     @property
-    def families(self):
+    def families(self) -> List[str]:
         """! @brief List of families the device belongs to, ordered most generic to least."""
         return [f for f in self._info.families[1:]]
 
     @property
-    def memory_map(self):
+    def memory_map(self) -> MemoryMap:
         """! @brief MemoryMap object."""
         # Lazily construct the memory map.
         if self._memory_map is None:
@@ -642,7 +689,7 @@ class CmsisPackDevice(object):
         return self._memory_map
 
     @property
-    def svd(self):
+    def svd(self) -> Optional[IO[bytes]]:
         """! @brief File-like object for the device's SVD file.
         @todo Support multiple cores.
         """
@@ -653,7 +700,7 @@ class CmsisPackDevice(object):
             return None
 
     @property
-    def default_reset_type(self):
+    def default_reset_type(self) -> Target.ResetType:
         """! @brief One of the Target.ResetType enums.
         @todo Support multiple cores.
         """

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -17,12 +17,19 @@
 
 import logging
 import os
+from typing import (IO, TYPE_CHECKING, List, Optional, Tuple, Type, Union)
 
-from .cmsis_pack import (CmsisPack, MalformedCmsisPackError)
+from .cmsis_pack import (CmsisPack, CmsisPackDevice, MalformedCmsisPackError)
 from ..family import FAMILIES
 from .. import TARGET
 from ...coresight.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
+
+if TYPE_CHECKING:
+    from zipfile import ZipFile
+    from cmsis_pack_manager import CmsisPackRef
+    from ...core.session import Session
+    from ...utility.sequencer import CallSequence
 
 try:
     import cmsis_pack_manager
@@ -32,7 +39,20 @@ except ImportError:
 
 LOG = logging.getLogger(__name__)
 
-class ManagedPacks(object):
+class ManagedPacksStub:
+    @staticmethod
+    def get_installed_packs(cache: Optional[object] = None) -> List:
+        return []
+
+    @staticmethod
+    def get_installed_targets(cache: Optional[object] = None) -> List:
+        return []
+
+    @staticmethod
+    def populate_target(device_name: str) -> None:
+        pass
+
+class ManagedPacksImpl:
     """! @brief Namespace for managed CMSIS-Pack utilities.
 
     By managed, we mean managed by the cmsis-pack-manager package. All the methods on this class
@@ -41,10 +61,8 @@ class ManagedPacks(object):
     """
 
     @staticmethod
-    def get_installed_packs(cache=None):
+    def get_installed_packs(cache: Optional[cmsis_pack_manager.Cache] = None) -> List["CmsisPackRef"]: # type:ignore
         """! @brief Return a list containing CmsisPackRef objects for all installed packs."""
-        if not CPM_AVAILABLE:
-            return []
         if cache is None:
             cache = cmsis_pack_manager.Cache(True, True)
         results = []
@@ -59,10 +77,8 @@ class ManagedPacks(object):
         return results
 
     @staticmethod
-    def get_installed_targets(cache=None):
+    def get_installed_targets(cache: Optional[cmsis_pack_manager.Cache] = None) -> List[CmsisPackDevice]: # type:ignore
         """! @brief Return a list of CmsisPackDevice objects for installed pack targets."""
-        if not CPM_AVAILABLE:
-            return []
         if cache is None:
             cache = cmsis_pack_manager.Cache(True, True)
         results = []
@@ -73,7 +89,7 @@ class ManagedPacks(object):
         return sorted(results, key=lambda dev:dev.part_number)
 
     @staticmethod
-    def populate_target(device_name):
+    def populate_target(device_name: str) -> None:
         """! @brief Add targets from cmsis-pack-manager matching the given name.
 
         Targets are added to the `#TARGET` list. A case-insensitive comparison against the
@@ -86,11 +102,16 @@ class ManagedPacks(object):
             if device_name == dev.part_number.lower():
                 PackTargets.populate_device(dev)
 
-class _PackTargetMethods(object):
+if CPM_AVAILABLE:
+    ManagedPacks = ManagedPacksImpl
+else:
+    ManagedPacks = ManagedPacksStub
+
+class _PackTargetMethods:
     """! @brief Container for methods added to the dynamically generated pack target subclass."""
 
     @staticmethod
-    def _pack_target__init__(self, session):
+    def _pack_target__init__(self, session: "Session") -> None: # type:ignore
         """! @brief Constructor for dynamically created target class."""
         super(self.__class__, self).__init__(session, self._pack_device.memory_map)
 
@@ -101,7 +122,7 @@ class _PackTargetMethods(object):
         self._svd_location = SVDFile(filename=self._pack_device.svd)
 
     @staticmethod
-    def _pack_target_create_init_sequence(self):
+    def _pack_target_create_init_sequence(self) -> "CallSequence": # type:ignore
         """! @brief Creates an init task to set the default reset type."""
         seq = super(self.__class__, self).create_init_sequence()
         seq.wrap_task('discovery',
@@ -112,16 +133,16 @@ class _PackTargetMethods(object):
         return seq
 
     @staticmethod
-    def _pack_target_set_default_reset_type(self):
+    def _pack_target_set_default_reset_type(self) -> None: # type:ignore
         """! @brief Set's the first core's default reset type to the one specified in the pack."""
         if 0 in self.cores:
             self.cores[0].default_reset_type = self._pack_device.default_reset_type
 
-class PackTargets(object):
+class PackTargets:
     """! @brief Namespace for CMSIS-Pack target generation utilities. """
 
     @staticmethod
-    def _find_family_class(dev):
+    def _find_family_class(dev: CmsisPackDevice) -> Type[CoreSightTarget]:
         """! @brief Search the families list for matching entry."""
         for familyInfo in FAMILIES:
             # Skip if wrong vendor.
@@ -139,7 +160,7 @@ class PackTargets(object):
         return CoreSightTarget
 
     @staticmethod
-    def _generate_pack_target_class(dev):
+    def _generate_pack_target_class(dev: CmsisPackDevice) -> Optional[type]:
         """! @brief Generates a new target class from a CmsisPackDevice.
 
         @param dev A CmsisPackDevice object.
@@ -165,7 +186,7 @@ class PackTargets(object):
             return None
 
     @staticmethod
-    def populate_device(dev):
+    def populate_device(dev: CmsisPackDevice) -> None:
         """! @brief Generates and populates the target defined by a CmsisPackDevice.
 
         The new target class is added to the `#TARGET` list.
@@ -186,8 +207,10 @@ class PackTargets(object):
         except (MalformedCmsisPackError, FileNotFoundError) as err:
             LOG.warning(err)
 
+    PackReferenceType = Union[CmsisPack, str, "ZipFile", IO[bytes]]
+
     @staticmethod
-    def populate_targets_from_pack(pack_list):
+    def populate_targets_from_pack(pack_list: Union[PackReferenceType, List[PackReferenceType], Tuple[PackReferenceType]]) -> None:
         """! @brief Adds targets defined in the provided CMSIS-Pack.
 
         Targets are added to the `#TARGET` list.

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -27,6 +27,13 @@ from ..target.builtin import BUILTIN_TARGETS
 from ..board.board_ids import BOARD_ID_TO_INFO
 from ..target.pack import pack_target
 
+from ..probe.debug_probe import DebugProbe
+
+class StubProbe(DebugProbe):
+    @property
+    def unique_id(self) -> str:
+        return "0"
+
 class ListGenerator(object):
     @staticmethod
     def list_probes():
@@ -137,7 +144,9 @@ class ListGenerator(object):
             if name_filter and name_filter not in name.lower():
                 continue
 
-            s = Session(None) # Create empty session
+            # Create session with a stub probe that allows us to instantiate the target. This will create
+            # Board and Target instances of its own, so set some options to control that.
+            s = Session(StubProbe(), no_config=True, target_override='cortex_m')
             t = TARGET[name](s)
 
             # Filter by vendor.

--- a/pyocd/utility/autoflush.py
+++ b/pyocd/utility/autoflush.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,9 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import (Any, TYPE_CHECKING)
+
 from ..core import exceptions
 
-class Autoflush(object):
+if TYPE_CHECKING:
+    from ..core.target import Target
+    from types import TracebackType
+
+class Autoflush:
     """! @brief Context manager for performing flushes.
 
     Pass a Target instance to the constructor, and when the context exits, the target will be
@@ -27,7 +34,7 @@ class Autoflush(object):
     due to Python's dynamic dispatch.
     """
 
-    def __init__(self, target):
+    def __init__(self, target: "Target") -> None:
         """! @brief Constructor.
 
         @param self The object.
@@ -36,10 +43,11 @@ class Autoflush(object):
         """
         self._target = target
 
-    def __enter__(self):
+    def __enter__(self) -> "Autoflush":
         return self
 
-    def __exit__(self, type, value, traceback):
-        if type is None or not issubclass(type, exceptions.TransferError):
+    def __exit__(self, exc_type: type, value: Any, traceback: "TracebackType") -> bool:
+        if exc_type is None or not issubclass(exc_type, exceptions.TransferError):
             self._target.flush()
         return False
+    

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 import logging
-from typing import (Any, Dict, Iterable, List, Union)
+from typing import (Any, Dict, Iterable, List, Optional, Union)
 
 from ..core.target import Target
 from ..core.options import OPTIONS_INFO
@@ -186,7 +186,7 @@ def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
     return options
 
 ## Map to convert from reset type names to enums.
-RESET_TYPE_MAP = {
+RESET_TYPE_MAP: Dict[str, Optional[Target.ResetType]] = {
         'default': None,
         'hw': Target.ResetType.HW,
         'sw': Target.ResetType.SW,
@@ -200,7 +200,7 @@ RESET_TYPE_MAP = {
         'emulated': Target.ResetType.SW_EMULATED,
     }
 
-def convert_reset_type(value: str) -> Target.ResetType:
+def convert_reset_type(value: str) -> Optional[Target.ResetType]:
     """! @brief Convert a reset_type session option value to the Target.ResetType enum.
     @param value The value of the reset_type session option.
     @exception ValueError Raised if an unknown reset_type value is passed.

--- a/pyocd/utility/columns.py
+++ b/pyocd/utility/columns.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +18,11 @@
 import sys
 import logging
 from shutil import get_terminal_size
+from typing import (IO, Iterable, List, Optional, Tuple)
 
 LOG = logging.getLogger(__name__)
 
-class ColumnFormatter(object):
+class ColumnFormatter:
     """! @brief Formats a set of values in multiple columns.
 
     The value_list must be a list of bi-tuples (name, value) sorted in the desired display order.
@@ -29,7 +31,7 @@ class ColumnFormatter(object):
     will be printed in column major order.
     """
 
-    def __init__(self, maxwidth=None, inset=2):
+    def __init__(self, maxwidth: Optional[int] = None, inset: int = 2) -> None:
         """! @brief Constructor.
         @param self The object.
         @param maxwidth Number of characters to which the output width must be constrained. If not provided,
@@ -39,11 +41,11 @@ class ColumnFormatter(object):
         """
         self._inset = inset
         self._term_width = (maxwidth or get_terminal_size()[0]) - inset * 4
-        self._items = []
+        self._items: List[Tuple[str, str]] = []
         self._max_name_width = 0
         self._max_value_width = 0
 
-    def add_items(self, item_list):
+    def add_items(self, item_list: Iterable[Tuple[str, str]]) -> None:
         """! @brief Add items to the output.
         @param self The object.
         @param item_list Must be a list of bi-tuples (name, value) sorted in the desired display order.
@@ -55,7 +57,7 @@ class ColumnFormatter(object):
             self._max_name_width = max(self._max_name_width, len(name))
             self._max_value_width = max(self._max_value_width, len(value))
 
-    def format(self):
+    def format(self) -> str:
         """! @brief Return the formatted columns as a string.
         @param self The object.
         @return String containing the output of the column printer.
@@ -78,7 +80,7 @@ class ColumnFormatter(object):
             txt += "\n"
         return txt
 
-    def write(self, output_file=None):
+    def write(self, output_file: IO[str] = None) -> None:
         """! @brief Write the formatted columns to stdout or the specified file.
         @param self The object.
         @param output_file Optional file to which the column printer output will be written. If no specified,

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -15,14 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 from typing import Union
-
-# iter_single_bytes() returns an iterator over a bytes object that produces
-# single-byte bytes objects for each byte in the passed in value. Normally on
-# py3 iterating over a bytes will give you ints for each byte, while on py3
-# you'll get single-char strs.
-iter_single_bytes = functools.partial(map, lambda v: bytes((v,))) # pylint: disable=invalid-name
 
 # to_bytes_safe() converts a unicode string to a bytes object by encoding as
 # latin-1. It will also accept a value that is already a bytes object and

--- a/pyocd/utility/compatibility.py
+++ b/pyocd/utility/compatibility.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 import functools
+from typing import Union
 
 # iter_single_bytes() returns an iterator over a bytes object that produces
 # single-byte bytes objects for each byte in the passed in value. Normally on
@@ -26,8 +27,8 @@ iter_single_bytes = functools.partial(map, lambda v: bytes((v,))) # pylint: disa
 # to_bytes_safe() converts a unicode string to a bytes object by encoding as
 # latin-1. It will also accept a value that is already a bytes object and
 # return it unmodified.
-def to_bytes_safe(v):
-    if type(v) is str:
+def to_bytes_safe(v: Union[str, bytes]) -> bytes:
+    if isinstance(v, str):
         return v.encode('utf-8')
     else:
         return v
@@ -35,8 +36,8 @@ def to_bytes_safe(v):
 # to_str_safe() converts a bytes object to a unicode string by decoding from
 # latin-1. It will also accept a value that is already a str object and
 # return it unmodified.
-def to_str_safe(v):
-    if type(v) is str:
+def to_str_safe(v: Union[str, bytes]) -> str:
+    if isinstance(v, str):
         return v
     else:
         return v.decode('utf-8')

--- a/pyocd/utility/concurrency.py
+++ b/pyocd/utility/concurrency.py
@@ -15,14 +15,15 @@
 # limitations under the License.
 
 from functools import wraps
+from typing import (Any, Callable)
 
-def locked(func):
+def locked(func: Callable) -> Callable:
     """! @brief Decorator to automatically lock a method of a class.
 
     The class is required to have `lock()` and `unlock()` methods.
     """
     @wraps(func)
-    def _locking(self, *args, **kwargs):
+    def _locking(self, *args: Any, **kwargs: Any) -> Any:
         try:
             self.lock()
             return func(self, *args, **kwargs)

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -17,11 +17,14 @@
 
 import struct
 import binascii
+from typing import (Any, Iterator, Sequence, Tuple, cast)
 import six
 
 from .mask import align_up
 
-def byte_list_to_nbit_le_list(data, bitwidth, pad=0x00):
+ByteList = Sequence[int]
+
+def byte_list_to_nbit_le_list(data: ByteList, bitwidth: int, pad: int = 0x00) -> Sequence[int]:
     """! @brief Convert a list of bytes to a list of n-bit integers (little endian)
 
     If the length of the data list is not a multiple of `bitwidth` // 8, then the pad value is used
@@ -44,7 +47,7 @@ def byte_list_to_nbit_le_list(data, bitwidth, pad=0x00):
         res.append(sum((padded_data[i] << (i * 8)) for i in range(bytewidth)))
     return res
 
-def nbit_le_list_to_byte_list(data, bitwidth):
+def nbit_le_list_to_byte_list(data: Sequence[int], bitwidth: int) -> ByteList:
     """! @brief Convert a list of n-bit values into a byte list.
 
     @param data List of n-bit values.
@@ -53,7 +56,7 @@ def nbit_le_list_to_byte_list(data, bitwidth):
     """
     return [(x >> shift) & 0xff for x in data for shift in range(0, bitwidth, 8)]
 
-def byte_list_to_u32le_list(data, pad=0x00):
+def byte_list_to_u32le_list(data: ByteList, pad: int = 0x00) -> Sequence[int]:
     """! @brief Convert a list of bytes to a list of 32-bit integers (little endian)
 
     If the length of the data list is not a multiple of 4, then the pad value is used
@@ -71,7 +74,7 @@ def byte_list_to_u32le_list(data, pad=0x00):
         res += byte_list_to_u32le_list(list(data[-remainder:]) + [pad] * padCount)
     return res
 
-def u32le_list_to_byte_list(data):
+def u32le_list_to_byte_list(data: Sequence[int]) -> ByteList:
     """! @brief Convert a word array into a byte array"""
     res = []
     for x in data:
@@ -81,41 +84,41 @@ def u32le_list_to_byte_list(data):
         res.append((x >> 24) & 0xff)
     return res
 
-def u16le_list_to_byte_list(data):
+def u16le_list_to_byte_list(data: Sequence[int]) -> ByteList:
     """! @brief Convert a halfword array into a byte array"""
     byteData = []
     for h in data:
         byteData.extend([h & 0xff, (h >> 8) & 0xff])
     return byteData
 
-def byte_list_to_u16le_list(byteData):
+def byte_list_to_u16le_list(byteData: ByteList) -> Sequence[int]:
     """! @brief Convert a byte array into a halfword array"""
     data = []
     for i in range(0, len(byteData), 2):
         data.append(byteData[i] | (byteData[i + 1] << 8))
     return data
 
-def u32_to_float32(data):
+def u32_to_float32(data: int) -> float:
     """! @brief Convert a 32-bit int to an IEEE754 float"""
     d = struct.pack(">I", data & 0xffff_ffff)
     return struct.unpack(">f", d)[0]
 
-def float32_to_u32(data):
+def float32_to_u32(data: float) -> int:
     """! @brief Convert an IEEE754 float to a 32-bit int"""
     d = struct.pack(">f", data)
     return struct.unpack(">I", d)[0]
 
-def u64_to_float64(data):
+def u64_to_float64(data: int) -> float:
     """! @brief Convert a 64-bit int to an IEEE754 float"""
     d = struct.pack(">Q", data & 0xffff_ffff_ffff_ffff)
     return struct.unpack(">d", d)[0]
 
-def float64_to_u64(data):
+def float64_to_u64(data: float) -> int:
     """! @brief Convert an IEEE754 float to a 64-bit int"""
     d = struct.pack(">d", data)
     return struct.unpack(">Q", d)[0]
 
-def uint_to_hex_le(value, width):
+def uint_to_hex_le(value: int, width: int) -> str:
     """! @brief Create an n-digit hexadecimal string from an integer value.
     @param value Integer value to format.
     @param width The width in bits.
@@ -125,7 +128,7 @@ def uint_to_hex_le(value, width):
     """
     return ''.join("%02x" % ((value >> b) & 0xff) for b in range(0, align_up(width, 8), 8))
 
-def hex_le_to_uint(value, width):
+def hex_le_to_uint(value: str, width: int) -> int:
     """! @brief Create an an integer value from an n-digit hexadecimal string.
     @param value String consisting of pairs of hex digits with no intervening whitespace. Must have at least
         enough hex bytes to meet the desired width. The first hex byte is the LSB.
@@ -135,61 +138,61 @@ def hex_le_to_uint(value, width):
     """
     return sum((int(value[i:i+2], base=16) << (i * 4)) for i in range(0, align_up(width, 8) // 4, 2))
 
-def u32_to_hex8le(val):
+def u32_to_hex8le(val: int) -> str:
     """! @brief Create 8-digit hexadecimal string from 32-bit register value"""
     return uint_to_hex_le(val, 32)
 
-def u64_to_hex16le(val):
+def u64_to_hex16le(val: int) -> str:
     """! @brief Create 16-digit hexadecimal string from 64-bit register value"""
     return uint_to_hex_le(val, 64)
 
-def hex8_to_u32be(data):
+def hex8_to_u32be(data: str) -> int:
     """! @brief Build 32-bit register value from big-endian 8-digit hexadecimal string
     @note Endianness in this function name is backwards.
     """
     return hex_le_to_uint(data, 32)
 
-def hex16_to_u64be(data):
+def hex16_to_u64be(data: str) -> int:
     """! @brief Build 64-bit register value from big-endian 16-digit hexadecimal string
     @note Endianness in this function name is backwards.
     """
     return hex_le_to_uint(data, 64)
 
-def hex8_to_u32le(data):
+def hex8_to_u32le(data: str) -> int:
     """! @brief Build 32-bit register value from little-endian 8-digit hexadecimal string
     @note Endianness in this function name is backwards.
     """
     return int(data[0:8], 16)
 
-def hex16_to_u64le(data):
+def hex16_to_u64le(data: str) -> int:
     """! @brief Build 64-bit register value from little-endian 16-digit hexadecimal string
     @note Endianness in this function name is backwards.
     """
     return int(data[0:16], 16)
 
-def byte_to_hex2(val):
+def byte_to_hex2(val: int) -> str:
     """! @brief Create 2-digit hexadecimal string from 8-bit value"""
     return "%02x" % int(val)
 
-def hex_to_byte_list(data):
+def hex_to_byte_list(data: str) -> ByteList:
     """! @brief Convert string of hex bytes to list of integers"""
     return list(six.iterbytes(binascii.unhexlify(data)))
 
-def hex_decode(cmd):
+def hex_decode(cmd: str) -> bytes:
     """! @brief Return the binary data represented by the hexadecimal string."""
     return binascii.unhexlify(cmd)
 
-def hex_encode(string):
+def hex_encode(string: bytes) -> bytes:
     """! @brief Return the hexadecimal representation of the binary data."""
     return binascii.hexlify(string)
 
-def pairwise(iterable):
+def pairwise(iterable: Iterator[Any]) -> Iterator[Tuple[Any, Any]]:
     """! s -> (s0,s1), (s2,s3), (s3, s4), ..."""
     r = []
     for x in iterable:
         r.append(x)
         if len(r) == 2:
-            yield tuple(r)
+            yield cast(Tuple[Any, Any], tuple(r))
             r = []
     if len(r) > 0:
         yield (r[0], r[1])

--- a/pyocd/utility/conversion.py
+++ b/pyocd/utility/conversion.py
@@ -18,7 +18,6 @@
 import struct
 import binascii
 from typing import (Any, Iterator, Sequence, Tuple, cast)
-import six
 
 from .mask import align_up
 
@@ -176,7 +175,7 @@ def byte_to_hex2(val: int) -> str:
 
 def hex_to_byte_list(data: str) -> ByteList:
     """! @brief Convert string of hex bytes to list of integers"""
-    return list(six.iterbytes(binascii.unhexlify(data)))
+    return list(binascii.unhexlify(data))
 
 def hex_decode(cmd: str) -> bytes:
     """! @brief Return the binary data represented by the hexadecimal string."""

--- a/pyocd/utility/graph.py
+++ b/pyocd/utility/graph.py
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-class GraphNode(object):
+from typing import (Callable, List, Optional, Sequence, Type, Union)
+
+class GraphNode:
     """! @brief Simple graph node.
 
     All nodes have a parent, which is None for a root node, and zero or more children.
@@ -23,40 +25,43 @@ class GraphNode(object):
     Supports indexing and iteration over children.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """! @brief Constructor."""
-        super(GraphNode, self).__init__()
-        self._parent = None
-        self._children = []
+        super().__init__()
+        self._parent: Optional[GraphNode] = None
+        self._children: List[GraphNode] = []
 
     @property
-    def parent(self):
+    def parent(self) -> Optional["GraphNode"]:
         """! @brief This node's parent in the object graph."""
         return self._parent
 
     @property
-    def children(self):
+    def children(self) -> Sequence["GraphNode"]:
         """! @brief Child nodes in the object graph."""
         return self._children
 
     @property
-    def is_leaf(self):
+    def is_leaf(self) -> bool:
         """! @brief Returns true if the node has no children."""
         return len(self.children) == 0
 
-    def add_child(self, node):
+    def add_child(self, node: "GraphNode") -> None:
         """! @brief Link a child node onto this object."""
         node._parent = self
         self._children.append(node)
 
-    def find_root(self):
+    def find_root(self) -> "GraphNode":
         """! @brief Returns the root node of the object graph."""
         root = self
         while root.parent is not None:
             root = root.parent
         return root
 
-    def find_children(self, predicate, breadth_first=True):
+    def find_children(self,
+            predicate: Callable[["GraphNode"], bool],
+            breadth_first: bool = True
+        ) -> Sequence["GraphNode"]:
         """! @brief Recursively search for children that match a given predicate.
         @param self
         @param predicate A callable accepting a single argument for the node to examine. If the
@@ -66,25 +71,25 @@ class GraphNode(object):
         @param breadth_first Whether to search breadth first. Pass False to search depth first.
         @returns List of matching child nodes, or an empty list if no matches were found.
         """
-        def _search(node, klass):
-            results = []
-            childrenToExamine = []
+        def _search(node: GraphNode):
+            results: List[GraphNode] = []
+            childrenToExamine: List[GraphNode] = []
             for child in node.children:
                 if predicate(child):
                     results.append(child)
                 elif not breadth_first:
-                    results.extend(_search(child, klass))
+                    results.extend(_search(child))
                 elif breadth_first:
                     childrenToExamine.append(child)
 
             if breadth_first:
                 for child in childrenToExamine:
-                    results.extend(_search(child, klass))
+                    results.extend(_search(child))
             return results
 
-        return _search(self, predicate)
+        return _search(self)
 
-    def get_first_child_of_type(self, klass):
+    def get_first_child_of_type(self, klass: Type) -> Optional["GraphNode"]:
         """! @brief Breadth-first search for a child of the given class.
         @param self
         @param klass The class type to search for. The first child at any depth that is an instance
@@ -98,7 +103,7 @@ class GraphNode(object):
         else:
             return None
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: Union[int, slice]) -> Union["GraphNode", List["GraphNode"]]:
         """! @brief Returns the indexed child.
 
         Slicing is supported.
@@ -109,11 +114,11 @@ class GraphNode(object):
         """! @brief Iterate over the node's children."""
         return iter(self.children)
 
-    def _dump_desc(self):
+    def _dump_desc(self) -> str:
         """! @brief Similar to __repr__ by used for dump_to_str()."""
         return str(self)
 
-    def dump_to_str(self):
+    def dump_to_str(self) -> str:
         """! @brief Returns a string describing the object graph."""
 
         def _dump(node, level):
@@ -124,6 +129,6 @@ class GraphNode(object):
 
         return _dump(self, 0)
 
-    def dump(self):
+    def dump(self) -> None:
         """! @brief Pretty print the object graph to stdout."""
         print(self.dump_to_str())

--- a/pyocd/utility/hex.py
+++ b/pyocd/utility/hex.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,13 +18,14 @@
 import sys
 import string
 import io
+from typing import (IO, Optional, Sequence)
 
 from . import conversion
 
 ## ASCII printable characters not including whitespace that changes line position.
 _PRINTABLE = string.digits + string.ascii_letters + string.punctuation + ' '
 
-def format_hex_width(value, width):
+def format_hex_width(value: int, width: int) -> str:
     """! @brief Formats the value as hex of the specified bit width.
 
     @param value Integer value to be formatted.
@@ -41,7 +43,13 @@ def format_hex_width(value, width):
     else:
         raise ValueError("unrecognized register width (%d)" % width)
 
-def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True):
+def dump_hex_data(
+        data: Sequence[int],
+        start_address: int = 0,
+        width: int = 8,
+        output: Optional[IO[str]] = None,
+        print_ascii: bool = True
+    ) -> None:
     """! @brief Prints a canonical hex dump of the given data.
 
     Each line of the output consists of an address column, the data as hex, and a printable ASCII
@@ -122,7 +130,7 @@ def dump_hex_data(data, start_address=0, width=8, output=None, print_ascii=True)
                 if width == 8:
                     d = [d]
                 else:
-                    d = conversion.nbit_le_list_to_byte_list([d], width)
+                    d = list(conversion.nbit_le_list_to_byte_list([d], width))
                     d.reverse()
                 s += "".join((chr(b) if (chr(b) in _PRINTABLE) else '.') for b in d)
             output.write(" " * (max_line_width - actual_line_width) + "   " + s + "|")

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -16,8 +16,9 @@
 
 import operator
 from functools import reduce
+from typing import (Any, Optional, Sequence, Tuple, Union)
 
-def bitmask(*args):
+def bitmask(*args: Union[int, Sequence[int], Tuple[int, int]]) -> int:
     """! @brief Returns a mask with specified bit ranges set.
 
     An integer mask is generated based on the bits and bit ranges specified by the
@@ -54,7 +55,7 @@ def bitmask(*args):
 
     return mask
 
-def bit_invert(value, width=32):
+def bit_invert(value: int, width: int = 32) -> int:
     """! @brief Return the bitwise inverted value of the argument given a specified width.
 
     @param value Integer value to be inverted.
@@ -66,37 +67,37 @@ def bit_invert(value, width=32):
 invert32 = bit_invert
 """! @brief Return the 32-bit inverted value of the argument."""
 
-def bfx(value, msb, lsb):
+def bfx(value: int, msb: int, lsb: int) -> int:
     """! @brief Extract a value from a bitfield."""
     mask = bitmask((msb, lsb))
     return (value & mask) >> lsb
 
-def bfxw(value, lsb, width):
+def bfxw(value: int, lsb: int, width: int) -> int:
     """! @brief Extract a value from a bitfield given the LSb and width."""
     mask = bitmask((lsb + width, lsb))
     return (value & mask) >> lsb
 
-def bfi(value, msb, lsb, field):
+def bfi(value: int, msb: int, lsb: int, field: int) -> int:
     """! @brief Change a bitfield value."""
     mask = bitmask((msb, lsb))
     value &= ~mask
     value |= (field << lsb) & mask
     return value
 
-class Bitfield(object):
+class Bitfield:
     """! @brief Represents a bitfield of a register."""
 
-    def __init__(self, msb, lsb=None, name=None):
+    def __init__(self, msb: int, lsb: Optional[int] = None, name: Optional[str] = None):
         self._msb = msb
         self._lsb = lsb if (lsb is not None) else msb
         self._name = name
         assert self._msb >= self._lsb
 
     @property
-    def width(self):
+    def width(self) -> int:
         return self._msb - self._lsb + 1
 
-    def get(self, value):
+    def get(self, value: int) -> int:
         """! @brief Extract the bitfield value from a register value.
         @param self The Bitfield object.
         @param value Integer register value.
@@ -104,7 +105,7 @@ class Bitfield(object):
         """
         return bfx(value, self._msb, self._lsb)
 
-    def set(self, register_value, field_value):
+    def set(self, register_value: int, field_value: int) -> int:
         """! @brief Modified the bitfield in a register value.
         @param self The Bitfield object.
         @param register_value Integer register value.
@@ -113,10 +114,10 @@ class Bitfield(object):
         """
         return bfi(register_value, self._msb, self._lsb, field_value)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<{}@{:x} name={} {}:{}>".format(self.__class__.__name__, id(self), self._name, self._msb, self._lsb)
 
-def msb(n):
+def msb(n: int) -> int:
     """! @brief Return the bit number of the highest set bit."""
     ndx = 0
     while ( 1 < n ):
@@ -124,7 +125,7 @@ def msb(n):
         ndx += 1
     return ndx
 
-def same(d1, d2):
+def same(d1: Sequence[Any], d2: Sequence[Any]) -> bool:
     """! @brief Test whether two sequences contain the same values.
 
     Unlike a simple equality comparison, this function works as expected when the two sequences
@@ -138,19 +139,19 @@ def same(d1, d2):
             return False
     return True
 
-def align_down(value, multiple):
+def align_down(value: int, multiple: int) -> int:
     """! @brief Return value aligned down to multiple."""
     return value // multiple * multiple
 
-def align_up(value, multiple):
+def align_up(value: int, multiple: int) -> int:
     """! @brief Return value aligned up to multiple."""
     return (value + multiple - 1) // multiple * multiple
 
-def round_up_div(value, divisor):
+def round_up_div(value: int, divisor: int) -> int:
     """! @brief Return value divided by the divisor, rounding up to the nearest multiple of the divisor."""
     return (value + divisor - 1) // divisor
 
-def parity32_high(n):
+def parity32_high(n: int) -> int:
     """! @brief Compute parity over a 32-bit value.
 
     This function is intended to be used for computing parity over a 32-bit value transferred in an Arm

--- a/pyocd/utility/timeout.py
+++ b/pyocd/utility/timeout.py
@@ -16,7 +16,10 @@
 # limitations under the License.
 
 from time import (time, sleep)
-from typing import Optional
+from typing import (Any, Optional, TYPE_CHECKING)
+
+if TYPE_CHECKING:
+    from types import TracebackType
 
 class Timeout:
     """! @brief Timeout helper context manager.
@@ -73,12 +76,12 @@ class Timeout:
         self._is_first_check = True
         self._is_running = False
 
-    def __enter__(self):
+    def __enter__(self) -> "Timeout":
         self.start()
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+    def __exit__(self, exc_type: type, value: Any, traceback: "TracebackType") -> bool:
+        return False
 
     def start(self) -> None:
         """! @brief Start or restart the timeout timer.
@@ -93,7 +96,7 @@ class Timeout:
         self._timed_out = False
         self._is_first_check = True
 
-    def clear(self):
+    def clear(self) -> None:
         """! @brief Reset the timeout back to initial, non-running state.
 
         The timeout can be made to run again by calling start().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,7 @@ passenv = CI_JOBS
 commands =
     python automated_test.py -j4 -q
 """
+
+[tool.mypy]
+files = "pyocd"
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ install_requires =
     pyusb>=1.2.1,<2.0
     pyyaml>=6.0,<7.0
     six>=1.15.0,<2.0
+    typing-extensions>=4.0,<5.0
 
 [options.extras_require]
 test =

--- a/test/unit/test_compatibility.py
+++ b/test/unit/test_compatibility.py
@@ -14,23 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-import six
-
 from pyocd.utility.compatibility import (
-    iter_single_bytes,
     to_bytes_safe,
     to_str_safe,
 )
 
 class TestCompatibility(object):
-    def test_iter_single_bytes_bytes(self):
-        i = iter_single_bytes(b"1234")
-        assert next(i) == b'1'
-        assert next(i) == b'2'
-        assert next(i) == b'3'
-        assert next(i) == b'4'
-
     def test_to_bytes_safe(self):
         assert to_bytes_safe(b"hello") == b"hello"
         assert to_bytes_safe("string") == b"string"

--- a/test/unit/test_gdbserver.py
+++ b/test/unit/test_gdbserver.py
@@ -1,0 +1,67 @@
+# pyOCD debugger
+# Copyright (c) 2021 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyocd.gdbserver.gdbserver import (
+    escape,
+    unescape,
+)
+
+# escaped chars: '#$}*'
+# escaped by prefixing with '}' and xor'ing the char with 0x20
+#
+# '#' (0x23) -> '}\x03'
+# '$' (0x24) -> '}\x04'
+# '}' (0x7d) -> '}]'
+# '*' (0x2a) -> '}\x0a'
+
+class TestGdbServerEscaping:
+    def test_escape_transparent(self):
+        assert escape(b"hello") == b"hello"
+
+    def test_escape_individual(self):
+        assert escape(b"hello#foo") == b"hello}\x03foo"
+        assert escape(b"hello$foo") == b"hello}\x04foo"
+        assert escape(b"hello}foo") == b"hello}]foo"
+        assert escape(b"hello*foo") == b"hello}\x0afoo"
+
+    def test_escape_single(self):
+        assert escape(b"#") == b"}\x03"
+        assert escape(b"$") == b"}\x04"
+        assert escape(b"}") == b"}]"
+        assert escape(b"*") == b"}\x0a"
+
+    def test_escape_combined(self):
+        assert escape(b"#$}*") == b"}\x03}\x04}]}\x0a"
+        assert escape(b'}}}') == b"}]}]}]"
+
+    def test_unescape_transparent(self):
+        assert unescape(b"bytes") == list(b"bytes")
+
+    def test_unescape_individual(self):
+        assert unescape(b"hello}\x03foo") == list(b"hello#foo")
+        assert unescape(b"hello}\x04foo") == list(b"hello$foo")
+        assert unescape(b"hello}]foo") == list(b"hello}foo")
+        assert unescape(b"hello}\x0afoo") == list(b"hello*foo")
+
+    def test_unescape_single(self):
+        assert unescape(b"}\x03") == [b'#'[0]]
+        assert unescape(b"}\x04") == [b'$'[0]]
+        assert unescape(b"}]") == [b'}'[0]]
+        assert unescape(b"}\x0a") == [b'*'[0]]
+
+    def test_unescape_combined(self):
+        assert unescape(b"}\x03}\x04}]}\x0a") == list(b"#$}*")
+        assert unescape(b"}]}]}]") == list(b"}}}")


### PR DESCRIPTION
These changes add type annotations for the most important classes and APIs. There are some related changes, and some general cleanup.

- Annotate `MemoryInterface`, `MemoryMap` and memory region classes, core register classes, `Target`,  `SoCTarget`, `CoreSightTarget`, `CortexM`, `DebugPort`, `AccessPort`, `Session`, `OptionsManager`, `DebugProbe`, `CMSISDAPDebugProbe`, `Board`, CMSIS pack classes, and more.
- Add new `CoreTarget(Target)` superclass that CortexM derives from.
- Some misc type fixes.
- Replace usage of `six` in several places (the ultimate goal is to remove the dependency on `six`), including rewriting the gdbserver binary encode and decode routines (with added unit test cases).

I've been using pylance in VSCode for type checking. It has slightly different behaviour and rules from mypy, but generally seems better overall.