### PR TITLE
Fix an issue with --color=always being equivalent to auto.

### DIFF
--- a/docs/configuring_logging.md
+++ b/docs/configuring_logging.md
@@ -50,16 +50,14 @@ level of WARNING to INFO.
 
 ## Color logging
 
-By default, log output to the console is colorised. Control over colorised log output is possible two ways.
+By default, log output to a tty is colorised. Control over colorised log output is possible two ways.
 
 The command-line `--color` argument accepts an optional parameter that must be one of `auto`, `always`, or `never`.
 The default is `auto`, which will enable color only when outputting to a tty.
 
 Another option for controlling color output is the `PYOCD_COLOR` environment variable. It should be set to one of the
-same values supported by `--color`, or left empty. This environment variable changes the default color output setting,
-and is overridden by `--color` on the command line.
-
-Currently, due to limitations in the colorisation support, `always` behaves the same as `auto`.
+same values supported by `--color`. This environment variable changes the default color output setting, and is
+overridden by `--color` on the command line.
 
 
 ## Loggers

--- a/docs/env_vars.md
+++ b/docs/env_vars.md
@@ -7,6 +7,26 @@ title: Environment variables
 <tr><th>Variable</th><th>Description</th></tr>
 
 <tr><td>
+<a if="pyocd_project_dir"><p><code>PYOCD_COLOR</code></p></a>
+</td><td>
+<p>Changes the default color output setting. Must be one of <code>auto</code>, <code>always</code>, or
+<code>never</code>. If not defined, the default is <code>auto</code>, which will enable color only when
+outputting to a tty. Overridden by <code>--color</code> on the command line.</p>
+</td></tr>
+
+<tr><td>
+<a if="pyocd_history"><p><code>PYOCD_HISTORY</code></p></a>
+</td><td>
+<p>Path to the <code>pyocd commander</code> command history file. The default is <code>~/.pyocd_history</code>.</p>
+</td></tr>
+
+<tr><td>
+<a if="pyocd_history_length"><p><code>PYOCD_HISTORY_LENGTH</code></p></a>
+</td><td>
+<p>Maximum number of entries in the command history file. Set to -1 for unlimited. Default is 1000.</p>
+</td></tr>
+
+<tr><td>
 <a if="pyocd_project_dir"><p><code>PYOCD_PROJECT_DIR</code></p></a>
 </td><td>
 <p>Sets the path to pyOCD's project directory. This variable acts as a fallback if the <code>project_dir</code>
@@ -22,18 +42,6 @@ unset. CMSIS-DAP v2 probes are unaffected by the environment variable; pyusb is 
 <p>Forcing the USB backend is really only useful on Windows, because both <code>hidapiusb</code> and
 <code>pywinusb</code> backends are available. Note that pyOCD only installs the <code>hidapiusb</code> backend
 by default.</p>
-</td></tr>
-
-<tr><td>
-<a if="pyocd_history"><p><code>PYOCD_HISTORY</code></p></a>
-</td><td>
-<p>Path to the <code>pyocd commander</code> command history file. The default is <code>~/.pyocd_history</code>.</p>
-</td></tr>
-
-<tr><td>
-<a if="pyocd_history_length"><p><code>PYOCD_HISTORY_LENGTH</code></p></a>
-</td><td>
-<p>Maximum number of entries in the command history file. Set to -1 for unlimited. Default is 1000.</p>
 </td></tr>
 
 </table>

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,9 +28,6 @@ if TYPE_CHECKING:
 
 from .session import Session
 from ..probe.aggregator import DebugProbeAggregator
-
-# Init colorama here since this is currently the only module that uses it.
-colorama.init()
 
 class ConnectHelper:
     """! @brief Helper class for streamlining the probe discovery and session creation process.


### PR DESCRIPTION
Configure colorama appropriately so that `--color=always` works as expected when outputting to non-tty devices/files.

Color log setup is refactored to `build_color_logger()` in `pyocd.utility.color_log` so it can be reused easily. The colorama init call is moved here.

Small doc updates to remove note about `--color=always` issue, and document the `PYOCD_COLOR` environment variable.