### PR TITLE
commands: rmwatch optionally accepts type and size

### DIFF
--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -247,7 +247,7 @@ class SoCTarget(TargetGraphNode):
     def set_watchpoint(self, addr: int, size: int, type: Target.WatchpointType) -> bool:
         return self.selected_core_or_raise.set_watchpoint(addr, size, type)
 
-    def remove_watchpoint(self, addr: int, size: int, type: Target.WatchpointType) -> None:
+    def remove_watchpoint(self, addr: int, size: Optional[int], type: Optional[Target.WatchpointType]) -> None:
         return self.selected_core_or_raise.remove_watchpoint(addr, size, type)
 
     def reset(self, reset_type: Optional[Target.ResetType] = None) -> None:

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -290,7 +290,7 @@ class Target(MemoryInterface):
     def set_watchpoint(self, addr: int, size: int, type: WatchpointType) -> bool:
         raise NotImplementedError()
 
-    def remove_watchpoint(self, addr: int, size: int, type: WatchpointType) -> None:
+    def remove_watchpoint(self, addr: int, size: Optional[int], type: Optional[WatchpointType]) -> None:
         raise NotImplementedError()
 
     def reset(self, reset_type: Optional[ResetType] = None) -> None:

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1268,7 +1268,7 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         if self.dwt is not None:
             return self.dwt.set_watchpoint(addr, size, type)
 
-    def remove_watchpoint(self, addr, size, type):
+    def remove_watchpoint(self, addr, size=None, type=None):
         """@brief Remove a hardware watchpoint.
         """
         if self.dwt is not None:

--- a/pyocd/coresight/dwt.py
+++ b/pyocd/coresight/dwt.py
@@ -162,15 +162,19 @@ class DWT(CoreSightComponent):
         LOG.error('No more watchpoints are available, dropped watchpoint at 0x%08x', addr)
         return False
 
-    def remove_watchpoint(self, addr, size, type):
-        """@brief Remove a hardware watchpoint."""
-        watch = self.find_watchpoint(addr, size, type)
-        if watch is None:
-            return
+    def remove_watchpoint(self, addr, size=None, type=None):
+        """@brief Remove a hardware watchpoint.
 
-        watch.func = 0
-        self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, 0)
-        self.watchpoint_used -= 1
+        size and type are optional. If not specified, all watchpoints matching other parameters, or only
+        the address if neither size nor type are specified, will be removed.
+        """
+        for watch in self.watchpoints:
+            if (watch.addr == addr
+                    and (size is None or watch.size == size)
+                    and (type is None or watch.func == self.WATCH_TYPE_TO_FUNCT[type])):
+                watch.func = 0
+                self.ap.write_memory(watch.comp_register_addr + self.DWT_FUNCTION_OFFSET, 0)
+                self.watchpoint_used -= 1
 
     def remove_all_watchpoints(self):
         for watch in self.watchpoints:


### PR DESCRIPTION
This patch addresses issues with the `rmwatch` command. The `Target.remove_watchpoint()` API required the address, size, and type to remove a watchpoint, but `rmwatch` only passed the address.

1. `Target.remove_watchpoint()` size and type parameters are optional now. This means the API can now remove more than one watchpoint if size and/or type are not provided and there are multiple watchpoints with the same address (although more than one watchpoint for a single address is very rare).
2. `rmwatch` optionally accepts size and type parameters, with the same format as `watch`.