### PR TITLE
STLinkV3: fix setting SWD frequency and improve max frequency.

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -598,3 +598,21 @@ Default is False, so possible WAIT or FAULT SWD acknowldeges and protocol errors
 </td></tr>
 
 </table>
+
+## STLink options
+
+These session options are available when the STLink debug probe plugin is active.
+
+<table>
+
+<tr><th>Option Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+
+<tr><td>stlink.v3_prescaler</td>
+<td>int</td>
+<td>1</td>
+<td>
+Sets the HCLK prescaler of an STLinkV3, changing performance versus power tradeoff.
+The value must be one of 1=high performance (default), 2=normal, or 4=low power.
+</td></tr>
+
+</table>

--- a/pyocd/probe/stlink/constants.py
+++ b/pyocd/probe/stlink/constants.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 class Commands:
-    """!
+    """
     @brief STLink V2 and V3 commands.
     """
 
@@ -90,7 +90,7 @@ class Commands:
     JTAG_STLINK_JTAG_COM = 0x01
 
 class Status:
-    """!
+    """
     @brief STLink status codes and messages.
     """
     # Status codes.
@@ -120,7 +120,9 @@ class Status:
     SWD_AP_WDATA_ERROR = 0x18
     SWD_AP_STICKY_ERROR = 0x19
     SWD_AP_STICKYORUN_ERROR = 0x1a
+    BAD_AP = 0x1d
     SWV_NOT_AVAILABLE = 0x20
+    JTAG_CONF_CHANGED = 0x40
     JTAG_FREQ_NOT_SUPPORTED = 0x41
     JTAG_UNKNOWN_CMD = 0x42
 
@@ -151,13 +153,15 @@ class Status:
         SWD_AP_WDATA_ERROR : "AP WDATA error",
         SWD_AP_STICKY_ERROR : "AP sticky error",
         SWD_AP_STICKYORUN_ERROR : "AP sticky overrun error",
+        BAD_AP : "Bad AP",
         SWV_NOT_AVAILABLE : "SWV not available",
+        JTAG_CONF_CHANGED : "Configuration changed",
         JTAG_FREQ_NOT_SUPPORTED : "Frequency not supported",
         JTAG_UNKNOWN_CMD : "Unknown command",
     }
 
     @staticmethod
-    def get_error_message(status):
+    def get_error_message(status: int) -> str:
         return "STLink error ({}): {}".format(status, Status.MESSAGES.get(status, "Unknown error"))
 
 ## Map from SWD frequency in Hertz to delay loop count.


### PR DESCRIPTION
The main point of this PR is to fix a bug setting the SWD frequency for V3 where it was always setting JTAG frequency instead. (STLink treats the two as separate frequencies.)

In addition, the STLinkV3 HCLK prescaler is set on open from a `stlink.v3_prescaler` session option. By default it's set to 1 for high performance. This increases the maximum frequency from 21.333 MHz to the maximum rating of 24 MHz. You can see the actual frequency reported by the STLink in a debug log from the `pyocd.probe.stlink.stlink` module.

Fixes #1276.