### PR TITLE
Fix set option command, -n arg for find command

### DIFF
--- a/docs/builtin-targets.md
+++ b/docs/builtin-targets.md
@@ -176,6 +176,26 @@ title: Built-in targets
     <td>HC32F196</td>
     </tr>
 
+    <tr><td><code>hc32f451xc</code></td>
+    <td>HDSC</td>
+    <td>HC32F451xC</td>
+    </tr>
+
+    <tr><td><code>hc32f451xe</code></td>
+    <td>HDSC</td>
+    <td>HC32F451xE</td>
+    </tr>
+
+    <tr><td><code>hc32f452xc</code></td>
+    <td>HDSC</td>
+    <td>HC32F452xC</td>
+    </tr>
+
+    <tr><td><code>hc32f452xe</code></td>
+    <td>HDSC</td>
+    <td>HC32F452xE</td>
+    </tr>
+
     <tr><td><code>hc32f460xc</code></td>
     <td>HDSC</td>
     <td>HC32F460xC</td>
@@ -232,6 +252,11 @@ title: Built-in targets
     </tr>
 
     <tr><td><code>hc32m120</code></td>
+    <td>HDSC</td>
+    <td>HC32M120</td>
+    </tr>
+
+    <tr><td><code>hc32m120x6</code></td>
     <td>HDSC</td>
     <td>HC32M120</td>
     </tr>
@@ -481,6 +506,11 @@ title: Built-in targets
     <td>M263KIAAE</td>
     </tr>
 
+    <tr><td><code>m467hjhae</code></td>
+    <td>Nuvoton</td>
+    <td>M467HJHAE</td>
+    </tr>
+
     <tr><td><code>m487jidae</code></td>
     <td>Nuvoton</td>
     <td>M487JIDAE</td>
@@ -504,6 +534,16 @@ title: Built-in targets
     <tr><td><code>max32630</code></td>
     <td>Maxim</td>
     <td>MAX32630</td>
+    </tr>
+
+    <tr><td><code>max32660</code></td>
+    <td>Maxim</td>
+    <td>MAX32660</td>
+    </tr>
+
+    <tr><td><code>max32670</code></td>
+    <td>Maxim</td>
+    <td>MAX32670</td>
     </tr>
 
     <tr><td><code>mimxrt1010</code></td>

--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -205,6 +205,15 @@ Reset the target, optionally specifying the reset type.
 Unlock security on the target.
 </td></tr>
 
+<tr><td colspan="3"><b>Gdbserver</b></td></tr>
+
+<tr><td>
+<a href="#exit"><tt>exit</tt></a>
+</td><td>
+</td><td>
+Terminate running gdbservers in this session.
+</td></tr>
+
 <tr><td colspan="3"><b>General</b></td></tr>
 
 <tr><td>
@@ -255,7 +264,7 @@ Fill a range of memory with a pattern.
 <tr><td>
 <a href="#find"><tt>find</tt></a>
 </td><td>
-ADDR LEN BYTE+
+[-n] ADDR LEN BYTE+
 </td><td>
 Search for a value in memory within the given address range.
 </td></tr>
@@ -361,7 +370,6 @@ Write 8-bit bytes to memory.
 <tr><td>
 <a href="#init"><tt>init</tt></a>
 </td><td>
-init
 </td><td>
 Ignored; for OpenOCD compatibility.
 </td></tr>
@@ -653,45 +661,45 @@ Show current vector catch settings.
 </table>
 
 
-Commands
---------
+Command details
+---------------
 
 ### Breakpoints
 
 ##### `break`
 
-**Usage**: ADDR \
-Set a breakpoint address. 
+**Usage**: break ADDR \
+Set a breakpoint address.
 
 
 ##### `lsbreak`
 
-**Usage**:  \
-List breakpoints. 
+**Usage**: lsbreak  \
+List breakpoints.
 
 
 ##### `lswatch`
 
-**Usage**:  \
-List watchpoints. 
+**Usage**: lswatch  \
+List watchpoints.
 
 
 ##### `rmbreak`
 
-**Usage**: ADDR \
-Remove a breakpoint. 
+**Usage**: rmbreak ADDR \
+Remove a breakpoint.
 
 
 ##### `rmwatch`
 
-**Usage**: ADDR \
-Remove a watchpoint. 
+**Usage**: rmwatch ADDR \
+Remove a watchpoint.
 
 
 ##### `watch`
 
-**Usage**: ADDR [r|w|rw] [1|2|4] \
-Set a watchpoint address, and optional access type (default rw) and size (4). 
+**Usage**: watch ADDR [r|w|rw] [1|2|4] \
+Set a watchpoint address, and optional access type (default rw) and size (4).
 
 
 ### Bringup
@@ -699,20 +707,20 @@ These commands are meant to be used when starting up Commander in no-init mode. 
 
 ##### `initdp`
 
-**Usage**:  \
-Init DP and power up debug. 
+**Usage**: initdp  \
+Init DP and power up debug.
 
 
 ##### `makeap`
 
-**Usage**: APSEL \
+**Usage**: makeap APSEL \
 Creates a new AP object for the given APSEL. The type of AP, MEM-AP or generic, is autodetected.
 
 
 ##### `reinit`
 
-**Usage**:  \
-Reinitialize the target object. 
+**Usage**: reinit  \
+Reinitialize the target object.
 
 
 ### Commander
@@ -720,14 +728,14 @@ Reinitialize the target object.
 ##### `exit`
 
 **Aliases**: `quit` \
-**Usage**:  \
-Quit pyocd commander. 
+**Usage**: exit  \
+Quit pyocd commander.
 
 
 ##### `list`
 
-**Usage**:  \
-Show available targets. 
+**Usage**: list  \
+Show available targets.
 
 
 ### Core
@@ -735,28 +743,28 @@ Show available targets.
 ##### `continue`
 
 **Aliases**: `c`, `go`, `g` \
-**Usage**:  \
+**Usage**: continue  \
 Resume execution of the target. The target's state is read back after resuming. If the target is not running, then it's state is reported. For instance, if the target is halted immediately after resuming, a debug event such as a breakpoint most likely occurred.
 
 
 ##### `core`
 
-**Usage**: [NUM] \
-Select CPU core by number or print selected core. 
+**Usage**: core [NUM] \
+Select CPU core by number or print selected core.
 
 
 ##### `halt`
 
 **Aliases**: `h` \
-**Usage**:  \
-Halt the target. 
+**Usage**: halt  \
+Halt the target.
 
 
 ##### `step`
 
 **Aliases**: `s` \
-**Usage**: [COUNT] \
-Step one or more instructions. 
+**Usage**: step [COUNT] \
+Step one or more instructions.
 
 
 ### Dap
@@ -764,43 +772,51 @@ Step one or more instructions.
 ##### `readap`
 
 **Aliases**: `rap` \
-**Usage**: [APSEL] ADDR \
-Read AP register. 
+**Usage**: readap [APSEL] ADDR \
+Read AP register.
 
 
 ##### `readdp`
 
 **Aliases**: `rdp` \
-**Usage**: ADDR \
-Read DP register. 
+**Usage**: readdp ADDR \
+Read DP register.
 
 
 ##### `writeap`
 
 **Aliases**: `wap` \
-**Usage**: [APSEL] ADDR DATA \
-Write AP register. 
+**Usage**: writeap [APSEL] ADDR DATA \
+Write AP register.
 
 
 ##### `writedp`
 
 **Aliases**: `wdp` \
-**Usage**: ADDR DATA \
-Write DP register. 
+**Usage**: writedp ADDR DATA \
+Write DP register.
 
 
 ### Device
 
 ##### `reset`
 
-**Usage**: [halt|-halt|-h] [TYPE] \
+**Usage**: reset [halt|-halt|-h] [TYPE] \
 Reset the target, optionally specifying the reset type. The reset type must be one of 'default', 'hw', 'sw', 'hardware', 'software', 'sw_sysresetreq', 'sw_vectreset', 'sw_emulated', 'sysresetreq', 'vectreset', or 'emulated'.
 
 
 ##### `unlock`
 
-**Usage**:  \
-Unlock security on the target. 
+**Usage**: unlock  \
+Unlock security on the target.
+
+
+### Gdbserver
+
+##### `exit`
+
+**Usage**: exit  \
+Terminate running gdbservers in this session. For the pyocd gdbserver subcommand, terminating gdbservers will cause the process to exit. The effect when the gdbserver(s) are running in a different environment depends on that program. Note that gdb will still believe the connection to be valid after this command completes, so executing the 'disconnect' command is a necessity.
 
 
 ### General
@@ -808,8 +824,8 @@ Unlock security on the target.
 ##### `help`
 
 **Aliases**: `?` \
-**Usage**: [CMD] \
-Show help for commands. 
+**Usage**: help [CMD] \
+Show help for commands.
 
 
 ### Memory
@@ -817,114 +833,114 @@ Show help for commands.
 ##### `compare`
 
 **Aliases**: `cmp` \
-**Usage**: ADDR [LEN] FILENAME \
+**Usage**: compare ADDR [LEN] FILENAME \
 Compare a memory range against a binary file. If the length is not provided, then the length of the file is used.
 
 
 ##### `disasm`
 
 **Aliases**: `d` \
-**Usage**: [-c/--center] ADDR [LEN] \
-Disassemble instructions at an address. Only available if the capstone library is installed. To install capstone, run 'pip install capstone'.
+**Usage**: disasm [-c/--center] ADDR [LEN] \
+Disassemble instructions at an address. The length argument is in bytes and is optional, with a default of 6. If the -c option is used, the disassembly is centered on the given address. Otherwise the disassembly begins at the given address.
 
 
 ##### `erase`
 
-**Usage**: [ADDR] [COUNT] \
-Erase all internal flash or a range of sectors. 
+**Usage**: erase [ADDR] [COUNT] \
+Erase all internal flash or a range of sectors.
 
 
 ##### `fill`
 
-**Usage**: [SIZE] ADDR LEN PATTERN \
+**Usage**: fill [SIZE] ADDR LEN PATTERN \
 Fill a range of memory with a pattern. The optional SIZE parameter must be one of 8, 16, or 32. If not provided, the size is determined by the pattern value's most significant set bit. Only RAM regions may be filled.
 
 
 ##### `find`
 
-**Usage**: ADDR LEN BYTE+ \
-Search for a value in memory within the given address range. A pattern of any number of bytes can be searched for. Each BYTE parameter must be an 8-bit value.
+**Usage**: find [-n] ADDR LEN BYTE+ \
+Search for a value in memory within the given address range. A pattern of any number of bytes can be searched for. Each BYTE parameter must be an 8-bit value. If the -n argument is passed, the search is negated and looks for the first set of bytes that does not match the provided values.
 
 
 ##### `load`
 
-**Usage**: FILENAME [ADDR] \
-Load a binary, hex, or elf file with optional base address. 
+**Usage**: load FILENAME [ADDR] \
+Load a binary, hex, or elf file with optional base address.
 
 
 ##### `loadmem`
 
-**Usage**: ADDR FILENAME \
+**Usage**: loadmem ADDR FILENAME \
 Load a binary file to an address in memory (RAM or flash). This command is deprecated in favour of the more flexible 'load'.
 
 
 ##### `read16`
 
 **Aliases**: `rh` \
-**Usage**: ADDR [LEN] \
+**Usage**: read16 ADDR [LEN] \
 Read 16-bit halfwords. Optional length parameter is the number of bytes (not half-words) to read. It must be divisible by 2. If the length is not provided, one halfword is read. The address may be unaligned.
 
 
 ##### `read32`
 
 **Aliases**: `rw` \
-**Usage**: ADDR [LEN] \
+**Usage**: read32 ADDR [LEN] \
 Read 32-bit words. Optional length parameter is the number of bytes (not words) to read. It must be divisible by 4. If the length is not provided, one word is read. The address may be unaligned.
 
 
 ##### `read64`
 
 **Aliases**: `rd` \
-**Usage**: ADDR [LEN] \
+**Usage**: read64 ADDR [LEN] \
 Read 64-bit words. Optional length parameter is the number of bytes (not double-words!) to read. It must be divisible by 8. If the length is not provided, one word is read. The address may be unaligned.
 
 
 ##### `read8`
 
 **Aliases**: `rb` \
-**Usage**: ADDR [LEN] \
+**Usage**: read8 ADDR [LEN] \
 Read 8-bit bytes. Optional length parameter is the number of bytes to read. If the length is not provided, one byte is read.
 
 
 ##### `savemem`
 
-**Usage**: ADDR LEN FILENAME \
-Save a range of memory to a binary file. 
+**Usage**: savemem ADDR LEN FILENAME \
+Save a range of memory to a binary file.
 
 
 ##### `write16`
 
 **Aliases**: `wh` \
-**Usage**: ADDR DATA+ \
+**Usage**: write16 ADDR DATA+ \
 Write 16-bit halfwords to memory. The data arguments are 16-bit halfwords in big-endian format and are written as little-endian. The address may be unaligned. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
 
 
 ##### `write32`
 
 **Aliases**: `ww` \
-**Usage**: ADDR DATA+ \
+**Usage**: write32 ADDR DATA+ \
 Write 32-bit words to memory. The data arguments are 32-bit words in big-endian format and are written as little-endian. The address may be unaligned. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
 
 
 ##### `write64`
 
 **Aliases**: `wd` \
-**Usage**: ADDR DATA... \
+**Usage**: write64 ADDR DATA... \
 Write 64-bit double-words to memory. The data arguments are 64-bit words in big-endian format and are written as little-endian. The address may be unaligned. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
 
 
 ##### `write8`
 
 **Aliases**: `wb` \
-**Usage**: ADDR DATA+ \
+**Usage**: write8 ADDR DATA+ \
 Write 8-bit bytes to memory. The data arguments are 8-bit bytes. Can write to both RAM and flash. Flash writes are subject to minimum write size and alignment, and the flash page must have been previously erased.
 
 
-### Openocd_compatibility
+### Openocd compatibility
 
 ##### `init`
 
-**Usage**: init \
+**Usage**: init  \
 Ignored; for OpenOCD compatibility.
 
 
@@ -932,7 +948,7 @@ Ignored; for OpenOCD compatibility.
 
 ##### `flushprobe`
 
-**Usage**:  \
+**Usage**: flushprobe  \
 Ensure all debug probe requests have been completed.
 
 
@@ -941,14 +957,14 @@ Ensure all debug probe requests have been completed.
 ##### `reg`
 
 **Aliases**: `rr` \
-**Usage**: [-p] [-f] [REG...] \
+**Usage**: reg [-p] [-f] [REG...] \
 Print core or peripheral register(s). If no arguments are provided, the 'general' core register group will be printed. Either a core register name, the name of a peripheral, or a peripheral.register can be provided. When a peripheral name is provided without a register, all registers in the peripheral will be printed. The -p option forces evaluating the register name as a peripheral register name. If the -f option is passed, then individual fields of peripheral registers will be printed in addition to the full value.
 
 
 ##### `wreg`
 
 **Aliases**: `wr` \
-**Usage**: [-r] [-p] [-f] REG VALUE \
+**Usage**: wreg [-r] [-p] [-f] REG VALUE \
 Set the value of a core or peripheral register. The REG parameter must be a core register name or a peripheral.register. When a peripheral register is written, if the -r option is passed then it is read back and the updated value printed. The -p option forces evaluating the register name as a peripheral register name. If the -f option is passed, then individual fields of peripheral registers will be printed in addition to the full value.
 
 
@@ -956,7 +972,7 @@ Set the value of a core or peripheral register. The REG parameter must be a core
 
 ##### `arm`
 
-**Usage**: semihosting {enable,disable} \
+**Usage**: arm semihosting {enable,disable} \
 Enable or disable semihosting. Provided for compatibility with OpenOCD. The same functionality can be achieved by setting the 'enable_semihosting' session option.
 
 
@@ -964,13 +980,13 @@ Enable or disable semihosting. Provided for compatibility with OpenOCD. The same
 
 ##### `gdbserver`
 
-**Usage**: {start,stop,status} \
+**Usage**: gdbserver {start,stop,status} \
 Control the gdbserver for the selected core. The action argument should be either 'start', 'stop', or 'status'. Use the 'gdbserver_port' and 'telnet_port' session options to control the ports the gdbserver uses.
 
 
 ##### `probeserver`
 
-**Usage**: {start,stop,status} \
+**Usage**: probeserver {start,stop,status} \
 Control the debug probe server. The action argument should be either 'start', 'stop', or 'status. Use the 'probeserver.port' option to control the TCP port the server uses.
 
 
@@ -979,13 +995,13 @@ These commands require an ELF to be set.
 
 ##### `symbol`
 
-**Usage**: NAME \
+**Usage**: symbol NAME \
 Show a symbol's value. An ELF file must have been specified with the --elf option.
 
 
 ##### `where`
 
-**Usage**: [ADDR] \
+**Usage**: where [ADDR] \
 Show symbol, file, and line for address. The symbol name, source file path, and line number are displayed for the specified address. If no address is given then current PC is used. An ELF file must have been specified with the --elf option.
 
 
@@ -994,28 +1010,149 @@ Show symbol, file, and line for address. The symbol name, source file path, and 
 ##### `status`
 
 **Aliases**: `st` \
-**Usage**:  \
-Show the target's current state. 
+**Usage**: status  \
+Show the target's current state.
 
 
 ### Threads
 
 ##### `threads`
 
-**Usage**: {flush,enable,disable,status} \
-Control thread awareness. 
+**Usage**: threads {flush,enable,disable,status} \
+Control thread awareness.
 
 
 ### Values
 
 ##### `set`
 
-**Usage**: NAME VALUE \
-Set a value. 
+**Usage**: set NAME VALUE \
+Set a value.
 
 
 ##### `show`
 
-**Usage**: NAME \
-Display a value. 
+**Usage**: show NAME \
+Display a value.
 
+
+
+Value details
+-------------
+
+##### `aps`
+
+**Access**: read-only \
+**Usage**: show aps \
+List discovered Access Ports.
+
+##### `cores`
+
+**Access**: read-only \
+**Usage**: show cores \
+Information about CPU cores in the target.
+
+##### `fault`
+
+**Access**: read-only \
+**Usage**: show fault \
+Fault status information. By default, only asserted fields are shown. Add -a to command to show all fields.
+
+##### `frequency`
+
+**Access**: write-only \
+**Usage**: set frequency VALUE \
+Set SWD or JTAG clock frequency in Hertz. A case-insensitive metric scale suffix of either 'k' or 'm' is allowed, as well as a trailing "Hz". There must be no space between the frequency and the suffix. For example, "2.5MHz" sets the clock to 2.5 MHz.
+
+##### `graph`
+
+**Access**: read-only \
+**Usage**: show graph \
+Print the target object graph.
+
+##### `hnonsec`
+
+**Access**: read-write \
+**Usage**: show hnonsec, set hnonsec VALUE \
+The current HNONSEC value used by the selected MEM-AP.
+
+##### `hprot`
+
+**Access**: read-write \
+**Usage**: show hprot, set hprot VALUE \
+The current HPROT value used by the selected MEM-AP.
+
+##### `locked`
+
+**Access**: read-only \
+**Usage**: show locked \
+Report whether the target is locked.
+
+##### `log`
+
+**Access**: write-only \
+**Usage**: set log VALUE \
+Set log level to one of 'debug', 'info', 'warning', 'error', 'critical'. If pyocd module names are provided as arguments after the log level then only those modules will have their log level changed.
+
+##### `map`
+
+**Access**: read-only \
+**Usage**: show map \
+Target memory map.
+
+##### `mem-ap`
+
+**Access**: read-write \
+**Usage**: show mem-ap, set mem-ap VALUE \
+The currently selected MEM-AP used for memory read/write commands. When the selected core is changed by the 'core' command, the selected MEM-AP is changed to match. This overrides a user-selected MEM-AP if different from the AP for the newly selected core.
+
+##### `nreset`
+
+**Access**: read-write \
+**Usage**: show nreset, set nreset VALUE \
+Current nRESET signal state. Accepts a value of 0 or 1.
+
+##### `option`
+
+**Access**: read-write \
+**Usage**: show option, set option VALUE \
+The current value of one or more session options. When setting, each argument should follow the form "NAME[=VALUE]".
+
+##### `peripherals`
+
+**Access**: read-only \
+**Usage**: show peripherals \
+List of target peripheral instances.
+
+##### `probe-uid`
+
+**Aliases**: `uid` \
+**Access**: read-only \
+**Usage**: show probe-uid \
+Target's unique ID.
+
+##### `register-groups`
+
+**Access**: read-only \
+**Usage**: show register-groups \
+Display available register groups for the selected core.
+
+##### `step-into-interrupts`
+
+**Aliases**: `si` \
+**Access**: read-write \
+**Usage**: show step-into-interrupts, set step-into-interrupts VALUE \
+Display whether interrupts are enabled when single stepping. Set to 1 to enable.
+
+##### `target`
+
+**Access**: read-only \
+**Usage**: show target \
+General target information.
+
+##### `vector-catch`
+
+**Aliases**: `vc` \
+**Access**: read-write \
+**Usage**: show vector-catch, set vector-catch VALUE \
+Show current vector catch settings. When setting, the alue is a concatenation of one letter per enabled source in any order, or 'all' or 'none'. (h=hard fault, b=bus fault, m=mem fault, i=irq err, s=state err, c=check err, p=nocp, r=reset, a=all, n=none).

--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -394,8 +394,10 @@ class DisassembleCommand(CommandBase):
             'nargs': [1, 2, 3],
             'usage': "[-c/--center] ADDR [LEN]",
             'help': "Disassemble instructions at an address.",
-            'extra_help': "Only available if the capstone library is installed. To install "
-                           "capstone, run 'pip install capstone'.",
+            'extra_help':
+                "The length argument is in bytes and is optional, with a default of 6. If the -c option "
+                "is used, the disassembly is centered on the given address. Otherwise the disassembly "
+                "begins at the given address.",
             }
 
     def parse(self, args):

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
 # Copyright (c) 2020 Patrick Huesmann
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,9 +16,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import namedtuple
+from typing import (Any, Dict, List, NamedTuple, Tuple, Union)
 
-OptionInfo = namedtuple('OptionInfo', 'name type default help')
+class OptionInfo(NamedTuple):
+    # TODO Change 'type' field's type Any, and use Union for multi-typed options instead of a tuple of types.
+    name: str
+    type: Union[type, Tuple[type, ...]]
+    default: Any
+    help: str
 
 ## @brief Definitions of the builtin options.
 BUILTIN_OPTIONS = [
@@ -177,9 +183,9 @@ BUILTIN_OPTIONS = [
     ]
 
 ## @brief The runtime dictionary of options.
-OPTIONS_INFO = {}
+OPTIONS_INFO: Dict[str, OptionInfo] = {}
 
-def add_option_set(options):
+def add_option_set(options: List[OptionInfo]) -> None:
     """@brief Merge a list of OptionInfo objects into OPTIONS_INFO."""
     OPTIONS_INFO.update({oi.name: oi for oi in options})
 

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 import logging
-from typing import (Any, Dict, Iterable, List, Optional, Union)
+from typing import (Any, Dict, Iterable, List, Optional, Tuple, Union, cast)
 
 from ..core.target import Target
 from ..core.options import OPTIONS_INFO
@@ -128,6 +128,75 @@ def convert_vector_catch(vcvalue: Union[str, bytes]) -> int:
         # Reraise an error with a more helpful message.
         raise ValueError("invalid vector catch option '{}'".format(e.args[0]))
 
+def convert_one_session_option(name: str, value: Optional[str]) -> Tuple[str, Any]:
+    """@brief Convert one session option's value from a string.
+
+    Handles "no-" prefixed option names by inverting their boolean value. If a non-boolean option has
+    a "no-" prefix, then a warning is logged and None returned for the value.
+
+    @return Bi-tuple of option name, converted value. The option name may be modified from the one passed
+        in for cases like a "no-" prefix.
+    """
+    # Check for and strip "no-" prefix before we validate the option name.
+    if name.startswith('no-'):
+        name = name[3:]
+        had_no_prefix = True
+    else:
+        had_no_prefix = False
+
+    # Look up this option.
+    try:
+        info = OPTIONS_INFO[name]
+    except KeyError:
+        # Return the value unmodified for unknown options.
+        LOG.warning("unknown session option '%s'", name)
+        return name, value
+
+    # Check if "no-" prefix is allowed. Only bool options can use it.
+    if had_no_prefix and (info.type is not bool):
+        LOG.warning("'no-' prefix used on non-boolean session option '%s'", name)
+        return name, None
+
+    # Default result; unset option value.
+    result = None
+
+    # Extract the option's type. If its type is a tuple of types, then take the first type.
+    if info.type is tuple:
+        option_type = cast(tuple, info.type)[0]
+    else:
+        option_type = info.type
+
+    # Handle bool options without a value specially.
+    if value is None:
+        if issubclass(option_type, bool):
+            result = not had_no_prefix
+        else:
+            LOG.warning("non-boolean option '%s' requires a value", name)
+    # Convert string value to option type.
+    elif issubclass(option_type, bool):
+        if value.lower() in ("true", "1", "yes", "on", "false", "0", "no", "off"):
+            result = value.lower() in ("true", "1", "yes", "on")
+
+            # If a bool option with "no-" prefix has a value, the value is inverted.
+            if had_no_prefix:
+                result = not result
+        else:
+            LOG.warning("invalid value for option '%s'", name)
+    elif issubclass(option_type, int):
+        try:
+            result = int(value, base=0)
+        except ValueError:
+            LOG.warning("invalid value for option '%s'", name)
+    elif issubclass(option_type, float):
+        try:
+            result = float(value)
+        except ValueError:
+            LOG.warning("invalid value for option '%s'", name)
+    else:
+        result = value
+
+    return name, result
+
 def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
     """@brief Convert a list of session option settings to a dictionary."""
     options = {}
@@ -141,48 +210,9 @@ def convert_session_options(option_list: Iterable[str]) -> Dict[str, Any]:
                 name = o.strip().lower()
                 value = None
 
-            # Check for and strip "no-" prefix before we validate the option name.
-            if (value is None) and (name.startswith('no-')):
-                name = name[3:]
-                had_no_prefix = True
-            else:
-                had_no_prefix = False
-
-            # Look for this option.
-            try:
-                info = OPTIONS_INFO[name]
-            except KeyError:
-                LOG.warning("ignoring unknown session option '%s'", name)
-                continue
-
-            # Handle bool options without a value specially.
-            if value is None:
-                if info.type is bool:
-                    value = not had_no_prefix
-                else:
-                    LOG.warning("non-boolean option '%s' requires a value", name)
-                    continue
-            # Convert string value to option type.
-            elif info.type is bool:
-                if value.lower() in ("true", "1", "yes", "on", "false", "0", "no", "off"):
-                    value = value.lower() in ("true", "1", "yes", "on")
-                else:
-                    LOG.warning("invalid value for option '%s'", name)
-                    continue
-            elif info.type is int:
-                try:
-                    value = int(value, base=0)
-                except ValueError:
-                    LOG.warning("invalid value for option '%s'", name)
-                    continue
-            elif info.type is float:
-                try:
-                    value = float(value)
-                except ValueError:
-                    LOG.warning("invalid value for option '%s'", name)
-                    continue
-
-            options[name] = value
+            name, value = convert_one_session_option(name, value)
+            if value is not None:
+                options[name] = value
     return options
 
 ## Map to convert from reset type names to enums.

--- a/scripts/generate_command_help.py
+++ b/scripts/generate_command_help.py
@@ -15,13 +15,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+
+if sys.version_info[:2] < (3, 9):
+    print(f"This script requires Python 3.9 or later")
+    sys.exit(1)
+
+from pyocd.commands.base import (
+    ALL_COMMANDS,
+    CommandBase,
+    ValueBase,
+    )
+
 # These modules must be imported in order to load the commands into the ALL_COMMANDS table.
 import pyocd.commands.commands
 import pyocd.commands.values
-from pyocd.commands.base import (
-    ALL_COMMANDS,
-    ValueBase,
-    )
 
 ACCESS_DESC = {
         'r': "read-only",
@@ -76,42 +84,63 @@ def build_categories(commands):
             categories.setdefault(cmd.INFO['category'], []).append(cmd)
     return categories
 
+def get_all_values(commands: dict[str, list[ValueBase]]) -> list[ValueBase]:
+    """Converts dict of group name to list of commands"""
+    return [
+        c
+        for group_commands in commands.values()
+        for c in group_commands
+        ]
+
 def gen_cmd_groups(commands):
     categories = build_categories(commands)
 
     for group in sorted(categories.keys()):
-        print(f"""<tr><td colspan="3"><b>{group.capitalize()}</b></td></tr>
-""")
-
         # Filter out the base classes that have empty 'names'.
         filtered_cmds = [c for c in categories[group] if c.INFO['names']]
         group_cmds = sorted(filtered_cmds, key=lambda c: c.INFO['names'][0])
+
+        # Skip empty groups.
+        if not group_cmds:
+            continue
+
+        print(f"""<tr><td colspan="3"><b>{group.capitalize()}</b></td></tr>
+""")
+
         for cmd in group_cmds:
             gen_command(cmd.INFO)
 
-def gen_value_groups(commands):
-    for group in sorted(commands.keys()):
+def gen_value_groups(commands: list[ValueBase]) -> None:
+    # Filter out the base classes that have empty 'names'.
+    filtered_cmds = [c for c in commands if c.INFO['names']]
+    group_cmds = sorted(filtered_cmds, key=lambda c: c.INFO['names'][0])
+
 #         print(f"""<tr><td colspan="3"><b>{group.capitalize()}</b></td></tr>""")
 
-        # Filter out the base classes that have empty 'names'.
-        filtered_cmds = [c for c in commands[group] if c.INFO['names']]
-        group_cmds = sorted(filtered_cmds, key=lambda c: c.INFO['names'][0])
-        for cmd in group_cmds:
-            gen_value(cmd.INFO)
+    for cmd in group_cmds:
+        gen_value(cmd.INFO)
+
+def format_group_name(group: str) -> str:
+    return group.replace('_', ' ').capitalize()
 
 def gen_command_docs(commands):
     nl = "\\"
     categories = build_categories(commands)
     for group in sorted(categories.keys()):
-        group_docs = GROUP_DOCS.get(group, '')
-        print(f"""
-### {group.capitalize()}""")
-        if group_docs:
-            print(group_docs)
-
         # Filter out the base classes that have empty 'names'.
         filtered_cmds = [c for c in categories[group] if c.INFO['names']]
         group_cmds = sorted(filtered_cmds, key=lambda c: c.INFO['names'][0])
+
+        # Skip empty groups.
+        if not group_cmds:
+            continue
+
+        group_docs = GROUP_DOCS.get(group, '')
+        print(f"""
+### {format_group_name(group)}""")
+        if group_docs:
+            print(group_docs)
+
         for cmd in group_cmds:
             info = cmd.INFO
             print(f"""
@@ -119,9 +148,47 @@ def gen_command_docs(commands):
 """)
             if len(info['names']) > 1:
                 print(f"""**Aliases**: {', '.join("`%s`" % n for n in info['names'][1:])} """ + nl)
-            print(f"""**Usage**: {info['usage']} {nl}
-{info['help']} {info.get('extra_help', '')}
+
+            help = info['help']
+            if 'extra_help' in info:
+                help += " " + info['extra_help']
+            print(f"""**Usage**: {info['names'][0]} {info['usage']} {nl}
+{help}
 """)
+
+def gen_value_docs(commands: list[ValueBase]) -> None:
+    nl = "\\"
+    # Filter out the base classes that have empty 'names'.
+    filtered_cmds = [c for c in commands if c.INFO['names']]
+    group_cmds = sorted(filtered_cmds, key=lambda c: c.INFO['names'][0])
+
+    for cmd in group_cmds:
+        info = cmd.INFO
+        names = info['names']
+        first_name = names[0]
+        access = info['access']
+        access_desc = ACCESS_DESC[access]
+        help = info['help']
+        if 'extra_help' in info:
+            help += " " + info['extra_help']
+
+        print(f"""
+##### `{first_name}`
+""")
+        if len(names) > 1:
+            print(f"""**Aliases**: {', '.join("`%s`" % n for n in names[1:])} """ + nl)
+
+        print(f"**Access**: {access_desc} {nl}")
+        print(f"**Usage**: ", end='')
+        if 'r' in access:
+            print(f"show {first_name}", end='')
+        if access == 'rw':
+            print(", ", end='')
+        if 'w' in access:
+            print(f"set {first_name} VALUE", end='')
+        print(f" {nl}")
+
+        print(help)
 
 def get_all_command_classes():
     klasses = set()
@@ -143,6 +210,7 @@ def split_into_commands_and_values():
 
 def main():
     all_cmds_by_group, all_values_by_group = split_into_commands_and_values()
+    all_values = get_all_values(all_values_by_group)
     print("""
 All commands
 ------------
@@ -168,15 +236,21 @@ command can be read, written, or both.
 
 <tr><th>Value</th><th>Access</th><th>Description</th></tr>
 """)
-    gen_value_groups(all_values_by_group)
+    gen_value_groups(all_values)
     print("""
 </table>
 """)
 
     print("""
-Commands
---------""")
+Command details
+---------------""")
     gen_command_docs(all_cmds_by_group)
+
+    print("""
+
+Value details
+-------------""")
+    gen_value_docs(all_values)
 
 if __name__ == '__main__':
     main()

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -223,23 +223,41 @@ def commands_test(board_id):
         # For now we just verify that the commands run without raising an exception.
         print("\n------ Testing commands ------")
 
-        def test_command(cmd):
+        def test_command(cmd, print_result=True):
             try:
                 print("\nTEST: %s" % cmd)
                 context.process_command_line(cmd)
             except:
-                print("TEST FAILED")
+                if print_result:
+                    print("TEST FAILED")
                 failed_commands.append(cmd)
                 traceback.print_exc(file=sys.stdout)
                 return False
             else:
-                print("TEST PASSED")
+                if print_result:
+                    print("TEST PASSED")
                 return True
 
         for cmd in COMMANDS_TO_TEST:
             if test_command(cmd):
                 test_pass_count += 1
             test_count += 1
+
+        #
+        # Special command tests.
+        #
+        print("\n------ Additional command tests ------")
+
+        # set option
+        session.options['auto_unlock'] = False
+        if test_command('set option auto_unlock=on', print_result=False):
+            if session.options['auto_unlock'] is True:
+                test_pass_count += 1
+                print("TEST PASSED")
+            else:
+                print("TEST FAILED")
+
+        test_count += 1
 
         print("\n\nTest Summary:")
         print("Pass count %i of %i tests" % (test_pass_count, test_count))

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -139,6 +139,7 @@ def commands_test(board_id):
                 "fill 16 0x%08x 64 0x55aa" % (ram_base + 64),
                 "find 0x%08x 128 0xaa 0x55" % ram_base, # find that will pass
                 "find 0x%08x 128 0xff" % ram_base, # find that will fail
+                "find -n 0x%08x 128 0xff" % ram_base, # inverted find that will now pass
                 "erase 0x%08x" % (boot_first_free_block_addr),
                 "erase 0x%08x 1" % (boot_first_free_block_addr + boot_blocksize),
                 "go",

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -35,6 +35,10 @@ TEST_DATA_DIR = os.path.join(TEST_DIR, "data")
 TEST_OUTPUT_DIR = os.path.join(TEST_DIR, "output")
 
 def get_test_binary_path(binary_name):
+    if binary_name is None:
+        binary_name = os.environ.get('PYOCD_TEST_BINARY')
+        if binary_name is None:
+            raise RuntimeError("no test binary available")
     return os.path.join(TEST_DATA_DIR, "binaries", binary_name)
 
 def get_env_name():

--- a/test/unit/test_cmdline.py
+++ b/test/unit/test_cmdline.py
@@ -96,7 +96,10 @@ class TestConvertSessionOptions(object):
         assert convert_session_options([]) == {}
 
     def test_unknown_option(self):
+        # No value.
         assert convert_session_options(['dumkopf']) == {}
+        # With a value
+        assert convert_session_options(['dumkopf=123']) == {'dumkopf': "123"}
 
     def test_bool(self):
         assert convert_session_options(['auto_unlock']) == {'auto_unlock': True}


### PR DESCRIPTION
The main purpose of this patch is to fix the `set option` command, and to add a `-n` argument to `find` to invert the search comparison. Test cases are added for these changes.

This handful of other changes are included:

- Type annotations added to the commands base classes and setting options sources.
- Factored `convert_one_session_option()` out of `convert_session_options()` utility and fixed some potential issues with it.
- Functional tests can use a `PYOCD_TEST_BINARY` environment variable if the board has no test binary already defined.
