### PR TITLE
flash: init flash algo with default reset type

### DIFF
--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -229,7 +229,7 @@ class Flash:
             TRACE.debug("algo init and load to %#010x", self.flash_algo['load_address'])
 
             if reset:
-                self.target.reset_and_halt(Target.ResetType.SW)
+                self.target.reset_and_halt()
             self.prepare_target()
 
             # Load flash algo code into target RAM.


### PR DESCRIPTION
When resetting the target to init a flash algo, use the default reset type instead of always forcing software reset. This means that user choice made by changing the `reset_type` option also affect flash algos.

Fixes one of the problems in #1327.