### PR TITLE
coresight: fix GenericMemAPTarget issues.

### DIFF
--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -18,6 +18,7 @@
 import logging
 
 from .component import CoreSightCoreComponent
+from ..core import exceptions
 from ..core.target import Target
 from ..core.core_registers import CoreRegistersIndex
 
@@ -115,22 +116,22 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
         return None
 
     def read_core_register(self, reg):
-        return DEAD_VALUE
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def read_core_register_raw(self, reg):
-        return DEAD_VALUE
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def read_core_registers_raw(self, reg_list):
-        return [DEAD_VALUE] * len(reg_list)
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def write_core_register(self, reg, data):
-        pass
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def write_core_register_raw(self, reg, data):
-        pass
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def write_core_registers_raw(self, reg_list, data_list):
-        pass
+        raise exceptions.CoreRegisterAccessError("GenericMemAPTarget does not support core register access")
 
     def set_breakpoint(self, addr, type=Target.BreakpointType.AUTO):
         return False

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Cypress Semiconductor Corporation
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 import logging
 
-from .component import CoreSightComponent
+from .component import CoreSightCoreComponent
 from ..core.target import Target
 from ..core.core_registers import CoreRegistersIndex
 
@@ -26,7 +26,7 @@ LOG = logging.getLogger(__name__)
 DEAD_VALUE = 0
 
 
-class GenericMemAPTarget(Target, CoreSightComponent):
+class GenericMemAPTarget(Target, CoreSightCoreComponent):
     """@brief This target represents ARM debug Access Port without a CPU
 
     It may be used to access the address space of the target via Access Ports
@@ -43,7 +43,7 @@ class GenericMemAPTarget(Target, CoreSightComponent):
 
     def __init__(self, session, ap, memory_map=None, core_num=0, cmpid=None, address=None):
         Target.__init__(self, session, memory_map)
-        CoreSightComponent.__init__(self, ap, cmpid, address)
+        CoreSightCoreComponent.__init__(self, ap, cmpid, address)
         self.core_number = core_num
         self.core_type = DEAD_VALUE
         self._core_registers = CoreRegistersIndex()

--- a/pyocd/coresight/generic_mem_ap.py
+++ b/pyocd/coresight/generic_mem_ap.py
@@ -71,7 +71,7 @@ class GenericMemAPTarget(Target, CoreSightCoreComponent):
         self.ap.write_memory(addr, value, transfer_size)
 
     def read_memory(self, addr, transfer_size=32, now=True):
-        return self.ap.read_memory(addr, transfer_size, True)
+        return self.ap.read_memory(addr, transfer_size, now)
 
     def read_memory_block8(self, addr, size):
         return self.ap.read_memory_block8(addr, size)


### PR DESCRIPTION
Fixes three issues with `GenericMemAPTarget`.

1. Regress caused by a superclass being changed from `CoreSightCoreComponent`. This caused `DebugContext` to raise an exception.
2. Core register methods were returning 0 to indicate they did nothing, but they should be have been modified to raise `CoreRegisterAccessError` after that exception was added.
3. `.read_memory()` didn't pass the `now` argument to the AP method, so the return type could have been different from what was expected.

cc @ihos-cypress

Fixes #1345 