### PR TITLE
rtos: zephyr: interpret thread priority as signed 8-bit integer

### DIFF
--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2016-2020 Arm Limited
 # Copyright (c) 2022 Intel Corporation
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from .provider import (TargetThread, ThreadProvider)
 from .common import (read_c_string, HandlerModeThread)
 from ..core import exceptions
@@ -22,7 +25,7 @@ from ..core.target import Target
 from ..core.plugin import Plugin
 from ..debug.context import DebugContext
 from ..coresight.cortex_m_core_registers import index_for_reg
-import logging
+from ..utility.mask import twos_complement
 
 # Create a logger for this module.
 LOG = logging.getLogger(__name__)
@@ -189,7 +192,7 @@ class ZephyrThread(TargetThread):
 
     def update_info(self):
         try:
-            self._priority = self._target_context.read8(self._base + self._offsets["t_prio"])
+            self._priority = twos_complement(self._target_context.read8(self._base + self._offsets["t_prio"]), width=8)
             self._state = self._target_context.read8(self._base + self._offsets["t_state"])
 
             if self._provider.version > 0:

--- a/pyocd/utility/mask.py
+++ b/pyocd/utility/mask.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -166,3 +167,18 @@ def parity32_high(n: int) -> int:
     n ^= n >> 4
     n &= 0xf
     return (0xD32C0000 << n) & (1 << 32)
+
+def twos_complement(value: int, width: int) -> int:
+    """@brief Convert an unsigned int to signed.
+
+    @param value Signed value as an unsigned int.
+    @param width Bit width of _value_.
+    @return Signed version of _value_.
+    """
+    signmask = 1 << (width - 1)
+    if (value & signmask) == 0:
+        # Mask off sign bit.
+        return value & (signmask - 1)
+    else:
+        # Two's complement.
+        return -bit_invert(value, width - 1) - 1


### PR DESCRIPTION
This patch also adds a `twos_complement()` utility function.