### PR TITLE
Cortex-M: fix regression with writing CFBP and xPSR subregisters.

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1189,8 +1189,10 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
                 reg_data_list += [(-reg, singleLow), (-reg + 1, singleHigh)]
             elif CortexMCoreRegisterInfo.get(reg).is_cfbp_subregister and cfbpValue is None:
                 cfbpValue = self._base_read_core_registers_raw([CortexMCoreRegisterInfo.get('cfbp').index])[0]
+                reg_data_list.append((reg, data))
             elif CortexMCoreRegisterInfo.get(reg).is_psr_subregister and xpsrValue is None:
                 xpsrValue = self._base_read_core_registers_raw([CortexMCoreRegisterInfo.get('xpsr').index])[0]
+                reg_data_list.append((reg, data))
             else:
                 # Other register, just copy directly.
                 reg_data_list.append((reg, data))

--- a/test/cortex_test.py
+++ b/test/cortex_test.py
@@ -410,16 +410,75 @@ def cortex_test(board_id):
             target.write_core_registers_raw(['s0', 's1'], origRegs)
 
         print("Verify that all listed core registers can be accessed")
+
+        def test_reg_rw(r, new_value: int, test_write: bool) -> bool:
+            did_pass = True
+            try:
+                # Read original value.
+                original_val = target.read_core_register_raw(r.name)
+
+                if not test_write:
+                    return did_pass
+
+                # Make sure the new value changes.
+                if new_value == original_val:
+                    new_value = 0
+
+                # Change the value.
+                target.write_core_register_raw(r.name, new_value)
+                read_val = target.read_core_register_raw(r.name)
+                if read_val != new_value:
+                    print(f"Failed to change value of register {r.name} to {new_value:#x}; read {read_val:#x}")
+                    did_pass = False
+
+                target.write_core_register_raw(r.name, original_val)
+                read_val = target.read_core_register_raw(r.name)
+                if read_val != original_val:
+                    print(f"Failed to restore value of register {r.name} back to original {original_val:#x}; read {read_val:#x}")
+                    did_pass = False
+            except exceptions.CoreRegisterAccessError:
+                did_pass = False
+            return did_pass
+
         reg_count = 0
         passed_reg_count = 0
         for r in target.selected_core.core_registers.as_set:
-            try:
-                reg_count += 1
-                val = target.read_core_register(r.name)
-                target.write_core_register(r.name, val)
+            test_write = True
+
+            # Decide on a new value, ensuring it changes and taking into account register specifics.
+            r_mask = (1 << r.bitsize) - 1
+            if 'sp' in r.name:
+                r_mask &= ~0x3
+            elif r.name == 'pc':
+                r_mask &= ~0x1
+            elif 'xpsr' in r.name:
+                r_mask = 0xd0000000
+            elif 'control' == r.name:
+                # SPSEL is available on all cores.
+                r_mask = 0x2
+            elif r.name in ('primask', 'faultmask'):
+                r_mask = 0x1
+            elif r.name == 'basepri':
+                r_mask = 0x80
+            elif r.name == 'fpscr':
+                # v7-M bits
+                r_mask = 0xf7c0009f
+            new_value = 0xdeadbeef & r_mask
+
+            # Skip write tests on some regs:
+            # - combined CFBP
+            # - PSR variants not including XPSR
+            # - all _NS and _S variants
+            if ((r.name in ('cfbp',))
+                    or (('psr' in r.name) and (r.name != 'xpsr'))
+                    or ('_ns' in r.name) or ('_s' in r.name)
+                    ):
+                test_write = False
+
+            reg_count += 1
+            if test_reg_rw(r, new_value, test_write):
                 passed_reg_count += 1
-            except exceptions.CoreRegisterAccessError:
-                pass
+
         test_count += 1
         if passed_reg_count == reg_count:
             test_pass_count += 1


### PR DESCRIPTION
Writing any of CONTROL, FAULTMASK, BASEPRI, PRIMASK (CFBP), or the many xPSR variants failed due to a regression that introduced a logic error.

The `cortex_test.py` function test has been updated to to verify with readback that core register writes actually take effect. Only a few register aliases are excluded from this test for now.