### PR TITLE
list subcmd: set default log level to error

### DIFF
--- a/pyocd/subcommands/list_cmd.py
+++ b/pyocd/subcommands/list_cmd.py
@@ -32,6 +32,7 @@ class ListSubcommand(SubcommandBase):
 
     NAMES = ['list']
     HELP = "List information about probes, targets, or boards."
+    DEFAULT_LOG_LEVEL = logging.ERROR
 
     ## @brief Map to convert plugin groups to user friendly names.
     PLUGIN_GROUP_NAMES = {


### PR DESCRIPTION
This patch prevents the output of "Target type is cortex_m" log messages when listing builtin targets via `pyocd list --targets`