### PR TITLE
Gdbserver: clear shutdown event after disconnect

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2022 Clay McClure
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -308,6 +309,7 @@ class GDBServer(threading.Thread):
 
         while True:
             try:
+                self.shutdown_event.clear()
                 self.detach_event.clear()
 
                 # Notify listeners that the server is running after a short delay.


### PR DESCRIPTION
Otherwise, the listening socket is closed, preventing reconnection.