### PR TITLE
User defined commands

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,7 +3,7 @@ path_classifiers:
     - scripts/generate_command_help.py
   test:
     # Mark all code under the src/ directory as test related.
-    # Really, the crc analyzer is not for test, but LGTL can't build embedded.
+    # Really, the crc analyzer is not for test, but LGTM can't build embedded.
     - src
     - exclude: src/analyzer
 
@@ -21,4 +21,32 @@ queries:
   #
   # In some cases the 'while' block will exit with only a 'return', so the 'else' isn't really
   # necessary, but retaining it maintains the expected pattern.
-  - exclude: py/redundant-else
+  - exclude: "py/redundant-else"
+
+  # Exclude cases where there is an import of the same module via 'import foo' and 'from foo import ...'.
+  # The query for this is too general and catches a lot of cases that are not really errors, especially
+  # with includes of types for annotations.
+  #
+  # Example 1:
+  #
+  #   import pyocd
+  #   from pyocd import debug
+  #
+  # These two imports trigger this query, even though it's pretty clearly a reasonable usage.
+  #
+  # Example 2:
+  #
+  #   if TYPE_CHECKING:
+  #     import types
+  #
+  #   def foo():
+  #     import types
+  #
+  # In this case, types is only needed within foo() at runtime and is not imported globally to reduce
+  # namespace pollution and import times. But when type checking it's types is also imported. The query
+  # doesn't see the TYPE_CHECKING predicate and triggers.
+  - exclude: "py/import-and-import-from"
+
+  # This query triggers on logging of the probe's UID as specified on the command line in cleartext.
+  # Clearly the UID is not sensitive data, at least in the traditional sense.
+  - exclude: "py/clear-text-logging-sensitive-data"

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -1561,8 +1561,7 @@ class HelpCommand(CommandBase):
             }
 
     HELP_ADDENDUM = """
-All register names are also available as commands that print the register's value.
-Any ADDR or LEN argument will accept a register name.
+Any integer argument will accept a register name.
 Prefix line with $ to execute a Python expression.
 Prefix line with ! to execute a shell command."""
 

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -414,19 +414,14 @@ class CommandExecutionContext:
 
     def _build_python_namespace(self) -> None:
         """! @brief Construct the dictionary used as the namespace for python commands."""
-        import pyocd
+        assert self.session
         assert self.target
-        self._python_namespace = {
-                'session': self.session,
-                'board': self.board,
-                'target': self.target,
-                'probe': self.probe,
-                'dp': self.target.dp,
-                'aps': self.target.dp.aps,
+        ns = self.session.user_script_proxy.namespace
+        ns.update({
                 'elf': self.elf,
                 'map': self.target.memory_map,
-                'pyocd': pyocd,
-            }
+            })
+        self._python_namespace = ns
 
     def handle_python(self, invocation: CommandInvocation) -> None:
         """! @brief Evaluate a python expression."""

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -231,6 +231,9 @@ class CommandExecutionContext:
                         self.selected_ap_address = ap_num
                         break
 
+        # Add user-defined commands once we know we have a session created.
+        self.command_set.add_command_group('user')
+
         return True
 
     @property

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -531,11 +531,12 @@ class UserScriptFunctionProxy:
     This proxy makes arguments to user script functions optional.
     """
 
-    def __init__(self, fn) -> None:
+    def __init__(self, fn: Callable) -> None:
+        assert isinstance(fn, Callable)
         self._fn = fn
         self._spec = getfullargspec(fn)
 
-    def __call__(self, **kwargs) -> Any:
+    def __call__(self, **kwargs: Any) -> Any:
         args = {}
         for arg in self._spec.args:
             if arg in kwargs:
@@ -551,7 +552,11 @@ class UserScriptDelegateProxy:
 
     def __getattr__(self, name: str) -> Any:
         if name in self._script:
-            fn = self._script[name]
-            return UserScriptFunctionProxy(fn)
+            obj = self._script[name]
+            # Only return the function proxy if the object is indeed callable.
+            if isinstance(obj, Callable):
+                return UserScriptFunctionProxy(obj)
+            else:
+                return obj
         else:
             raise AttributeError(name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -98,3 +98,12 @@ pyocd.rtos =
     rtx5 = pyocd.rtos.rtx5:RTX5Plugin
     threadx = pyocd.rtos.threadx:ThreadXPlugin
     zephyr = pyocd.rtos.zephyr:ZephyrPlugin
+
+[flake8]
+exclude =
+    # Ignore the test user script since it uses globals not available to flake8, and will thus generate
+    # many failures.
+    test_user_script.py,
+    # Ignore gdb test script for similar reasons.
+    gdb_test_script.py
+

--- a/test/test_user_script.py
+++ b/test/test_user_script.py
@@ -1,5 +1,17 @@
 # Test user script.
-#
+
+@command(help="test command")
+def testcmd(f: float, i: int, s: str):
+    assert isinstance(f, float)
+    assert isinstance(i, int)
+    assert isinstance(s, str)
+
+@command("anothertestcmd", help="second test command")
+def testcmd2(*args):
+    assert isinstance(args, tuple)
+    assert all(isinstance(s, str) for s in args)
+
+
 # Provides stub implementations of all hooks.
 
 def will_connect(board):

--- a/test/user_script_test.py
+++ b/test/user_script_test.py
@@ -24,6 +24,7 @@ import logging
 from pyocd.core.helpers import ConnectHelper
 from pyocd.probe.pydapaccess import DAPAccess
 from pyocd.core.memory_map import MemoryType
+from pyocd.commands.execution_context import CommandExecutionContext
 
 from test_util import (
     Test,
@@ -75,6 +76,10 @@ def user_script_test(board_id):
         test_count = 0
         result = UserScriptTestResult()
 
+        # TEST basic functionality
+        print("\n------ Testing delegates ------")
+
+        # TODO verify user script delegates were called
         target.reset_and_halt()
         target.resume()
         target.halt()
@@ -82,6 +87,34 @@ def user_script_test(board_id):
 
         test_count += 1
         test_pass_count += 1
+        print("TEST PASSED")
+
+        # TEST user defined commands
+        print("\n------ Testing user defined commands ------")
+        context = CommandExecutionContext()
+        context.attach_session(session)
+
+        def test_command(cmd):
+            try:
+                print("\nTEST: %s" % cmd)
+                context.process_command_line(cmd)
+            except:
+                print("TEST FAILED")
+                traceback.print_exc(file=sys.stdout)
+                return False
+            else:
+                print("TEST PASSED")
+                return True
+
+        # Verify command with float, int, str args.
+        if test_command("testcmd 3.14 0xbeef foobar"):
+            test_pass_count += 1
+        test_count += 1
+
+        # Verify varargs: all should be strings in the cmd's args
+        if test_command("anothertestcmd a b 1 2 fee fie foe"):
+            test_pass_count += 1
+        test_count += 1
 
         print("\nTest Summary:")
         print("Pass count %i of %i tests" % (test_pass_count, test_count))


### PR DESCRIPTION
The primary purpose of this change is to implement support for defining custom commands in user scripts. This is accomplished with a `command` decorator added to the user script namespace. Documentation of this feature is added to the user script docs.

Accompanying changes:
- The `print()` function in user scripts is replaced with a proxy that can be redirected to another function at runtime. This is used to ensure that user script output appears on the command execution context output stream, and therefore will be visible in response to gdb monitor commands.
- Fix some help text for commands.
- Add check to `UserScriptDelegateProxy` that the retrieved attribute is a callable before wrapping it in `UserScriptFunctionDelegate`.
- Major reformatting of user script docs.