### PR TITLE
rtos: Fix reading Zephyr thread name and update debug symbol names

### DIFF
--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016-2020 Arm Limited
+# Copyright (c) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -192,12 +193,8 @@ class ZephyrThread(TargetThread):
             self._state = self._target_context.read8(self._base + self._offsets["t_state"])
 
             if self._provider.version > 0:
-                addr = self._target_context.read32(self._base + self._offsets["t_name"])
-                if addr != 0:
-                    self._name = read_c_string(self._target_context, addr)
-                else:
-                    self._name = "Unnamed"
-
+                addr = self._base + self._offsets["t_name"]
+                self._name = read_c_string(self._target_context, addr)
 
         except exceptions.TransferError:
             LOG.debug("Transfer error while reading thread info")

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -243,8 +243,8 @@ class ZephyrThreadProvider(ThreadProvider):
     ## Required Zephyr symbols.
     ZEPHYR_SYMBOLS = [
         "_kernel",
-        "_kernel_openocd_offsets",
-        "_kernel_openocd_size_t_size",
+        "_kernel_thread_info_offsets",
+        "_kernel_thread_info_size_t_size",
         ]
 
     ZEPHYR_OFFSETS = [
@@ -283,15 +283,15 @@ class ZephyrThreadProvider(ThreadProvider):
 
     def _get_offsets(self):
         # Read the kernel and thread structure member offsets
-        size = self._target_context.read8(self._symbols["_kernel_openocd_size_t_size"])
-        LOG.debug("_kernel_openocd_size_t_size = %d", size)
+        size = self._target_context.read8(self._symbols["_kernel_thread_info_size_t_size"])
+        LOG.debug("_kernel_thread_info_size_t_size = %d", size)
         if size != 4:
-            LOG.error("Unsupported _kernel_openocd_size_t_size")
+            LOG.error("Unsupported _kernel_thread_info_size_t_size")
             return None
 
         offsets = {}
         for index, name in enumerate(self.ZEPHYR_OFFSETS):
-            offset = self._symbols["_kernel_openocd_offsets"] + index * size
+            offset = self._symbols["_kernel_thread_info_offsets"] + index * size
             offsets[name] = self._target_context.read32(offset)
             LOG.debug("%s = 0x%04x", name, offsets[name])
 


### PR DESCRIPTION
- Fixes an issue reading Zephyr thread names caused by a change in how Zephyr stores them (one less level of indirection). This issue has been present for a very long time, since Zephyr v2.0.0 (released Sep 7 2019).

- Updates the Zephyr debug symbol names to reflect that they are no longer specific to OpenOCD. The old symbols were deprecated in Zephyr v2.6.0 (released Jun 4 2021) and will be removed after two releases.

Tested with Zephyr v2.7.0 `samples/philosophers` on `frdm_k64f`

Before this PR:
```
(gdb) i thr
  Id   Target Id                                  Frame 
* 2    Thread 536872064 (Running; Priority 40)    arch_cpu_idle () at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/cpu_idle.S:107
  3    Thread 536871888 (Suspended; Priority 254) arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  4    Thread 536871712 (Suspended; Priority 255) arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  5    Thread 536871536 (Suspended; Priority 0)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  6    Thread 536871360 (Suspended; Priority 1)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  7    Thread 536871184 (Suspended; Priority 2)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  8    Thread 536871008 (Suspended; Priority 3)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
```
After:
```
(gdb) i thr
  Id   Target Id                                                  Frame 
* 2    Thread 536872064 "idle 00" (Running; Priority 40)          arch_cpu_idle () at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/cpu_idle.S:107
  3    Thread 536871888 "Philosopher 5" (Suspended; Priority 254) arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  4    Thread 536871712 "Philosopher 4" (Pending; Priority 255)   arch_swap (key=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  5    Thread 536871536 "Philosopher 3" (Suspended; Priority 0)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  6    Thread 536871360 "Philosopher 2" (Suspended; Priority 1)   arch_swap (key=key@entry=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  7    Thread 536871184 "Philosopher 1" (Pending; Priority 2)     arch_swap (key=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
  8    Thread 536871008 "Philosopher 0" (Pending; Priority 3)     arch_swap (key=0) at /home/mhelm/zephyrproject/zephyr/arch/arm/core/aarch32/swap.c:53
```