### PR TITLE
J-Link: fix is_reset_asserted().

### DIFF
--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -279,7 +279,7 @@ class JLinkProbe(DebugProbe):
 
     def is_reset_asserted(self):
         try:
-            status = self._link.hardware_status()
+            status = self._link.hardware_status
             return status.tres == 0
         except JLinkException as exc:
             raise self._convert_exception(exc) from exc


### PR DESCRIPTION
Incorrectly accessing the `JLink.hardware_status` property as a callable method.