### PR TITLE
probe: stlink: hnonsec and hprot support

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -59,9 +59,9 @@ Remove a breakpoint.
 <tr><td>
 <a href="#rmwatch"><tt>rmwatch</tt></a>
 </td><td>
-ADDR
+ADDR [r|w|rw] [1|2|4]
 </td><td>
-Remove a watchpoint.
+Remove watchpoint(s).
 </td></tr>
 
 <tr><td>
@@ -547,15 +547,16 @@ Print the target object graph.
 </td><td>
 read-write
 </td><td>
-The current HNONSEC value used by the selected MEM-AP.
+The current HNONSEC attribute value used by the selected MEM-AP.
 </td></tr>
 
 <tr><td>
-<a href="#hprot"><tt>hprot</tt></a>
+<a href="#hprot"><tt>hprot</tt></a>,
+<a href="#hprot"><tt>memap_attr</tt></a>
 </td><td>
 read-write
 </td><td>
-The current HPROT value used by the selected MEM-AP.
+The current memory transfer attributes value used by the selected MEM-AP.
 </td></tr>
 
 <tr><td>
@@ -692,8 +693,8 @@ Remove a breakpoint.
 
 ##### `rmwatch`
 
-**Usage**: rmwatch ADDR \
-Remove a watchpoint.
+**Usage**: rmwatch ADDR [r|w|rw] [1|2|4] \
+Remove watchpoint(s). Access type and size are optional. All watchpoints matching the specified parameters will be removed.
 
 
 ##### `watch`
@@ -1074,13 +1075,18 @@ Print the target object graph.
 
 **Access**: read-write \
 **Usage**: show hnonsec, set hnonsec VALUE \
-The current HNONSEC value used by the selected MEM-AP.
+The current HNONSEC attribute value used by the selected MEM-AP. This value controls whether memory transactions are secure or nonsecure. The value is an integer, either 0 or secure or 1 for nonsecure.
 
 ##### `hprot`
 
+**Aliases**: `memap_attr` \
 **Access**: read-write \
 **Usage**: show hprot, set hprot VALUE \
-The current HPROT value used by the selected MEM-AP.
+The current memory transfer attributes value used by the selected MEM-AP. This integer value controls attributes of memory transfers. It is a direct mapping of the AHB
+or AXI attribute settings, depending on the type of MEM-AP. For AHB-APs, the value is HPROT[4:0].
+For AXI-APs, the value is {AxPROT[2:0}, AxCACHE[3:0]}, e.g. AxPROT in bits 6-4 and AxCACHE in
+its 3-0. Not all MEM-AP implementations support all attributes. See the Arm Technical Reference
+Manual for your device's MEM-AP for details.
 
 ##### `locked`
 

--- a/docs/debug_probes.md
+++ b/docs/debug_probes.md
@@ -129,7 +129,8 @@ In addition, there are numerous other commercial and open source debug probes ut
 PyOCD supports automatic target type identification for debug probes built with the widely used
 [DAPLink](https://github.com/ARMmbed/DAPLink) firmware.
 
-[DAPLink firmware updates](https://daplink.io/)
+DAPLink firmware updates are available on the [daplink.io](https://daplink.io/) site and on the project's
+[releases page](https://github.com/ARMmbed/DAPLink/releases) on GitHub.
 
 #### Session options
 
@@ -156,12 +157,15 @@ No host resident drivers need to be installed to use STLink probes; only libusb 
 The minimum supported STLink firmware version is V2J24, or any V3 version. However, upgrading to the latest version
 is strongly recommended. Numerous bugs have been fixed, and new commands added for feature and performance improvements.
 
-- V2J26: Adds 16-bit transfer support. If not supported, pyOCD will fall back to 8-bit transfers—it is possible this
+- V2J26: Adds 16-bit transfer support. If not supported, pyOCD will fall back to 8-bit transfers. It is possible this
     will produce unexpected behaviour if used to access Device memory (e.g. memory mapped registers).
 - V2J28: Minimum version for multicore target support.
-- V2J32/V3J6: Allows access to banked DP registers. Usually not needed.
+- V2J32/V3J2: Allows access to banked DP registers. Usually not needed.
+- V2J32/V3J2: Supports setting the AHB and AXI transfer attributes. See
+    [`set hnonsec`]({% link _docs/command_reference.md#hnonsec %}) and
+    [`set hprot`]({% link command_reference.md_docs/#hprot %}).
 
-[Firmware updates](https://www.st.com/en/development-tools/stsw-link007.html)
+[STLink firmware updates on www.st.com](https://www.st.com/en/development-tools/stsw-link007.html).
 
 PyOCD supports automatic target type identification for on-board STLink probes that report a board ID.
 
@@ -195,7 +199,7 @@ These are the SWD/JTAG frequencies available with different values of `stlink.v3
 To use a Segger J-Link probe, the driver package must be installed. Segger makes drivers available for Linux, macOS,
 and Windows.
 
-[Firmware and driver installer and updates](https://www.segger.com/downloads/jlink/)
+[J-Link firmware and driver installer and updates on www.segger.com](https://www.segger.com/downloads/jlink/)
 
 On macOS, you can install the `segger-jlink` cask with Homebrew to get managed driver updates.
 

--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -362,7 +362,10 @@ class HnonsecValue(ValueBase):
             'group': 'standard',
             'category': 'memory',
             'access': 'rw',
-            'help': "The current HNONSEC value used by the selected MEM-AP.",
+            'help': "The current HNONSEC attribute value used by the selected MEM-AP.",
+            'extra_help':
+                "This value controls whether memory transactions are secure or nonsecure. The value is an "
+                "integer, either 0 or secure or 1 for nonsecure."
             }
 
     def display(self, args):
@@ -385,11 +388,17 @@ class HnonsecValue(ValueBase):
 
 class HprotValue(ValueBase):
     INFO = {
-            'names': ['hprot'],
+            'names': ['hprot', 'memap_attr'],
             'group': 'standard',
             'category': 'memory',
             'access': 'rw',
-            'help': "The current HPROT value used by the selected MEM-AP.",
+            'help': "The current memory transfer attributes value used by the selected MEM-AP.",
+            'extra_help':
+"""This integer value controls attributes of memory transfers. It is a direct mapping of the AHB
+or AXI attribute settings, depending on the type of MEM-AP. For AHB-APs, the value is HPROT[4:0].
+For AXI-APs, the value is {AxPROT[2:0}, AxCACHE[3:0]}, e.g. AxPROT in bits 6-4 and AxCACHE in
+its 3-0. Not all MEM-AP implementations support all attributes. See the Arm Technical Reference
+Manual for your device's MEM-AP for details."""
             }
 
     def display(self, args):

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -19,7 +19,7 @@ import logging
 import struct
 import threading
 from enum import Enum
-from typing import (List, Optional, Sequence, Tuple)
+from typing import (List, Optional, Sequence, Tuple, Union)
 import usb.core
 
 from .constants import (Commands, Status, SWD_FREQ_MAP, JTAG_FREQ_MAP)
@@ -262,7 +262,7 @@ class STLink(object):
             if response[0] != Status.JTAG_CONF_CHANGED:
                 self._check_status(response[0:2])
 
-    def set_swd_frequency(self, freq=1800000):
+    def set_swd_frequency(self, freq: Union[int, float] = 1800000):
         with self._lock:
             if self._hw_version >= 3:
                 self.set_com_frequency(self.Protocol.SWD, freq)
@@ -274,7 +274,7 @@ class STLink(object):
                         return
                 raise exceptions.ProbeError("Selected SWD frequency is too low")
 
-    def set_jtag_frequency(self, freq=1120000):
+    def set_jtag_frequency(self, freq: Union[int, float] = 1120000):
         with self._lock:
             if self._hw_version >= 3:
                 self.set_com_frequency(self.Protocol.JTAG, freq)
@@ -286,7 +286,7 @@ class STLink(object):
                         return
                 raise exceptions.ProbeError("Selected JTAG frequency is too low")
 
-    def get_com_frequencies(self, protocol):
+    def get_com_frequencies(self, protocol: "STLink.Protocol"):
         assert self._hw_version >= 3
 
         with self._lock:
@@ -299,7 +299,7 @@ class STLink(object):
             freqCount = freqs.pop(0)
             return currentFreq, freqs[:freqCount]
 
-    def set_com_frequency(self, protocol, freq):
+    def set_com_frequency(self, protocol: "STLink.Protocol", freq: Union[int, float]):
         assert self._hw_version >= 3
 
         with self._lock:

--- a/pyocd/probe/stlink/stlink.py
+++ b/pyocd/probe/stlink/stlink.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ import logging
 import struct
 import threading
 from enum import Enum
-from typing import Optional
+from typing import (List, Optional, Sequence, Tuple)
 import usb.core
 
 from .constants import (Commands, Status, SWD_FREQ_MAP, JTAG_FREQ_MAP)
@@ -41,8 +41,8 @@ class STLink(object):
 
     ## Maximum number of bytes to send or receive for 32- and 16- bit transfers.
     #
-    # 8-bit transfers have a maximum size of the maximum USB packet size (64 bytes for full speed).
-    MAXIMUM_TRANSFER_SIZE = 1024
+    # 8-bit transfers have a maximum size of the maximum USB packet size (64 bytes for full speed, 512 for HS).
+    MAXIMUM_TRANSFER_SIZE = 6144
 
     ## Minimum required STLink firmware version (hw version 2).
     MIN_JTAG_VERSION = 24
@@ -62,6 +62,11 @@ class STLink(object):
     #
     # Keys are the hardware version, value is the minimum JTAG version.
     MIN_JTAG_VERSION_GET_BOARD_IDS = {2: 36, 3: 6}
+
+    ## Firmware versions that support CSW settings on memory access commands.
+    #
+    # Keys are the hardware version, value is the minimum JTAG version.
+    MIN_JTAG_VERSION_MEM_CSW = {2: 32, 3: 2}
 
     ## Port number to use to indicate DP registers.
     DP_PORT = 0xffff
@@ -368,14 +373,34 @@ class STLink(object):
                 self.write_dap_register(self.DP_PORT, dap.DP_CTRL_STAT,
                     dap.CTRLSTAT_STICKYERR | dap.CTRLSTAT_STICKYCMP | dap.CTRLSTAT_STICKYORUN)
 
-    def _read_mem(self, addr, size, memcmd, maxrx, apsel):
+    def _get_csw_bytes(self, csw: int) -> Tuple[int, int, int]:
+        """@brief Return the 3 bytes in little endian order for CSW[31:8] sent in the mem command.
+        @param csw CSW to use for the MEM-AP. Only the top 24 bits are used.
+        """
+        if self._check_version(self.MIN_JTAG_VERSION_MEM_CSW[self._hw_version]):
+            return ((csw >> 8) & 0xff), ((csw >> 16) & 0xff), ((csw >> 24) & 0xff)
+        else:
+            # This version of STLink firmware doesn't support nonstandard CSW.
+            # TODO should we log a warning here or elsewhere if csw is set to other than
+            # Secure,Priv,Noncacheable,Nonbufferable,Data?
+            return 0, 0, 0
+
+    def _read_mem(self, addr: int, size: int, memcmd: int, maxrx: int, apsel: int, csw: int) -> List[int]:
         with self._lock:
             result = []
             while size:
                 thisTransferSize = min(size, maxrx)
 
+                # Read Memory {8,16,32} command bytes
+                #   0:      JTAG_COMMAND
+                #   1:      JTAG_READMEM_{8,16,32}BIT
+                #   2-5:    address
+                #   6-7:    length in bytes <= 6144 (except 8-bit must <= USB packet size)
+                #   8:      APSEL
+                #   9-11:   CSW[31:8]
+                #   12-15:  TCP unique ID (not used by pyocd)
                 cmd = [Commands.JTAG_COMMAND, memcmd]
-                cmd.extend(struct.pack('<IHB', addr, thisTransferSize, apsel))
+                cmd.extend(struct.pack('<IHBBBB', addr, thisTransferSize, apsel, *self._get_csw_bytes(csw)))
                 result += self._device.transfer(cmd, readSize=thisTransferSize)
 
                 addr += thisTransferSize
@@ -402,14 +427,22 @@ class STLink(object):
                         raise exceptions.ProbeError(error_message)
             return result
 
-    def _write_mem(self, addr, data, memcmd, maxtx, apsel):
+    def _write_mem(self, addr: int, data: Sequence[int], memcmd: int, maxtx: int, apsel: int, csw: int) -> None:
         with self._lock:
             while len(data):
                 thisTransferSize = min(len(data), maxtx)
                 thisTransferData = data[:thisTransferSize]
 
+                # Write Memory {8,16,32} command bytes
+                #   0:      JTAG_COMMAND
+                #   1:      JTAG_WRITEMEM_{8,16,32}BIT
+                #   2-5:    address
+                #   6-7:    length in bytes <= 6144 (except 8-bit must <= USB packet size)
+                #   8:      APSEL
+                #   9-11:   CSW[31:8]
+                #   12-15:  TCP unique ID (not used by pyocd)
                 cmd = [Commands.JTAG_COMMAND, memcmd]
-                cmd.extend(struct.pack('<IHB', addr, thisTransferSize, apsel))
+                cmd.extend(struct.pack('<IHBBBB', addr, thisTransferSize, apsel, *self._get_csw_bytes(csw)))
                 self._device.transfer(cmd, writeData=thisTransferData)
 
                 addr += thisTransferSize
@@ -435,38 +468,38 @@ class STLink(object):
                     elif status != Status.JTAG_OK:
                         raise exceptions.ProbeError(error_message)
 
-    def read_mem32(self, addr, size, apsel):
+    def read_mem32(self, addr: int, size: int, apsel: int, csw: int):
         assert (addr & 0x3) == 0 and (size & 0x3) == 0, "address and size must be word aligned"
-        return self._read_mem(addr, size, Commands.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel, csw)
 
-    def write_mem32(self, addr, data, apsel):
+    def write_mem32(self, addr: int, data: Sequence[int], apsel: int, csw: int):
         assert (addr & 0x3) == 0 and (len(data) & 3) == 0, "address and size must be word aligned"
-        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_32BIT, self.MAXIMUM_TRANSFER_SIZE, apsel, csw)
 
-    def read_mem16(self, addr, size, apsel):
+    def read_mem16(self, addr: int, size: int, apsel: int, csw: int):
         assert (addr & 0x1) == 0 and (size & 0x1) == 0, "address and size must be half-word aligned"
 
         if not self._check_version(self.MIN_JTAG_VERSION_16BIT_XFER):
             # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
-            return self.read_mem8(addr, size, apsel)
+            return self.read_mem8(addr, size, apsel, csw)
 
-        return self._read_mem(addr, size, Commands.JTAG_READMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel, csw)
 
-    def write_mem16(self, addr, data, apsel):
+    def write_mem16(self, addr: int, data: Sequence[int], apsel: int, csw: int):
         assert (addr & 0x1) == 0 and (len(data) & 1) == 0, "address and size must be half-word aligned"
 
         if not self._check_version(self.MIN_JTAG_VERSION_16BIT_XFER):
             # 16-bit r/w is only available from J26, so revert to 8-bit accesses.
-            self.write_mem8(addr, data, apsel)
+            self.write_mem8(addr, data, apsel, csw)
             return
 
-        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel)
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_16BIT, self.MAXIMUM_TRANSFER_SIZE, apsel, csw)
 
-    def read_mem8(self, addr, size, apsel):
-        return self._read_mem(addr, size, Commands.JTAG_READMEM_8BIT, self._device.max_packet_size, apsel)
+    def read_mem8(self, addr: int, size: int, apsel: int, csw: int):
+        return self._read_mem(addr, size, Commands.JTAG_READMEM_8BIT, self._device.max_packet_size, apsel, csw)
 
-    def write_mem8(self, addr, data, apsel):
-        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_8BIT, self._device.max_packet_size, apsel)
+    def write_mem8(self, addr: int, data: Sequence[int], apsel: int, csw: int):
+        self._write_mem(addr, data, Commands.JTAG_WRITEMEM_8BIT, self._device.max_packet_size, apsel, csw)
 
     def _check_dp_bank(self, port, addr):
         """@brief Check if attempting to access a banked DP register with a firmware version that

--- a/pyocd/probe/stlink/usb.py
+++ b/pyocd/probe/stlink/usb.py
@@ -256,6 +256,12 @@ class STLinkUSBInterface:
                 data = self._read(readSize)
                 if TRACE.isEnabledFor(logging.DEBUG):
                     TRACE.debug("  USB IN < (%d) %s", len(data), ' '.join([f'{i:02x}' for i in data]))
+
+                # Verify we got all requested data.
+                if len(data) < readSize:
+                    raise exceptions.ProbeError("received incomplete command response from STLink "
+                            f"(got {len(data)}, expected {readSize}")
+
                 return data
         except usb.core.USBError as exc:
             raise exceptions.ProbeError("USB Error: %s" % exc) from exc

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -22,7 +22,7 @@ from .debug_probe import DebugProbe
 from ..core.memory_interface import MemoryInterface
 from ..core.plugin import Plugin
 from ..core.options import OptionInfo
-from ..coresight.ap import (APVersion, APSEL, APSEL_SHIFT)
+from ..coresight.ap import (APVersion, APSEL, APSEL_SHIFT, APv1Address)
 from .stlink.usb import STLinkUSBInterface
 from .stlink.stlink import STLink
 from .stlink.detect.factory import create_mbed_detector
@@ -229,6 +229,7 @@ class StlinkProbe(DebugProbe):
         # STLink memory access commands only support an 8-bit APSEL.
         if ap_address.ap_version != APVersion.APv1:
             return None
+        assert isinstance(ap_address, APv1Address)
         apsel = ap_address.apsel
         if apsel not in self._memory_interfaces:
             self._link.open_ap(apsel)

--- a/pyocd/probe/tcp_client_probe.py
+++ b/pyocd/probe/tcp_client_probe.py
@@ -253,6 +253,8 @@ class TCPClientProbe(DebugProbe):
     ##@{
 
     def connect(self, protocol=None):
+        if protocol is None:
+            protocol = DebugProbe.Protocol.DEFAULT
         self._perform_request('connect', protocol.name)
 
     def disconnect(self):
@@ -362,11 +364,11 @@ class RemoteMemoryInterface(MemoryInterface):
         self._remote_probe = remote_probe
         self._handle = handle
 
-    def write_memory(self, addr, data, transfer_size=32):
+    def write_memory(self, addr, data, transfer_size=32, **attrs):
         assert transfer_size in (8, 16, 32)
         self._remote_probe._perform_request('write_mem', self._handle, addr, data, transfer_size)
 
-    def read_memory(self, addr, transfer_size=32, now=True):
+    def read_memory(self, addr, transfer_size=32, now=True, **attrs):
         assert transfer_size in (8, 16, 32)
         result, exc = self._remote_probe._perform_request_without_raise('read_mem', self._handle, addr, transfer_size)
 
@@ -377,16 +379,16 @@ class RemoteMemoryInterface(MemoryInterface):
             return result
         return read_callback() if now else read_callback
 
-    def write_memory_block32(self, addr, data):
+    def write_memory_block32(self, addr, data, **attrs):
         self._remote_probe._perform_request('write_block32', self._handle, addr, data)
 
-    def read_memory_block32(self, addr, size):
+    def read_memory_block32(self, addr, size, **attrs):
         return self._remote_probe._perform_request('read_block32', self._handle, addr, size)
 
-    def write_memory_block8(self, addr, data):
+    def write_memory_block8(self, addr, data, **attrs):
         self._remote_probe._perform_request('write_block8', self._handle, addr, data)
 
-    def read_memory_block8(self, addr, size):
+    def read_memory_block8(self, addr, size, **attrs):
         return self._remote_probe._perform_request('read_block8', self._handle, addr, size)
 
 class TCPClientProbePlugin(Plugin):


### PR DESCRIPTION
This patch enables changing the security and other AHB/AXI transaction attributes when performing memory transfers via the STLink accelerated memory commands, ultimately changing the MEM-AP's `CSW` register value. These attributes are set using methods on the `MEM_AP` objects, or with the `set hnonsec` and `set hprot` commands. Which HPROT bits are supported and what they mean varies by the device and MEM-AP version; see Arm docs for details.

Note that there is an existing issue when modified transaction attributes: currently pyocd will use whatever attributes you have set for its own debug register accesses, not just user-triggered memory accesses. (Actually, modifying pyocd's accesses is the original reason this feature was introduced, so this issue is really a side effect of the original use case.) So for instance, if you change to unprivileged transactions (`HPROT[1]` = 0), then Cortex-M PPB registers cannot be accessed. Similarly, changing HNONSEC will modify the banked copy of PPB registers that is accesses.