### PR TITLE
Fix 'reg' command output stream

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -125,7 +125,7 @@ class RegisterCommandBase(CommandBase):
             value_str = self._format_core_register(info, value)
             col_printer.add_items([(info.name, value_str)])
 
-        col_printer.write()
+        col_printer.write(self.context.output_stream)
 
     def dump_registers(self, show_all=False, show_group=None):
         if not self.context.selected_core.is_halted():


### PR DESCRIPTION
This fix corrects the 'reg' command's output so it goes to the command execution context's output stream instead of sys.stdout, which makes it visible in the gdb console when executed as a monitor command.