### PR TITLE
CMSIS-DAP v2.1 target and board name support

### DIFF
--- a/docs/debug_probes.md
+++ b/docs/debug_probes.md
@@ -20,11 +20,18 @@ these types of debug probes:
  Plug-in Name        | Debug Probe Type
 ---------------------|--------------------
 `cmsisdap`           | [CMSIS-DAP](http://www.keil.com/pack/doc/CMSIS/DAP/html/index.html)
-`pemicro`            | [PE Micro](https://pemicro.com/) Cyclone and Multilink
 `picoprobe`          | Raspberry Pi [Picoprobe](https://github.com/raspberrypi/picoprobe)
 `jlink`              | [SEGGER](https://segger.com/) [J-Link](https://www.segger.com/products/debug-trace-probes/)
 `stlink`             | [STMicro](https://st.com/) [STLinkV2](https://www.st.com/en/development-tools/st-link-v2.html) and [STLinkV3](https://www.st.com/en/development-tools/stlink-v3set.html)
 `remote`             | pyOCD [remote debug probe client]({% link _docs/remote_probe_access.md %})
+
+Additional debug probe plugins are available as Python packages through [PyPI](https://pypi.python.org), and
+can be installed with pip:
+
+ Plug-in Name   | Package           | Debug Probe Type
+----------------|-------------------|--------------------
+`pemicro`       | pyocd-pemicro     | [PE Micro](https://pemicro.com/) Cyclone and Multilink.
+
 
 
 ## Unique IDs
@@ -46,6 +53,7 @@ Certain types of on-board debug probes can report the type of the target to whic
 
 Debug probes that support automatic target type reporting:
 
+- CMSIS-DAP probes supporting v2.1 of the protocol and reporting target type info
 - CMSIS-DAP probes based on the DAPLink firmware
 - STLinkV2-1 and STLinkV3
 
@@ -54,28 +62,47 @@ Debug probes that support automatic target type reporting:
 
 To view the connected probes and their unique IDs, run `pyocd list`. This command will produce output looking like this:
 
-      #   Probe                             Unique ID
-    ------------------------------------------------------------------------------------------
-      0   Arm LPC55xx DAPLink CMSIS-DAP     000000803f7099a85fdf51158d5dfcaa6102ef474c504355
-      1   Arm Musca-B1 [musca_b1]           500700001c16fcd400000000000000000000000097969902
+      #   Probe/Board                       Unique ID                                          Target
+    --------------------------------------------------------------------------------------------------------------------
+      0   Arm DAPLink CMSIS-DAP             02400b0129164e4500440012706e0007f301000097969900   ✔︎ k64f
+          NXP                               FRDM-K64F
 
-For those debug probes that support automatic target type reporting, the default target type is visible in brackets
-next to the probe's name. In addition, the name of the board is printed instead of the type of debug probe. This can be
-seen in the example output above for the "Arm Musca-B1" board, which has a default target type of `musca_b1`.
+      1   STLINK-V3                         002500074741500420383733                           ✖︎ stm32u585aiix
+          B-U585I-IOT02A
 
-If no target type appears in brackets, as can be seen above for the "Arm LPC55xx DAPLink CMSIS-DAP" probe (because it
-is a standalone probe), it means the debug probe does not report the type of its connected target. In this
-case, the target type must be manually specified either on the command line with the `-t` / `--target`
-argument, or by setting the `target_override` session option (possibly in a config file).
+      2   STM32 STLink                      066EFF555051897267233656                           ✔︎ stm32l475xg
+          DISCO-L475VG-IOT01A
 
-Note that the printed list includes only those probes that pyOCD can actively query for, which currently means only USB
-based probes.
+      3   Segger J-Link OB-K22-NordicSemi   960177309                                          n/a
+
+
+The output is divided into columns for the probe number, probe name, unique ID, and default target type name.
+Probes that have additional board identification will have a second row with the board name and possibly board
+vendor.
+
+The "Target" column shows the debug probe's default target type for debug probes that support automatic target
+type reporting. Whether that target type is installed and available for use is shown by a check or "X" mark
+before the target type name (and in different colours, if colour output is enabled). If an "X" mark is
+displayed, see the [target support documentation]({% link _docs/target_support.md %}) for information about
+how you can install that the target type.
+
+For debug probes that do not support automatic target type reporting, the Target column will simply display
+"n/a". This can be seen above for the "Segger J-Link OB-K22-NordicSemi" probe. The target type must be
+specified manually in such cases, otherwise full functionality, such as flash programming, will not be
+available.
+
+In any case, whether required because the probe doesn't have a default, or to override the default, the target
+type can be specified either on the command line with the `-t` / `--target` argument, or by setting the
+`target_override` session option (e.g., in a [config file]({% link _docs/configuration.md#config_file %})).
+
+Note that the printed list includes only those probes that pyOCD can actively query for, which currently means
+only USB based probes.
 
 
 ## Selecting the debug probe
 
-All of the pyOCD subcommands that communicate with a target require the user to either implicitly or explicitly
-specify a debug probe.
+All of the pyOCD subcommands that communicate with a target require the user to either implicitly or
+explicitly specify a debug probe.
 
 There are three ways the debug probe is selected:
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -54,22 +54,6 @@ Whether to perform a chip erase or sector erases when programming flash. The val
 'auto', 'sector', or 'chip'.
 </td></tr>
 
-<tr><td>cmsis_dap.deferred_transfers</td>
-<td>bool</td>
-<td>True</td>
-<td>
-Whether to use deferred transfers in the CMSIS-DAP probe backend. By disabling deferred transfers,
-all writes take effect immediately. However, performance is negatively affected.
-</td></tr>
-
-<tr><td>cmsis_dap.limit_packets</td>
-<td>bool</td>
-<td>False</td>
-<td>
-Restrict CMSIS-DAP backend to using a single in-flight command at a time. This is useful on some systems
-where USB is problematic, in particular virtual machines.
-</td></tr>
-
 <tr><td>cmsis_dap.prefer_v1</td>
 <td>bool</td>
 <td>False</td>
@@ -538,6 +522,32 @@ The source letters are:
 <td>
 When set to True, XPSR and CONTROL registers will have their respective bitfields defined for
 presentation in gdb.
+</td></tr>
+
+</table>
+
+## CMSIS-DAP probe options
+
+These session options are available when the CMSIS-DAP debug probe plugin is active.
+
+<table>
+
+<tr><th>Option Name</th><th>Type</th><th>Default</th><th>Description</th></tr>
+
+<tr><td>cmsis_dap.deferred_transfers</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Whether to use deferred transfers in the CMSIS-DAP probe backend. By disabling deferred transfers,
+all writes take effect immediately. However, performance is negatively affected.
+</td></tr>
+
+<tr><td>cmsis_dap.limit_packets</td>
+<td>bool</td>
+<td>False</td>
+<td>
+Restrict CMSIS-DAP backend to using a single in-flight command at a time. This is useful on some systems
+where USB is problematic, in particular virtual machines.
 </td></tr>
 
 </table>

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -25,17 +25,20 @@ from ..utility.graph import GraphNode
 
 if TYPE_CHECKING:
     from ..core.session import Session
+    from .board_ids import BoardInfo
 
 LOG = logging.getLogger(__name__)
 
 class Board(GraphNode):
     """@brief Represents the board containing the target and associated components.
 
-    The board is the root of the runtime object graph.
+    The board is the root of the runtime object graph. Responsible for creating the Target instance
+    corresponding to the indicated target type name.
     """
     def __init__(self,
             session: "Session",
             target: Optional[str] = None,
+            board_info: Optional["BoardInfo"] = None,
             ) -> None:
         """@brief Constructor
 
@@ -45,7 +48,7 @@ class Board(GraphNode):
 
         1. `target` parameter
         2. `target_override` session option
-        3. `soft_target` parameter
+        3. `board_info.target` parameter
         4. Last resort `cortex_m` target type. If this type is used, a warning is printed (unless the
             `warning.cortex_m_default` option is disabled).
 
@@ -53,12 +56,18 @@ class Board(GraphNode):
         @param session The session instance that owns us.
         @param target Target type name to use. If this parameter is set, it overrides all other sources of the
             target type.
+        @param board_info A `BoardInfo` object with various descriptive information about the board. The
+            `target` attribute is used as a secondary target type name, with lower precedence than the
+            `target_override` session option.
         """
         super().__init__()
 
         # Use the session option if no target type was given to us.
         if target is None:
-            target = session.options.get('target_override')
+            if session.options.is_set('target_override'):
+                target = session.options.get('target_override')
+            elif board_info:
+                target = board_info.target
 
         # As a last resort, default the target to 'cortex_m'.
         if target is None:
@@ -83,7 +92,9 @@ class Board(GraphNode):
 
         self._session = session
         self._target_type = target
-        self._test_binary = session.options.get('test_binary')
+        self._info = board_info
+        self._test_binary = board_info.binary if (board_info and board_info.binary) \
+                else session.options.get('test_binary')
         self._delegate = None
         self._inited = False
 
@@ -107,6 +118,10 @@ class Board(GraphNode):
 
         # Tell the user what target type is selected.
         LOG.info("Target type is %s", self._target_type)
+
+        self._name = board_info.name if (board_info and board_info.name) \
+                else f"Generic {self.target_type} board"
+        self._vendor = board_info.vendor if (board_info and board_info.vendor) else ""
 
         self.add_child(self.target)
 
@@ -170,11 +185,17 @@ class Board(GraphNode):
         return self._test_binary
 
     @property
-    def name(self) -> str:
-        return "generic"
+    def vendor(self) -> str:
+        """@brief The board's vendor name."""
+        return self._vendor
 
     @property
+    def name(self) -> str:
+        """@brief The board's name."""
+        return self._name
+
+    # Deprecated property.
+    @property
     def description(self) -> str:
-        assert self.session.probe
-        return "Generic board via " + self.session.probe.vendor_name + " " \
-                + self.session.probe.product_name + " [" + self.target_type + "]"
+        """@brief Return description of the board."""
+        return self.name

--- a/pyocd/board/board_ids.py
+++ b/pyocd/board/board_ids.py
@@ -19,7 +19,7 @@ from typing import (NamedTuple, Optional)
 
 class BoardInfo(NamedTuple):
     name: str
-    target: str
+    target: Optional[str] = None
     binary: Optional[str] = None
     vendor: Optional[str] = None
 

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -127,7 +127,7 @@ class ConnectHelper:
     def choose_probe(
             blocking: bool = True,
             return_first: bool = False,
-            unique_id: str = None
+            unique_id: Optional[str] = None
             ) -> Optional["DebugProbe"]:
         """@brief Return a debug probe possibly chosen by the user.
 
@@ -178,8 +178,8 @@ class ConnectHelper:
 
         # Ask user to select boards if there is more than 1 left
         if len(allProbes) > 1:
-            ch = 0
             ConnectHelper._print_probe_list(allProbes)
+            ch = 0
             while True:
                 print(colorama.Style.RESET_ALL)
                 print("Enter the number of the debug probe or 'q' to quit", end='')

--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf8 -*-
 # pyOCD debugger
 # Copyright (c) 2018-2019 Arm Limited
 # Copyright (c) 2021-2022 Chris Reed
@@ -20,6 +21,7 @@ import colorama
 import prettytable
 from typing import (Any, List, Mapping, Optional, Sequence, TYPE_CHECKING)
 
+from . import exceptions
 from .session import Session
 from ..probe.aggregator import DebugProbeAggregator
 
@@ -264,7 +266,12 @@ class ConnectHelper:
 
     @staticmethod
     def _print_probe_list(probes: Sequence["DebugProbe"]) -> None:
-        pt = prettytable.PrettyTable(["#", "Probe", "Unique ID"])
+        from ..target import TARGET
+        from ..target.pack.pack_target import is_pack_target_available
+
+        dim_dash = (colorama.Style.DIM + colorama.Fore.WHITE + "n/a" + colorama.Style.RESET_ALL)
+
+        pt = prettytable.PrettyTable(["#", "Probe/Board", "Unique ID", "Target"])
         pt.align = 'l'
         pt.header = True
         pt.border = True
@@ -272,10 +279,69 @@ class ConnectHelper:
         pt.vrules = prettytable.NONE
 
         for index, probe in enumerate(probes):
-            pt.add_row([
-                colorama.Fore.YELLOW + str(index),
-                colorama.Fore.GREEN + probe.description,
-                colorama.Fore.CYAN + probe.unique_id,
-                ])
+            try:
+                board_info = probe.associated_board_info
+                target_type_name = board_info.target if board_info else None
+
+                if target_type_name is not None:
+                    target_type_name = target_type_name.lower()
+                    has_target = ((target_type_name in TARGET)
+                                or is_pack_target_available(target_type_name, Session.get_current()))
+                    target_mark = ("✖︎", "✔︎")[has_target]
+                    target_color = colorama.Fore.LIGHTGREEN_EX if has_target else colorama.Fore.RED
+                    target_type_desc = f"{target_color}{target_mark} {target_type_name}"
+                else:
+                    target_type_desc = dim_dash
+
+                pt.add_row([
+                    colorama.Fore.MAGENTA + str(index),
+                    colorama.Fore.GREEN + probe.description,
+                    colorama.Fore.CYAN + probe.unique_id,
+                    target_type_desc,
+                    ])
+                if board_info:
+                    pt.add_row([
+                        "",
+                        (colorama.Fore.YELLOW + (board_info.vendor or board_info.name)) if board_info else dim_dash,
+                        (colorama.Fore.YELLOW + board_info.name) if (board_info and board_info.vendor) else "",
+                        "",
+                        ])
+            except exceptions.Error as err:
+                # Trap errors to report the probe as inaccessible. Failing probes shouldn't prevent use
+                # of other working probes.
+
+                # Read the product name and unique IDs in exception handlers so we can still print
+                # the probe listing even if getting these properties fails.
+                try:
+                    product_name = probe.product_name
+                except exceptions.Error:
+                    product_name = "Error accessing probe"
+
+                try:
+                    uid = probe.unique_id
+                except exceptions.Error:
+                    uid = "Unknown"
+
+                pt.add_row([
+                    colorama.Style.DIM + colorama.Fore.MAGENTA + str(index) + colorama.Style.RESET_ALL,
+                    colorama.Style.BRIGHT + colorama.Fore.RED + product_name + colorama.Style.RESET_ALL,
+                    colorama.Style.DIM + colorama.Fore.WHITE + uid + colorama.Style.RESET_ALL,
+                    dim_dash,
+                    ])
+                pt.add_row([
+                    "",
+                    colorama.Fore.RED + type(err).__name__,
+                    colorama.Fore.RED + str(err),
+                    "",
+                    ])
+
+            # Add empty row between probes.
+            if index < (len(probes) - 1):
+                pt.add_row([
+                    "",
+                    "",
+                    "",
+                    "",
+                    ])
         print(pt)
         print(colorama.Style.RESET_ALL, end='')

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -41,10 +41,6 @@ BUILTIN_OPTIONS = [
     OptionInfo('chip_erase', str, "sector",
         "Whether to perform a chip erase or sector erases when programming flash. The value must be"
         " one of \"auto\", \"sector\", or \"chip\"."),
-    OptionInfo('cmsis_dap.deferred_transfers', bool, True,
-        "Whether the CMSIS-DAP probe backend will use deferred transfers for improved performance."),
-    OptionInfo('cmsis_dap.limit_packets', bool, False,
-        "Restrict CMSIS-DAP backend to using a single in-flight command at a time."),
     OptionInfo('cmsis_dap.prefer_v1', bool, False,
         "If a device provides both CMSIS-DAP v1 and v2 interfaces, use the v1 interface in preference of v2. "
         "Normal behaviour is to prefer the v2 interface. This option is primarily intended for testing."),

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -25,6 +25,7 @@ from pyocd.probe.pydapaccess.dap_access_api import DAPAccessIntf
 from .debug_probe import DebugProbe
 from ..core import exceptions
 from ..core.plugin import Plugin
+from ..core.options import OptionInfo
 from .pydapaccess import DAPAccess
 from ..board.mbed_board import MbedBoard
 from ..board.board_ids import BOARD_ID_TO_INFO
@@ -550,3 +551,13 @@ class CMSISDAPProbePlugin(Plugin):
     @property
     def description(self):
         return "CMSIS-DAP debug probe"
+
+    @property
+    def options(self):
+        """@brief Returns CMSIS-DAP probe options."""
+        return [
+            OptionInfo('cmsis_dap.deferred_transfers', bool, True,
+                "Whether the CMSIS-DAP probe backend will use deferred transfers for improved performance."),
+            OptionInfo('cmsis_dap.limit_packets', bool, False,
+                "Restrict CMSIS-DAP backend to using a single in-flight command at a time."),
+            ]

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -85,7 +85,11 @@ class CMSISDAPProbe(DebugProbe):
     DAPLINK_VIDPID = (0x0d28, 0x0204)
 
     @classmethod
-    def get_all_connected_probes(cls, unique_id: str = None, is_explicit: bool = False) -> Sequence["DebugProbe"]:
+    def get_all_connected_probes(
+                cls,
+                unique_id: Optional[str] = None,
+                is_explicit: bool = False
+            ) -> Sequence["DebugProbe"]:
         try:
             return [cls(dev) for dev in DAPAccess.get_connected_devices()]
         except DAPAccess.Error as exc:

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,9 +18,7 @@
 from time import sleep
 import logging
 from typing import (Callable, Collection, Dict, List, Optional, overload, Sequence, Set, TYPE_CHECKING, Tuple, Union)
-from typing_extensions import Literal
-
-from pyocd.probe.pydapaccess.dap_access_api import DAPAccessIntf
+from typing_extensions import (Literal, Protocol)
 
 from .debug_probe import DebugProbe
 from ..core import exceptions
@@ -28,14 +26,60 @@ from ..core.plugin import Plugin
 from ..core.options import OptionInfo
 from .pydapaccess import DAPAccess
 from ..board.mbed_board import MbedBoard
-from ..board.board_ids import BOARD_ID_TO_INFO
+from ..board.board_ids import (BoardInfo, BOARD_ID_TO_INFO)
 
 if TYPE_CHECKING:
+    from types import TracebackType
     from ..board.board import Board
 
 LOG = logging.getLogger(__name__)
 TRACE = LOG.getChild("trace")
 TRACE.setLevel(logging.CRITICAL)
+
+class _OpenableProtocol(Protocol):
+    @property
+    def is_open(self) -> bool:
+        ...
+
+    def open(self) -> None:
+        ...
+
+    def close(self) -> None:
+        ...
+
+class _TemporaryOpen:
+    """@brief Context manager to ensure the device is open for a short time."""
+
+    def __init__(self, device: _OpenableProtocol, suppress_exceptions: bool = True) -> None:
+        self._device = device
+        self._suppress_exceptions = suppress_exceptions
+        self._did_open_link: bool = False
+
+    def __enter__(self) -> "_TemporaryOpen":
+        try:
+            # Temporarily open the device if not already opened.
+            if not self._device.is_open:
+                self._device.open()
+                self._did_open_link = True
+        except (DAPAccess.Error, exceptions.Error) as err:
+            if not self._suppress_exceptions:
+                raise
+            else:
+                LOG.debug("suppressing error from attempting to open device %s: %s", self._device, err)
+
+        return self
+
+    def __exit__(self, exc_type: Optional[type], exc_value: Optional[Exception], traceback: Optional["TracebackType"]) -> bool:
+        # Close the device if we had to open it.
+        if self._did_open_link:
+            self._device.close()
+
+        # Check for and possibly suppress an exception.
+        if (exc_type is not None) and issubclass(exc_type, exceptions.Error):
+            if self._suppress_exceptions:
+                return True
+
+        return False
 
 class CMSISDAPProbe(DebugProbe):
     """@brief Wraps a pydapaccess link as a DebugProbe.
@@ -107,8 +151,8 @@ class CMSISDAPProbe(DebugProbe):
         except DAPAccess.Error as exc:
             raise cls._convert_exception(exc) from exc
 
-    def __init__(self, device: DAPAccessIntf) -> None:
-        super(CMSISDAPProbe, self).__init__()
+    def __init__(self, device: DAPAccess) -> None:
+        super().__init__()
         self._link = device
         self._supported_protocols: List[DebugProbe.Protocol] = []
         self._protocol: Optional[DebugProbe.Protocol] = None
@@ -132,13 +176,7 @@ class CMSISDAPProbe(DebugProbe):
 
     @property
     def description(self) -> str:
-        try:
-            # self.board_id may be None.
-            board_info = BOARD_ID_TO_INFO[self.board_id]
-        except KeyError:
-            return self.vendor_name + " " + self.product_name
-        else:
-            return "{0} [{1}]".format(board_info.name, board_info.target)
+        return self.vendor_name + " " + self.product_name
 
     @property
     def vendor_name(self) -> str:
@@ -169,18 +207,52 @@ class CMSISDAPProbe(DebugProbe):
     def capabilities(self) -> Set[DebugProbe.Capability]:
         return self._caps
 
+    @property
+    def associated_board_info(self) -> Optional["BoardInfo"]:
+        """@brief Info about the board associated with this probe, if known."""
+        # Get internal board info if available.
+        if (self.board_id is not None) and (self.board_id in BOARD_ID_TO_INFO):
+            info = BOARD_ID_TO_INFO[self.board_id]
+        else:
+            info = None
+
+        with _TemporaryOpen(self._link):
+            if self._link.supports_board_and_target_names:
+                # Get v2.1 board and target info values.
+                vendor, board = self._link.board_names
+                _, part_number = self._link.target_names
+
+                # Use the target from internal board info in preference, so built-in targets take
+                # precedence over DFPs (because the probe will only report part numbers from DFPs).
+                if info and info.target:
+                    target_device_name = info.target
+                elif part_number:
+                    target_device_name = part_number.lower().replace("-", "_")
+                else:
+                    target_device_name = None
+
+                # If we have either target type or board then construct the board info.
+                if target_device_name or board:
+                    # Vendor can be None, but the BoardInfo must have a valid name.
+                    if not board:
+                        assert target_device_name
+                        board = "Generic " + (part_number or target_device_name)
+
+                    info = BoardInfo(name=board, target=target_device_name, vendor=vendor)
+
+        return info
+
     def create_associated_board(self) -> Optional["Board"]:
         assert self.session is not None
 
-        # Only support associated Mbed boards for DAPLink firmware. We can't assume other
-        # CMSIS-DAP firmware is using the same serial number format, so we cannot reliably
-        # extract the board ID.
-        if self.board_id is not None:
-            return MbedBoard(self.session, board_id=self.board_id)
-        else:
-            return None
+        board_info = self.associated_board_info
+        if self.board_id or board_info:
+            return MbedBoard(self.session, board_info=board_info, board_id=self.board_id)
+        return None
 
     def open(self) -> None:
+        if self._is_open:
+            return
         assert self.session
         try:
             TRACE.debug("trace: open")
@@ -189,13 +261,28 @@ class CMSISDAPProbe(DebugProbe):
             self._is_open = True
             self._link.set_deferred_transfer(self.session.options.get('cmsis_dap.deferred_transfers'))
 
+            if self._link.supports_board_and_target_names:
+                board_names = self._link.board_names
+                target_names = self._link.target_names
+                if board_names != (None, None):
+                    LOG.debug("Board: %s %s", board_names[0] or "(no vendor)", board_names[1] or "(no name)")
+                if target_names != (None, None):
+                    LOG.debug("Target: %s %s", target_names[0] or "(no vendor)", target_names[1] or "(no name)")
+
             # Read CMSIS-DAP capabilities
-            self._capabilities = self._link.identify(DAPAccess.ID.CAPABILITIES)
+            caps_value = self._link.identify(DAPAccess.ID.CAPABILITIES)
+            if not isinstance(caps_value, int):
+                raise exceptions.ProbeError(f"probe {self.unique_id} returned invalid capabilities")
+            self._capabilities = caps_value
             self._supported_protocols = [DebugProbe.Protocol.DEFAULT]
             if self._capabilities & self.SWD_CAPABILITY_MASK:
                 self._supported_protocols.append(DebugProbe.Protocol.SWD)
             if self._capabilities & self.JTAG_CAPABILITY_MASK:
                 self._supported_protocols.append(DebugProbe.Protocol.JTAG)
+            # Warn if neither SWD nor JTAG is supported.
+            if (self._capabilities & (self.SWD_CAPABILITY_MASK | self.JTAG_CAPABILITY_MASK)) == 0:
+                LOG.warning("probe %s reported capabilities indicating it supports neither SWD nor JTAG",
+                        self.unique_id)
 
             self._caps = {
                 self.Capability.SWJ_SEQUENCE,
@@ -211,6 +298,8 @@ class CMSISDAPProbe(DebugProbe):
             raise self._convert_exception(exc) from exc
 
     def close(self) -> None:
+        if not self._is_open:
+            return
         try:
             TRACE.debug("trace: close")
 
@@ -240,8 +329,9 @@ class CMSISDAPProbe(DebugProbe):
             raise self._convert_exception(exc) from exc
 
         # Read the current mode and save it.
-        actualMode = self._link.get_swj_mode()
-        self._protocol = self._PORT_TO_PROTOCOL[actualMode]
+        actual_mode = self._link.get_swj_mode()
+        assert actual_mode is not None
+        self._protocol = self._PORT_TO_PROTOCOL[actual_mode]
 
     def swj_sequence(self, length: int, bits: int) -> None:
         TRACE.debug("trace: swj_sequence(length=%i, bits=%x)", length, bits)
@@ -488,7 +578,7 @@ class CMSISDAPProbe(DebugProbe):
         try:
             self._link.reg_write_repeat(len(values), ap_reg, values, dap_index=0)
             TRACE.debug("trace: write_ap_multi(addr=%#010x, (%i)[%s])", addr, len(values),
-                    ", ".join(["%#010x" % v for v in values]))
+                   ", ".join(["%#010x" % v for v in values]))
         except DAPAccess.Error as exc:
             TRACE.debug("trace: write_ap_multi(addr=%#010x, (%i)[%s]) -> error(%s)", addr, len(values),
                     ", ".join(["%#010x" % v for v in values]), exc)

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from ..core.session import Session
     from ..core.memory_interface import MemoryInterface
     from ..board.board import Board
+    from ..board.board_ids import BoardInfo
     from ..coresight.ap import APAddressBase
 
 class DebugProbe:
@@ -222,6 +223,11 @@ class DebugProbe:
         """
         raise NotImplementedError()
 
+    @property
+    def associated_board_info(self) -> Optional["BoardInfo"]:
+        """@brief Info about the board associated with this probe, if known."""
+        return None
+
     def create_associated_board(self) -> Optional["Board"]:
         """@brief Create a board instance representing the board of which the probe is a component.
 
@@ -231,7 +237,6 @@ class DebugProbe:
         does not have an associated board, then this method returns None.
 
         @param self
-        @param session Session to pass to the board upon construction.
         """
         return None
 

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -115,7 +115,11 @@ class DebugProbe:
         JTAG_SEQUENCE = 7
 
     @classmethod
-    def get_all_connected_probes(cls, unique_id: str = None, is_explicit: bool = False) -> Sequence["DebugProbe"]:
+    def get_all_connected_probes(
+                cls,
+                unique_id: Optional[str] = None,
+                is_explicit: bool = False
+            ) -> Sequence["DebugProbe"]:
         """@brief Returns a list of DebugProbe instances.
 
         To filter the list of returned probes, the `unique_id` parameter may be set to a string with a full or

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018-2019 Arm Limited
+# Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,7 @@
 
 
 from enum import Enum
-from typing import (Tuple, Sequence)
+from typing import (Optional, Tuple, Sequence)
 
 class DAPAccessIntf(object):
 
@@ -111,6 +112,14 @@ class DAPAccessIntf(object):
         raise NotImplementedError()
 
     @property
+    def firmware_version(self) -> Optional[str]:
+        """@brief A string of the product firmware version, or None.
+
+        Only probes supporting CMSIS-DAP protocol v2.1 or later can return their firmware version.
+        """
+        raise NotImplementedError()
+
+    @property
     def vendor_name(self):
         raise NotImplementedError()
 
@@ -124,11 +133,36 @@ class DAPAccessIntf(object):
         raise NotImplementedError()
 
     @property
+    def board_names(self) -> Tuple[Optional[str], Optional[str]]:
+        """@brief Bi-tuple of CMSIS-DAP v2.1 board vendor name and product name.
+
+        If the CMSIS-DAP protocol does not support reading board names from DAP_Info, a pair of
+        None will be returned. If either of the names are not returned from the device, then None
+        is substituted.
+        """
+        raise NotImplementedError()
+
+    @property
+    def target_names(self) -> Tuple[Optional[str], Optional[str]]:
+        """@brief Bituple of CMSIS-DAP v2.1 target vendor name and part number.
+
+        If the CMSIS-DAP protocol does not support reading target names from DAP_Info, a pair of
+        None will be returned. If either of the names are not returned from the device, then None
+        is substituted.
+        """
+        raise NotImplementedError()
+
+    @property
     def has_swd_sequence(self):
         """@brief Boolean indicating whether the DAP_SWD_Sequence command is supported.
 
         This property is only valid after the probe is opened. Until then, the value will be None.
         """
+        raise NotImplementedError()
+
+    @property
+    def supports_board_and_target_names(self) -> bool:
+        """@brief Boolean of whether board_names and target_names are supported."""
         raise NotImplementedError()
 
     @property

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -131,6 +131,11 @@ class DAPAccessIntf(object):
         """
         raise NotImplementedError()
 
+    @property
+    def is_open(self) -> bool:
+        """@brief Whether the probe's USB interface is open."""
+        raise NotImplementedError()
+
     # ------------------------------------------- #
     #          Host control functions
     # ------------------------------------------- #

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -618,8 +618,43 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
         return self._vidpid
 
     @property
+    def board_names(self) -> Tuple[Optional[str], Optional[str]]:
+        """@brief Bi-tuple of CMSIS-DAP v2.1 board vendor name and product name.
+
+        If the CMSIS-DAP protocol does not support reading board names from DAP_Info, a pair of
+        None will be returned. If either of the names are not returned from the device, then None
+        is substituted.
+        """
+        if not self.supports_board_and_target_names:
+            return (None, None)
+        vendor = self._protocol.dap_info(self.ID.BOARD_VENDOR)
+        name = self._protocol.dap_info(self.ID.BOARD_NAME)
+        return (vendor, name)
+
+    @property
+    def target_names(self) -> Tuple[Optional[str], Optional[str]]:
+        """@brief Bituple of CMSIS-DAP v2.1 target vendor name and part number.
+
+        If the CMSIS-DAP protocol does not support reading target names from DAP_Info, a pair of
+        None will be returned. If either of the names are not returned from the device, then None
+        is substituted.
+        """
+        if not self.supports_board_and_target_names:
+            return (None, None)
+        vendor = self._protocol.dap_info(self.ID.DEVICE_VENDOR)
+        name = self._protocol.dap_info(self.ID.DEVICE_NAME)
+        return (vendor, name)
+
+    @property
     def has_swd_sequence(self):
         return self._cmsis_dap_version >= CMSISDAPVersion.V1_2_0
+
+    @property
+    def supports_board_and_target_names(self) -> bool:
+        """@brief Boolean of whether board_names and target_names are supported."""
+        return ((self._cmsis_dap_version >= CMSISDAPVersion.V2_1_0)
+                or ((self._cmsis_dap_version >= CMSISDAPVersion.V1_3_0)
+                    and (self._cmsis_dap_version < CMSISDAPVersion.V2_0_0)))
 
     def lock(self):
         """@brief Lock the interface."""

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -202,4 +202,10 @@ class HidApiUSB(Interface):
             self.read_sem.release()
             self.thread.join()
             self.thread = None
+
+            # Clear closed event, recreate read sem and receiveed data deque so they
+            # are cleared and ready if we're re-opened.
+            self.closed_event.clear()
+            self.read_sem = threading.Semaphore(0)
+            self.received_data = collections.deque()
         self.device.close()

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 from time import sleep
-from typing import (Any, Callable, List, Optional, Sequence, Union)
+from typing import (Any, Callable, List, Optional, Sequence, Union, TYPE_CHECKING)
 
 from .debug_probe import DebugProbe
 from ..core.memory_interface import MemoryInterface
@@ -29,6 +29,9 @@ from .stlink.detect.factory import create_mbed_detector
 from ..board.mbed_board import MbedBoard
 from ..board.board_ids import BOARD_ID_TO_INFO
 from ..utility import conversion
+
+if TYPE_CHECKING:
+    from ..board.board_ids import BoardInfo
 
 class StlinkProbe(DebugProbe):
     """@brief Wraps an STLink as a DebugProbe."""
@@ -79,15 +82,7 @@ class StlinkProbe(DebugProbe):
 
     @property
     def description(self) -> str:
-        if self._board_id is None:
-            return self.product_name
-
-        try:
-            board_info = BOARD_ID_TO_INFO[self._board_id]
-        except KeyError:
-            return self.product_name
-        else:
-            return "{0} [{1}]".format(board_info.name, board_info.target)
+        return self.product_name
 
     @property
     def vendor_name(self):
@@ -117,10 +112,18 @@ class StlinkProbe(DebugProbe):
     def capabilities(self):
         return self._caps
 
+    @property
+    def associated_board_info(self) -> Optional["BoardInfo"]:
+        if (self._board_id is not None) and (self._board_id in BOARD_ID_TO_INFO):
+            return BOARD_ID_TO_INFO[self._board_id]
+        else:
+            return None
+
     def create_associated_board(self):
         assert self.session is not None
-        if self._board_id is not None:
-            return MbedBoard(self.session, board_id=self._board_id)
+        board_info = self.associated_board_info
+        if board_info or self._board_id:
+            return MbedBoard(self.session, board_info=board_info, board_id=self._board_id)
         else:
             return None
 

--- a/pyocd/utility/color_log.py
+++ b/pyocd/utility/color_log.py
@@ -112,13 +112,16 @@ def build_color_logger(
     @param level Log level of the root logger.
     @param color_setting One of 'auto', 'always', or 'never'. The default 'auto' enables color if `is_tty` is True.
     @param stream The stream to which the log will be output. The default is stderr.
-    @param is_tty Whether the output stream is a tty. Affects the 'auto' color_setting. If not provided, the `isatty()`
-        method of `stream` is called if it exists. If `stream` doesn't have `isatty()` then the default is False.
+    @param is_tty Whether the output stream is a tty. Affects the 'auto' color_setting. If not provided, the
+        `isatty()` method of both `sys.stdout` and `sys.stderr` is called if they exists. Both must return
+        True for the 'auto' color setting to enable color output.
     """
     if stream is None:
         stream = sys.stderr
     if is_tty is None:
-        is_tty = stream.isatty() if hasattr(stream, 'isatty') else False
+        stdout_is_tty = sys.stdout.isatty() if hasattr(sys.stdout, 'isatty') else False
+        stderr_is_tty = sys.stderr.isatty() if hasattr(sys.stderr, 'isatty') else False
+        is_tty = stdout_is_tty and stderr_is_tty
     use_color = (color_setting == "always") or (color_setting == "auto" and is_tty)
 
     # Init colorama with appropriate color setting.

--- a/test/automated_test.py
+++ b/test/automated_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -241,7 +241,8 @@ def test_board(config: BoardTestConfig):
 
     # Open board-specific output file. This is done after skipping so a skipped board doesn't have a
     # log file created for it (but a previous log file will be removed, above).
-    log_file = open(log_filename, "w", buffering=1) # 1=Line buffered
+    # buffering=1=Line buffered
+    log_file = open(log_filename, "w", buffering=1, encoding='utf-8', errors='backslashreplace')
 
     # Setup logging.
     log_handler = RecordingLogHandler(None)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ import six
 import subprocess
 import tempfile
 import threading
+import codecs
 from pyocd.utility.compatibility import to_str_safe
 
 OBJCOPY = "arm-none-eabi-objcopy"
@@ -164,7 +165,16 @@ class IOTee(object):
 
     def write(self, message):
         for out in self.outputs:
-            out.write(message)
+            encoding = out.encoding if getattr(out, 'encoding', None) else 'latin-1'
+
+            try:
+                # Pre-encode the output with error replacement, then convert back to a string
+                # to write to the file. Very inefficient, but prevents possible errors.
+                b = codecs.encode(message, encoding=encoding, errors='backslashreplace')
+                u = codecs.decode(b, encoding=encoding, errors='backslashreplace')
+                out.write(u)
+            except UnicodeEncodeError as err:
+                out.write(f"<encode error: {err}>")
 
     def flush(self):
         for out in self.outputs:


### PR DESCRIPTION
CMSIS-DAP v2.1 added several new info values to the DAP_Info command: name and vendor for both the board and target MCU. This patch enables pyocd to read and display these values in the probe listing (`pyocd list`).

In addition, the probe listing shows the default target type name in a dedicated column, and whether that target type is installed and available for use.

Here's what the new probe listing looks like:

<img width="893" alt="image" src="https://user-images.githubusercontent.com/3116536/163691389-8fb31bbf-c7e9-4c9c-952e-e5dd7a4bb203.png">

When the full CMSIS-DAP v2.1 info is available, the second row for a listed probe has the board name and vendor. The only probe firmware currently known to report these values is the 0257 release of [DAPLink](https://daplink.io). (I happened to not have a probe with this fw version connected when taking the screenshot just now, so only the board names based on board ID are shown.)

If the target type is not installed, it is shown in red with an ✖︎ instead of check mark.

To enable this feature, the CMSIS-DAP probe driver had to be modified to support clean and fast re-opening of the USB interface since the DAP_Info command can only be sent to an opened device. (Whereas previously only USB descriptor strings were used in the probe listing for CMSIS-DAP.)

Another included change modifies the `--color=auto` behaviour slightly. It now requires both stdout and stderr to be TTYs in order to enable color output, instead of just stderr as before. This ensures that non-logging output, such as the probe listing, is properly colorised or not depending on the output stream. If you have a need to separately control color output for stderr (logging) and stdout, well, pull requests will be happily accepted. 😉 