### PR TITLE
flash: mass erase: clean up confusing log messages

### DIFF
--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -178,7 +178,9 @@ class SoCTarget(TargetGraphNode):
     def mass_erase(self) -> None:
         if not self.call_delegate('mass_erase', target=self):
             # The default mass erase implementation is to simply perform a chip erase.
-            FlashEraser(self.session, FlashEraser.Mode.CHIP).erase()
+            eraser = FlashEraser(self.session, FlashEraser.Mode.CHIP)
+            eraser._log_chip_erase = False
+            eraser.erase()
 
     def write_memory(self, addr: int, data: int, transfer_size: int = 32) -> None:
         return self.selected_core_or_raise.write_memory(addr, data, transfer_size)


### PR DESCRIPTION
When chip erase is used as the default method of performing a mass erase, for targets that don't implement `Target.mass_erase()`, the user would see both mass and chip erase messages. The mass erase would always be reported as failing. Both problems are solved, and a single pair of erasing/completed messages is logged.

Example log extract for NXP MIMXRT1052:

```
...
0003116 I Mass erasing device... [eraser]
0003218 I IMXRT Boot Mode: Internal Boot [target_imxrt]
0003260 I IMXRT Boot Device: 0 [target_imxrt]
0010555 I Mass erase complete [eraser]
```

Fixes one of the issues identified in #1327.