### PR TITLE
Switch from naturalsort to natsort

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2022 David Runge
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +18,7 @@
 
 import logging
 import os
-from natsort import natsort
+from natsort import natsorted
 import textwrap
 from time import sleep
 from shutil import get_terminal_size
@@ -116,7 +117,7 @@ class StatusCommand(CommandBase):
 
 class RegisterCommandBase(CommandBase):
     def dump_register_group(self, group_name):
-        regs = natsort(self.context.selected_core.core_registers.iter_matching(
+        regs = natsorted(self.context.selected_core.core_registers.iter_matching(
                 lambda r: r.group == group_name), key=lambda r: r.name)
         reg_values = self.context.selected_core.read_core_registers_raw(r.name for r in regs)
         

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
     intelhex>=2.0,<3.0
     intervaltree>=3.0.2,<4.0
-    naturalsort>=1.5,<2.0
+    natsort>=8.0.0,<9.0
     prettytable>=2.0,<3.0
     pyelftools<1.0
     pylink-square>=0.11.1,<1.0


### PR DESCRIPTION
pyocd/commands/commands.py:
Use natsort's `natsorted()` instead of naturalsort's `natsort()`.

setup.cfg:
Replace naturalsort with natsort.

Fixes #1317