### PR TITLE
Fix gdbserver exit issues; cleanup related code

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -275,11 +275,14 @@ class GDBServer(threading.Thread):
         # Add the gdbserver command group.
         self._command_context.command_set.add_command_group('gdbserver')
 
-    def stop(self):
+    def stop(self, wait=True):
         if self.is_alive():
             self.shutdown_event.set()
-            LOG.debug("gdbserver shutdown event set; waiting for exit")
-            self.join()
+            if wait:
+                LOG.debug("gdbserver shutdown event set; waiting for exit")
+                self.join()
+            else:
+                LOG.debug("gdbserver shutdown event set")
             LOG.info("GDB server thread stopped")
 
     def _cleanup(self):

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -95,9 +95,33 @@ class GdbserverMonitorInitCommand(CommandBase):
             'group': 'gdbserver',
             'category': 'openocd_compatibility',
             'nargs': 2,
-            'usage': "init",
+            'usage': "",
             'help': "Ignored; for OpenOCD compatibility.",
             }
 
     def execute(self):
         pass
+
+class GdbserverMonitorExitCommand(CommandBase):
+    """@brief 'exit' command to cleanly shut down the gdbserver from an IDE.
+
+    This command is primarily intended to be used by an IDE to tell the pyocd process to exit when
+    the debug session is terminated.
+    """
+    INFO = {
+            'names': ['exit'],
+            'group': 'gdbserver',
+            'category': 'gdbserver',
+            'nargs': 0,
+            'usage': "",
+            'help': "Terminate running gdbservers in this session.",
+            'extra_help':
+                "For the pyocd gdbserver subcommand, terminating gdbservers will cause the process to exit. The "
+                "effect when the gdbserver(s) are running in a different environment depends on that program. "
+                "Note that gdb will still believe the connection to be valid after this command completes, so "
+                "executing the 'disconnect' command is a necessity."
+            }
+
+    def execute(self):
+        for server in self.context.session.gdbservers.values():
+            server.stop(wait=False)


### PR DESCRIPTION
Major cleanup of shutdown and detach related code in the gdbserver.

- The use of the shutdown and detach event objects is cleaned up and simplified. The detach event is only used by the connection loop method `_run_connection()`.
- The `detach` and `kill` command handlers set the detach event directly.
- Changed connection and the server cleaned to be done at the end of the relevant method so it's clear when it happens. Similarly, the connection/server loops have clear a clear exit controlled by the relevant events.
- Handling of server persisting and preparation for a new connection is done at the end of `_run_connection()`.
- The `detach` command is basically ignored if it is an extended-remote connection, per the gdbserver specification. The `kill` command will still close the connection.
- Fixed handling of server persisting if gdb closes its client connection without sending a command. (It will persist as expected if persisting is enabled.)
- Added `exit` monitor command that will terminate all gdbservers associated with the session. For `pyocd gdbserver` this will cause the process to exit regardless of whether persist is enabled.
- The `gdb_test.py` functional test will stop the gdbserver if it doesn't terminate by itself within the timeout after the test is done. (If the gdbserver is hung it may not be able to stop it, since there is no way to forcibly kill a thread in Python.)
- A few other changes to clean up the code.