### PR TITLE
setup: make pyocd-pemicro optional

### DIFF
--- a/docs/debug_probes.md
+++ b/docs/debug_probes.md
@@ -144,6 +144,23 @@ The Microchip (previously Atmel) EDBG probe firmware, at the time of this writin
 On macOS, reading command responses always times out. The probe works on other OSes, however.
 
 
+### PE Micro Cyclone and Multilink
+
+The Cyclone and Multilink debug probes from PE Micro are supported through the use of a separate probe driver
+plugin called `pyocd-pemicro`. This plugin can be installed at any time using `pip`:
+
+    pip install pyocd-pemicro
+
+It can also be installed at the same time as pyOCD by adding the `pemicro` install extra:
+
+    pip install pyocd[pemicro]
+
+Once the PE Micro probe driver is installed, Cyclone and Multilink probes connected by USB will immediately
+be available for use.
+
+Currently, PE Micro probes connected via the network are not accessible.
+
+
 ### STLink
 
 <div class="alert alert-warning">

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -2,49 +2,71 @@
 title: Installing
 ---
 
-PyOCD requires [Python](https://python.org/) 3.6 or later, and a recent version of [libusb](https://libusb.info/). It runs on macOS,
+PyOCD requires [Python](https://python.org/) 3.6 or later. It runs on macOS,
 Linux, FreeBSD, and Windows platforms.
+
+The latest pyOCD package is available [on PyPI](https://pypi.python.org/pypi/pyOCD/). The
+[GitHub releases](https://github.com/pyocd/pyOCD/releases) page details changes between versions.
 
 The latest stable version of pyOCD may be installed or upgraded via [pip](https://pip.pypa.io/en/stable/index.html)
 as follows:
 
 ```
-$ python3 -mpip install -U pyocd
+$ python3 -m pip install -U pyocd
 ```
 
 _Note: depending on your system, you may need to use `python` instead of `python3`._
 
-The latest pyOCD package is available [on PyPI](https://pypi.python.org/pypi/pyOCD/). The
-[GitHub releases](https://github.com/pyocd/pyOCD/releases) page details changes between versions.
+We also recommend using [pipx](https://pypa.github.io/pipx/) as an excellent method to install pyOCD in an isolated
+virtual Python environment.
+
+
+### PE Micro probe support
+
+Support for Cyclone and/or Multilink debug probes by [PE Micro](https://pemicro.com/) is available in a probe
+driver plug-in that is a separate package from pyOCD. There are two ways to install the PE Micro probe plug-in.
+Either substitute `pyocd[pemicro]` for `pyocd` in the commands above, or separately install `pyocd-pemicro`
+using pip.
+
+
+### Permissions issues
+
+Note that, depending on your operating system, you may run into permissions issues running these commands.
+You have a few options here:
+
+1. Install with [pipx](https://pypa.github.io/pipx/).
+2. Run the command in a [virtualenv](https://virtualenv.pypa.io/en/latest/)
+   local to a specific project working set.
+3. Under Linux, run with `sudo -H` to install pyOCD and dependencies globally. On macOS, installing with sudo
+    should never be required, although sometimes permissions/corrupted can become modified such that installing without
+    using sudo fails.
+4. Specify the `--user` option to install local to your user account.
+
+
+### Non-x86 systems
+
+For notes about installing and using on non-x86 systems such as Raspberry Pi, see the
+[relevant documentation]({% link _docs/installing_on_non_x86.md %}).
+
+
+### Development versions
 
 To install the latest prerelease version from the HEAD of the `develop` branch, you can do
 the following:
 
 ```
-$ python3 -mpip install --pre -U git+https://github.com/pyocd/pyOCD.git@develop
+$ python3 -m pip install --pre -U git+https://github.com/pyocd/pyOCD.git@develop
 ```
 
-You can also install directly from the source by cloning the git repository and running:
+You can also install directly from the source by cloning the [git repository](https://github.com/pyocd/pyOCD) and
+running this command from the working copy root directory:
 
 ```
-$ python3 -mpip install .
+$ python3 -m pip install .
 ```
 
 See the [developer's guide]({% link _docs/developers_guide.md %}) for more about setting up a development
 environment for pyOCD.
-
-Note that, depending on your operating system, you may run into permissions issues running these commands.
-You have a few options here:
-
-1. Under Linux, run with `sudo -H` to install pyOCD and dependencies globally. On macOS, installing with sudo
-    should never be required, although sometimes permissions can become modified such that installing without
-    using sudo fails.
-3. Specify the `--user` option to install local to your user account.
-4. Run the command in a [virtualenv](https://virtualenv.pypa.io/en/latest/)
-   local to a specific project working set.
-
-For notes about installing and using on non-x86 systems such as Raspberry Pi, see the
-[relevant documentation]({% link _docs/installing_on_non_x86.md %}).
 
 (Note: Installing by running `setup.py` directly is deprecated since pyOCD migrated to PEP 517 based packaging.
 In many cases it will not work at all. Installing with pip or another standards-compliant tool is the only

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ long_description_content_type = text/markdown
 maintainer = Chris Reed
 maintainer_email = chris.reed@arm.com
 url = https://github.com/pyocd/pyOCD
-keywords = embedded debugger arm gdbserver
+keywords = embedded, debug, debugger, arm, gdb, gdbserver, flash, test
 license = Apache 2.0
 classifiers =
     Development Status :: 5 - Production/Stable

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,13 +59,14 @@ install_requires =
     prettytable>=2.0,<3.0
     pyelftools<1.0
     pylink-square>=0.11.1,<1.0
-    pyocd_pemicro>=1.0.6
     pyusb>=1.2.1,<2.0
     pyyaml>=6.0,<7.0
     six>=1.15.0,<2.0
     typing-extensions>=4.0,<5.0
 
 [options.extras_require]
+pemicro =
+    pyocd_pemicro>=1.0.6
 test =
     pytest>=6.2
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     intervaltree>=3.0.2,<4.0
     libusb-package>=1.0,<2.0
     natsort>=8.0.0,<9.0
-    prettytable>=2.0,<3.0
+    prettytable>=2.0,<4.0
     pyelftools<1.0
     pylink-square>=0.11.1,<1.0
     pyusb>=1.2.1,<2.0


### PR DESCRIPTION
The main purpose of this PR is to move `pyocd-pemicro` to an optional extra install. There are two reasons for this:

1. The PEMicro shared libraries contained in the `pypemicro` Python package are closed source. That's an issue for a number of Linux distros. (The built-in Segger J-Link probe driver also uses a closed source shared library at runtime, but that library is not contained in or installed via a Python package.)

2. For some reason, the PEMicro shared libraries cause Microsoft PowerShell to crash when pyocd exits. See #1129.

Making `pyocd-pemicro` an install extra means that installing it is as simple `pip install pyocd[pemicro]`. Installation documentation has been updated to note this, and a section added to the debug probes documentation.

Other included changes: allow prettytable version 3.x; fix the keywords metadata value.

cc @Gargy007 @dvzrv 

Fixes #1319 
