### PR TITLE
Make the use of libusb-package optional

### DIFF
--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -19,7 +19,10 @@ from array import array
 
 from time import sleep
 from usb import core, util
-import libusb_package
+try:
+    from libusb_package import find as usb_find
+except ImportError:
+    from usb.core import find as usb_find
 
 import platform
 import errno
@@ -108,7 +111,7 @@ class PicoLink(object):
         """@brief Find and return all Picoprobes """
         try:
             # Use a custom matcher to make sure the probe is a Picoprobe and accessible.
-            return [PicoLink(probe) for probe in libusb_package.find(find_all=True, custom_match=FindPicoprobe(uid))]
+            return [PicoLink(probe) for probe in usb_find(find_all=True, custom_match=FindPicoprobe(uid))]
         except core.NoBackendError:
             show_no_libusb_warning()
             return []

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -41,13 +41,17 @@ TRACE = LOG.getChild("trace")
 TRACE.setLevel(logging.CRITICAL)
 
 try:
-    import libusb_package
     import usb.core
     import usb.util
+    try:
+        from libusb_package import find as usb_find
+    except ImportError:
+        from usb.core import find as usb_find
 except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
+
 
 class PyUSB(Interface):
     """@brief CMSIS-DAP USB interface class using pyusb for the backend."""
@@ -81,7 +85,7 @@ class PyUSB(Interface):
         assert self.closed is True
 
         # Get device handle
-        dev = libusb_package.find(custom_match=FindDap(self.serial_number))
+        dev = usb_find(custom_match=FindDap(self.serial_number))
         if dev is None:
             raise DAPAccessIntf.DeviceError(f"Probe {self.serial_number} not found")
 
@@ -180,7 +184,7 @@ class PyUSB(Interface):
         """
         # find all cmsis-dap devices
         try:
-            all_devices = libusb_package.find(find_all=True, custom_match=FindDap())
+            all_devices = usb_find(find_all=True, custom_match=FindDap())
         except usb.core.NoBackendError:
             if not PyUSB.did_show_no_libusb_warning:
                 LOG.warning("CMSIS-DAPv1 probes may not be detected because no libusb library was found.")

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -40,13 +40,17 @@ TRACE = LOG.getChild("trace")
 TRACE.setLevel(logging.CRITICAL)
 
 try:
-    import libusb_package
     import usb.core
     import usb.util
+    try:
+        from libusb_package import find as usb_find
+    except ImportError:
+        from usb.core import find as usb_find
 except ImportError:
     IS_AVAILABLE = False
 else:
     IS_AVAILABLE = True
+
 
 class PyUSBv2(Interface):
     """@brief CMSIS-DAPv2 interface using pyUSB."""
@@ -95,7 +99,7 @@ class PyUSBv2(Interface):
         assert self.closed is True
 
         # Get device handle
-        dev = libusb_package.find(custom_match=HasCmsisDapv2Interface(self.serial_number))
+        dev = usb_find(custom_match=HasCmsisDapv2Interface(self.serial_number))
         if dev is None:
             raise DAPAccessIntf.DeviceError(f"Probe {self.serial_number} not found")
 
@@ -204,7 +208,7 @@ class PyUSBv2(Interface):
         """@brief Returns all the connected devices with a CMSIS-DAPv2 interface."""
         # find all cmsis-dap devices
         try:
-            all_devices = libusb_package.find(find_all=True, custom_match=HasCmsisDapv2Interface())
+            all_devices = usb_find(find_all=True, custom_match=HasCmsisDapv2Interface())
         except usb.core.NoBackendError:
             common.show_no_libusb_warning()
             return []

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -15,7 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import libusb_package
+try:
+    from libusb_package import find as usb_find
+except ImportError:
+    from usb.core import find as usb_find
 import usb.core
 import usb.util
 import logging
@@ -101,7 +104,7 @@ class STLinkUSBInterface:
     @classmethod
     def get_all_connected_devices(cls):
         try:
-            devices = libusb_package.find(find_all=True, custom_match=cls._usb_match)
+            devices = usb_find(find_all=True, custom_match=cls._usb_match)
         except usb.core.NoBackendError:
             common.show_no_libusb_warning()
             return []


### PR DESCRIPTION
pyocd/probe/*:
Attempt to import libusb-package's `find()` function, else fall back to using pyusb's `find()` function.
This allows to use pyusb by just removing the project's requirement on libusb-package, as python-pyusb and libusb
packaging go hand-in-hand on Linux distributions.

Related to #1331 