### PR TITLE
pyDAPAccess: fix search for devices without UID

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -378,8 +378,11 @@ class FindDap:
         if cmsis_dap_interface is None:
             return False
         if self._serial is not None:
-            if self._serial == "" and dev.serial_number is None:
-                return True
+            if dev.serial_number is None:
+                if self._serial == "":
+                    return True
+                if self._serial == generate_device_unique_id(dev.idProduct, dev.idVendor, dev.bus, dev.address):
+                    return True
             if self._serial != dev.serial_number:
                 return False
         return True

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -362,8 +362,11 @@ class HasCmsisDapv2Interface:
             return False
 
         if self._serial is not None:
-            if self._serial == "" and dev.serial_number is None:
-                return True
+            if dev.serial_number is None:
+                if self._serial == "":
+                    return True
+                if self._serial == generate_device_unique_id(dev.idProduct, dev.idVendor, dev.bus, dev.address):
+                    return True
             if self._serial != dev.serial_number:
                 return False
         return True


### PR DESCRIPTION
Probes without UID get a unique ID generated during device listing.
Attempting to connect to a probe with a generated UID will fail as
its synthesized UID will be compared against the device empty UID during
device search.