### PR TITLE
gdbserver: return empty T response if reading regs fails

### DIFF
--- a/pyocd/gdbserver/context_facade.py
+++ b/pyocd/gdbserver/context_facade.py
@@ -210,7 +210,7 @@ class GDBDebugContextFacade(object):
         return signal
 
     def _get_reg_index_value_pairs(self, reg_list):
-        """! @brief Return register values as pairs.
+        """! @brief Return register values as pairs for the T response.
 
         Returns a string like NN:MMMMMMMM;NN:MMMMMMMM;...
         for the T response string.  NN is the index of the
@@ -220,15 +220,14 @@ class GDBDebugContextFacade(object):
         try:
             reg_values = self._context.read_core_registers_raw(reg_list)
         except exceptions.CoreRegisterAccessError:
-            reg_values = [None] * len(reg_list)
+            # If we cannot read registers, return an empty string. We mustn't return 'x's like the other
+            # register read methods do, because gdb terribly dislikes 'x's in a T response.
+            return result
 
         for reg_name, reg_value in zip(reg_list, reg_values):
             reg = self._context.core.core_registers.by_name[reg_name]
-            # Return x's if the register read failed.
-            if reg_value is None:
-                encoded_reg = "xx" * round_up_div(reg.bitsize, 8)
-            else:
-                encoded_reg = conversion.uint_to_hex_le(reg_value, reg.bitsize)
+            assert reg_value is not None
+            encoded_reg = conversion.uint_to_hex_le(reg_value, reg.bitsize)
             result += (conversion.byte_to_hex2(reg.gdb_regnum) + ':' + encoded_reg + ';').encode()
         return result
 


### PR DESCRIPTION
If reading registers for the T response fails (for instance if the core isn't halted), don't include any register values in the T response. Unlike other gdb register read responses, we shouldn't set the value of failed register reads to x's since gdb dislikes x's in a T response.