### PR TITLE
Power down DP only if resuming on disconnect

### DIFF
--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -117,7 +117,10 @@ class CoreSightTarget(SoCTarget):
         self.call_delegate('will_disconnect', target=self, resume=resume)
         for core in self.cores.values():
             core.disconnect(resume)
-        self.dp.disconnect()
+        # Only disconnect the DP if resuming; otherwise it will power down debug and potentially
+        # let the core continue running.
+        if resume:
+            self.dp.disconnect()
         self.call_delegate('did_disconnect', target=self, resume=resume)
 
     def create_discoverer(self) -> None:


### PR DESCRIPTION
If the DP is powered down the core may not stay halted.