### PR TITLE
Test: automated test supports remote probes

### DIFF
--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -79,8 +79,8 @@ class TCPClientProbe(DebugProbe):
     def __init__(self, unique_id):
         """! @brief Constructor."""
         super(TCPClientProbe, self).__init__()
-        self._uid = unique_id
         hostname, port = self._extract_address(unique_id)
+        self._uid = f"remote:{hostname}:{port}"
         self._socket = ClientSocket(hostname, port)
         self._is_open = False
         self._request_id = 0

--- a/pyocd/probe/tcp_probe_server.py
+++ b/pyocd/probe/tcp_probe_server.py
@@ -258,6 +258,12 @@ class DebugProbeRequestHandler(StreamRequestHandler):
     def finish(self):
         LOG.info("Remote probe client disconnected (%s from port %i)", self._client_domain, self.client_address[1])
 
+        # Flush the probe and ignore any lingering errors.
+        try:
+            self._session.probe.flush()
+        except exceptions.Error as err:
+            LOG.debug("exception while flushing probe on disconnect: %s", err)
+
         self._session = None
         StreamRequestHandler.finish(self)
 

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -380,7 +380,10 @@ def main():
 
     # Filter boards.
     if args.board:
+        # Get the full unique ID of any matching probes.
         board_id_list = [b for b in board_id_list if any(c for c in args.board if c.lower() in b.lower())]
+        # Add in any requested remotes.
+        board_id_list += [a for a in args.board if a.startswith('remote:')]
 
     # Generate board test configs.
     test_configs = [


### PR DESCRIPTION
Extend `automated_test.py` to accept `remote:` probe UIDs with its `-b` argument.

With this are two changes to the remote probe server to flush the probe on disconnect and client to report the probe's UID as the full form including port (e.g., `remote:hostname:5555`).