### PR TITLE
CMSIS-DAP: consistent USB timeouts, refactor backend ctors

### DIFF
--- a/pyocd/probe/pydapaccess/interface/common.py
+++ b/pyocd/probe/pydapaccess/interface/common.py
@@ -128,7 +128,7 @@ def check_ep(interface: "Interface", ep_index: int, ep_dir: int, ep_type: int) -
     return ((usb.util.endpoint_direction(ep.bEndpointAddress) == ep_dir) # type:ignore
         and (usb.util.endpoint_type(ep.bmAttributes) == ep_type)) # type:ignore
 
-def generate_device_unique_id(vid: int, pid: int, *locations: List[Union[int, str]]) -> str:
+def generate_device_unique_id(vid: int, pid: int, *locations: Union[int, str]) -> str:
     """@brief Generate a semi-stable unique ID from USB device properties.
 
     This function is intended to be used in cases where a device does not provide a serial number

--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2022 Harper Weigle
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -162,7 +162,7 @@ class HidApiUSB(Interface):
             self.read_sem.release()
         self.device.write([0] + data)
 
-    def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
+    def read(self):
         """@brief Read data on the IN endpoint associated to the HID interface"""
         # Windows doesn't use the read thread, so read directly.
         if _IS_WINDOWS:
@@ -176,7 +176,7 @@ class HidApiUSB(Interface):
 
         # Other OSes use the read thread, so we check for and pull data from the queue.
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
-        with Timeout(timeout, sleeptime=0.0001) as t_o:
+        with Timeout(self.DEFAULT_USB_TIMEOUT_S, sleeptime=0.0001) as t_o:
             while t_o.check():
                 if len(self.received_data) != 0:
                     break

--- a/pyocd/probe/pydapaccess/interface/interface.py
+++ b/pyocd/probe/pydapaccess/interface/interface.py
@@ -22,7 +22,8 @@ class Interface:
     def get_all_connected_interfaces():
         raise NotImplementedError()
 
-    DEFAULT_READ_TIMEOUT = 20
+    DEFAULT_USB_TIMEOUT_S = 10
+    DEFAULT_USB_TIMEOUT_MS = DEFAULT_USB_TIMEOUT_S * 1000
 
     def __init__(self):
         self.vid = 0
@@ -51,7 +52,7 @@ class Interface:
     def write(self, data):
         raise NotImplementedError()
 
-    def read(self, timeout=DEFAULT_READ_TIMEOUT):
+    def read(self):
         raise NotImplementedError()
 
     def read_swo(self):

--- a/pyocd/probe/pydapaccess/interface/pyusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_backend.py
@@ -53,19 +53,23 @@ class PyUSB(Interface):
 
     did_show_no_libusb_warning = False
 
-    def __init__(self):
+    def __init__(self, dev):
         super().__init__()
+        self.vid = dev.idVendor
+        self.pid = dev.idProduct
+        self.product_name = dev.product or f"{dev.idProduct:#06x}"
+        self.vendor_name = dev.manufacturer or f"{dev.idVendor:#06x}"
+        self.serial_number = dev.serial_number \
+                or generate_device_unique_id(dev.idProduct, dev.idVendor, dev.bus, dev.address)
         self.ep_out = None
         self.ep_in = None
         self.dev = None
         self.intf_number = None
-        self.serial_number = None
         self.kernel_driver_was_attached = False
         self.closed = True
         self.thread = None
         self.rcv_data = []
         self.read_sem = threading.Semaphore(0)
-        self.packet_size = 64
 
     def open(self):
         assert self.closed is True
@@ -173,13 +177,7 @@ class PyUSB(Interface):
         # iterate on all devices found
         boards = []
         for board in all_devices:
-            new_board = PyUSB()
-            new_board.vid = board.idVendor
-            new_board.pid = board.idProduct
-            new_board.product_name = board.product or f"{board.idProduct:#06x}"
-            new_board.vendor_name = board.manufacturer or f"{board.idVendor:#06x}"
-            new_board.serial_number = board.serial_number \
-                    or generate_device_unique_id(board.idProduct, board.idVendor, board.bus, board.address)
+            new_board = PyUSB(board)
             boards.append(new_board)
 
         return boards

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -51,14 +51,19 @@ class PyUSBv2(Interface):
 
     isAvailable = IS_AVAILABLE
 
-    def __init__(self):
+    def __init__(self, dev):
         super().__init__()
+        self.vid = dev.idVendor
+        self.pid = dev.idProduct
+        self.product_name = dev.product or f"{dev.idProduct:#06x}"
+        self.vendor_name = dev.manufacturer or f"{dev.idVendor:#06x}"
+        self.serial_number = dev.serial_number \
+                or generate_device_unique_id(dev.idProduct, dev.idVendor, dev.bus, dev.address)
         self.ep_out = None
         self.ep_in = None
         self.ep_swo = None
         self.dev = None
         self.intf_number = None
-        self.serial_number = None
         self.kernel_driver_was_attached = False
         self.closed = True
         self.thread = None
@@ -196,13 +201,7 @@ class PyUSBv2(Interface):
         # iterate on all devices found
         boards = []
         for board in all_devices:
-            new_board = PyUSBv2()
-            new_board.vid = board.idVendor
-            new_board.pid = board.idProduct
-            new_board.product_name = board.product or f"{board.idProduct:#06x}"
-            new_board.vendor_name = board.manufacturer or f"{board.idVendor:#06x}"
-            new_board.serial_number = board.serial_number \
-                    or generate_device_unique_id(board.idProduct, board.idVendor, board.bus, board.address)
+            new_board = PyUSBv2(board)
             boards.append(new_board)
 
         return boards

--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -1,7 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2019-2021 Arm Limited
 # Copyright (c) 2021 mentha
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -161,7 +161,7 @@ class PyUSBv2(Interface):
             while not self.rx_stop_event.is_set():
                 self.read_sem.acquire()
                 if not self.rx_stop_event.is_set():
-                    read_data = self.ep_in.read(self.packet_size, 10 * 1000)
+                    read_data = self.ep_in.read(self.packet_size, timeout=self.DEFAULT_USB_TIMEOUT_MS)
 
                     if TRACE.isEnabledFor(logging.DEBUG):
                         TRACE.debug("  USB IN < (%d) %s", len(read_data), ' '.join([f'{i:02x}' for i in read_data]))
@@ -175,7 +175,8 @@ class PyUSBv2(Interface):
         try:
             while not self.swo_stop_event.is_set():
                 try:
-                    self.swo_data.append(self.ep_swo.read(self.ep_swo.wMaxPacketSize, 10 * 1000))
+                    self.swo_data.append(self.ep_swo.read(self.ep_swo.wMaxPacketSize,
+                            timeout=self.DEFAULT_USB_TIMEOUT_MS))
                 except usb.core.USBError:
                     pass
         finally:
@@ -218,12 +219,12 @@ class PyUSBv2(Interface):
 
         self.read_sem.release()
 
-        self.ep_out.write(data)
+        self.ep_out.write(data, timeout=self.DEFAULT_USB_TIMEOUT_MS)
 
-    def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
+    def read(self):
         """@brief Read data on the IN endpoint."""
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
-        with Timeout(timeout, sleeptime=0.0001) as t_o:
+        with Timeout(self.DEFAULT_USB_TIMEOUT_S, sleeptime=0.0001) as t_o:
             while t_o.check():
                 if len(self.rcv_data) != 0:
                     break

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2022 Harper Weigle
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -150,10 +150,10 @@ class PyWinUSB(Interface):
         data.extend([0] * (self.packet_size - len(data)))
         self.report.send([0] + data)
 
-    def read(self, timeout=Interface.DEFAULT_READ_TIMEOUT):
+    def read(self):
         """@brief Read data on the IN endpoint associated to the HID interface"""
         # Spin for a while if there's not data available yet. 100 µs sleep between checks.
-        with Timeout(timeout, sleeptime=0.0001) as t_o:
+        with Timeout(self.DEFAULT_USB_TIMEOUT_S, sleeptime=0.0001) as t_o:
             while t_o.check():
                 if len(self.rcv_data):
                     break

--- a/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pywinusb_backend.py
@@ -46,15 +46,24 @@ class PyWinUSB(Interface):
 
     isAvailable = IS_AVAILABLE
 
-    def __init__(self):
+    def __init__(self, dev):
         super().__init__()
         # Vendor page and usage_id = 2
-        self.report = None
+        reports = dev.find_output_reports()
+        assert len(reports) == 1
+        self.report = reports[0]
+        self.packet_size = len(self.report.get_raw_data()) - 1
+        self.vendor_name = dev.vendor_name or f"{dev.vendor_id:#06x}"
+        self.product_name = dev.product_name or f"{dev.product_id:#06x}"
+        self.serial_number = dev.serial_number \
+                or generate_device_unique_id(dev.vendor_id, dev.product_id, dev.device_path)
+        self.vid = dev.vendor_id
+        self.pid = dev.product_id
+        self.device = dev
         # deque used here instead of synchronized Queue
         # since read speeds are ~10-30% faster and are
         # comparable to a list based implementation.
         self.rcv_data = collections.deque()
-        self.device = None
 
     # handler called when a report is received
     def rx_handler(self, data):
@@ -123,16 +132,7 @@ class PyWinUSB(Interface):
                 if len(report) != 1:
                     dev.close()
                     continue
-                new_board = PyWinUSB()
-                new_board.report = report[0]
-                new_board.packet_size = len(new_board.report.get_raw_data()) - 1
-                new_board.vendor_name = dev.vendor_name or f"{dev.vendor_id:#06x}"
-                new_board.product_name = dev.product_name or f"{dev.product_id:#06x}"
-                new_board.serial_number = dev.serial_number \
-                        or generate_device_unique_id(dev.vendor_id, dev.product_id, dev.device_path)
-                new_board.vid = dev.vendor_id
-                new_board.pid = dev.product_id
-                new_board.device = dev
+                new_board = PyWinUSB(dev)
                 boards.append(new_board)
             except Exception as e:
                 if (str(e) != "Failure to get HID pre parsed data"):


### PR DESCRIPTION
Some CMSIS-DAP backend maintenance here.

1. On the pyusb backends, only reads were given a timeout. This is addressed with a consistent 10 second timeout for all transfers. This is a real issue on Linux systems because the kernel USB stack can stall transfers for 5 seconds if a device on the same USB controller stops responding (as can easily happen when debugging USB device firmware).
2. The optional `timeout` argument to the backend `.read()` method was removed, and the same timeout 10 second used.
3. Cleaned up how the backend objects are constructed, by passing the device object or info to the constructor and letting it initialise attributes, rather than doing it all in `get_all_connected_interfaces()`.