### PR TITLE
Test: gdb test script improvements

### DIFF
--- a/test/gdb_test.py
+++ b/test/gdb_test.py
@@ -30,7 +30,6 @@ from subprocess import (
     Popen,
     STDOUT,
     PIPE,
-    check_output,
     )
 import argparse
 import logging
@@ -39,7 +38,6 @@ import threading
 
 from pyocd.__main__ import PyOCDTool
 from pyocd.core.helpers import ConnectHelper
-from pyocd.utility.compatibility import to_str_safe
 from pyocd.core.memory_map import MemoryType
 from pyocd.flash.file_programmer import FileProgrammer
 from test_util import (
@@ -63,6 +61,7 @@ LOG = logging.getLogger(__name__)
 
 PYTHON_GDB = "arm-none-eabi-gdb-py"
 TEST_TIMEOUT_SECONDS = 60.0 * 5
+SERVER_EXIT_TIMEOUT = 10.0
 
 GDB_SCRIPT_PATH = os.path.join(TEST_DIR, "gdb_test_script.py")
 
@@ -170,7 +169,7 @@ def test_gdb(board_id=None, n=0):
         LOG.info('Waiting for gdb to finish...')
         did_complete = wait_with_deadline(gdb_program, TEST_TIMEOUT_SECONDS)
         LOG.info('Waiting for server to finish...')
-        server_thread.join(timeout=TEST_TIMEOUT_SECONDS)
+        server_thread.join(timeout=SERVER_EXIT_TIMEOUT)
         if not did_complete:
             LOG.error("Test timed out!")
         if server_thread.is_alive():

--- a/test/gdb_test_script.py
+++ b/test/gdb_test_script.py
@@ -345,10 +345,16 @@ def run_test():
         if not is_event_breakpoint(event, breakpoint):
             fail_count += 1
             print("Error - breakpoint 1 test failed")
-        func_name = gdb.selected_frame().function().name
-        if rmt_func != func_name:
+        func = gdb.selected_frame().function()
+        if func is None:
             fail_count += 1
-            print("ERROR - break occurred at wrong function %s" % func_name)
+            print("ERROR - selected frame has no function!?")
+            print(gdb.selected_frame())
+        else:
+            func_name = func.name
+            if rmt_func != func_name:
+                fail_count += 1
+                print("ERROR - break occurred at wrong function %s" % func_name)
         breakpoint.delete()
         gdb_execute("set var run_breakpoint_test = 0")
 
@@ -371,10 +377,16 @@ def run_test():
 #         if not is_event_breakpoint(event):
 #             fail_count += 1
 #             print("Error - breakpoint 2 test failed")
-        func_name = gdb.selected_frame().function().name
-        if rmt_func != func_name and not ignore_hw_bkpt_result:
+        func = gdb.selected_frame().function()
+        if func is None:
             fail_count += 1
-            print("ERROR - break occurred at wrong function %s" % func_name)
+            print("ERROR - selected frame has no function!?")
+            print(gdb.selected_frame())
+        else:
+            func_name = func.name
+            if rmt_func != func_name and not ignore_hw_bkpt_result:
+                fail_count += 1
+                print("ERROR - break occurred at wrong function %s" % func_name)
         gdb_execute("clear %s" % rmt_func)
         gdb_execute("set var run_breakpoint_test = 0")
 


### PR DESCRIPTION
- Prevent an unhandled exception in `gdb_test_script.py` if the frame happens to not be on a valid function. This could happen if an interrupt or exception occurred. An error is recorded in this case, but the test continues.
- Reduce timeout waiting for the gdbserver to exit after gdb has terminated.