### PR TITLE
log messages: normalise error log messages to start with "Error:"

### DIFF
--- a/pyocd/__main__.py
+++ b/pyocd/__main__.py
@@ -168,7 +168,7 @@ class PyOCDTool(SubcommandBase):
             LOG.critical(e, exc_info=Session.get_current().log_tracebacks)
             return 1
         except Exception as e:
-            LOG.critical("uncaught exception: %s", e, exc_info=Session.get_current().log_tracebacks)
+            LOG.critical("Error: %s", e, exc_info=Session.get_current().log_tracebacks)
             return 1
 
     def show_options_help(self) -> None:

--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -132,12 +132,9 @@ class Board(GraphNode):
         """@brief Uninitialize the board."""
         if self._inited:
             LOG.debug("uninit board %s", self)
-            try:
-                resume = self.session.options.get('resume_on_disconnect')
-                self.target.disconnect(resume)
-                self._inited = False
-            except exceptions.Error as err:
-                LOG.error("link exception during target disconnect: %s", err, exc_info=self._session.log_tracebacks)
+            resume = self.session.options.get('resume_on_disconnect')
+            self.target.disconnect(resume)
+            self._inited = False
 
     @property
     def session(self) -> "Session":

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -544,17 +544,17 @@ class Session(Notifier):
                 self._board.uninit()
                 self._inited = False
             except exceptions.Error:
-                LOG.error("exception during board uninit:", exc_info=self.log_tracebacks)
+                LOG.error("Error during board uninit:", exc_info=self.log_tracebacks)
 
         if self._probe.is_open:
             try:
                 self._probe.disconnect()
             except exceptions.Error:
-                LOG.error("probe exception during disconnect:", exc_info=self.log_tracebacks)
+                LOG.error("Probe error during disconnect:", exc_info=self.log_tracebacks)
             try:
                 self._probe.close()
             except exceptions.Error:
-                LOG.error("probe exception during close:", exc_info=self.log_tracebacks)
+                LOG.error("Probe error during close:", exc_info=self.log_tracebacks)
 
 class UserScriptFunctionProxy:
     """@brief Proxy for user script functions.

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -134,7 +134,7 @@ class ADIv5Discovery(CoreSightDiscovery):
                     if invalid_count == self.session.options.get('adi.v5.max_invalid_ap_count'):
                         break
             except exceptions.Error as e:
-                LOG.error("Exception while probing AP#%d: %s", apsel, e,
+                LOG.error("Error probing AP#%d: %s", apsel, e,
                     exc_info=self.session.log_tracebacks)
                 break
             apsel += 1
@@ -162,7 +162,7 @@ class ADIv5Discovery(CoreSightDiscovery):
             ap = AccessPort.create(self.dp, ap_address)
             self.dp.aps[ap_address] = ap
         except exceptions.Error as e:
-            LOG.error("Exception reading AP#%d IDR: %s", apsel, e,
+            LOG.error("Error reading AP#%d IDR: %s", apsel, e,
                 exc_info=self.session.log_tracebacks)
 
     def _find_components(self):
@@ -242,7 +242,7 @@ class ADIv6Discovery(CoreSightDiscovery):
             ap = AccessPort.create(self.dp, ap_address, cmpid=cmpid)
             self.dp.aps[ap_address] = ap
         except exceptions.Error as e:
-            LOG.error("Exception reading AP@0x%08x IDR: %s", cmpid.address, e,
+            LOG.error("Error reading AP@0x%08x IDR: %s", cmpid.address, e,
                     exc_info=self.session.log_tracebacks)
 
     def _create_root_component(self, cmpid):
@@ -261,7 +261,7 @@ class ADIv6Discovery(CoreSightDiscovery):
             self.target.add_child(component)
             component.init()
         except exceptions.Error as e:
-            LOG.error("Exception creating root component at address 0x%08x: %s", cmpid.address, e,
+            LOG.error("Error creating root component at address 0x%08x: %s", cmpid.address, e,
                     exc_info=self.session.log_tracebacks)
 
     def _find_components_on_aps(self):

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -445,7 +445,7 @@ class SemihostAgent(object):
                 LOG.warning("Semihost: unimplemented request pc=%x r0=%x r1=%x", pc, op, args)
                 result = -1
             except (exceptions.Error, IOError) as e:
-                LOG.error("Exception while handling semihost request: %s", e,
+                LOG.error("Error while handling semihost request: %s", e,
                     exc_info=session.Session.get_current().log_tracebacks)
                 result = -1
         else:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -612,7 +612,7 @@ class GDBServer(threading.Thread):
                     # Note: if the target is not actually halted, gdb can get confused from this point on.
                     # But there's not much we can do if we're getting faults attempting to control it.
                     if not fault_retry_timeout.is_running:
-                        LOG.error('Exception reading target status: %s', e, exc_info=self.session.log_tracebacks)
+                        LOG.error('Error reading target status: %s', e, exc_info=self.session.log_tracebacks)
                     val = ('S%02x' % signals.SIGINT).encode()
                 break
 
@@ -653,7 +653,7 @@ class GDBServer(threading.Thread):
                     self.target.halt()
                 except exceptions.Error:
                     pass
-                LOG.warning('Exception while target was running: %s', e, exc_info=self.session.log_tracebacks)
+                LOG.warning('Error while target was running: %s', e, exc_info=self.session.log_tracebacks)
                 # This exception was not a transfer error, so reading the target state should be ok.
                 val = ('S%02x' % self.target_facade.get_signal_value()).encode()
                 break
@@ -1068,7 +1068,7 @@ class GDBServer(threading.Thread):
                     exc_info=self.session.log_tracebacks)
         except Exception as err:
             stream.write("Unexpected error: %s\n" % err)
-            LOG.error("Exception while executing remote command '%s': %s", cmd, err,
+            LOG.error("Error while executing remote command '%s': %s", cmd, err,
                     exc_info=self.session.log_tracebacks)
 
         # Convert back to bytes, hex encode, then return the response packet.


### PR DESCRIPTION
For exception handlers that print error log messages, normalise them to begin with "Error:" followed by the exception description. Any cases of "uncaught" are removed.