### PR TITLE
clean up some cortex-m connect and disconnect issues

### DIFF
--- a/docs/user_scripts.md
+++ b/docs/user_scripts.md
@@ -161,13 +161,14 @@ both target related objects, as well as parts of the pyOCD Python API.
 This section documents all functions that user scripts can provide to modify pyOCD's behaviour. Some are simply
 notifications, while others allow for overriding of default behaviour. Collectively, these are called delegate functions.
 
-All parameters of script delegate functions are optional. Parameters can be declared in any order, and that are not
-needed can be excluded. In fact, most parameters are not necessary because the same objects are available as script
-globals, for instance `session` and `target`.
+All parameters of user script delegate functions are optional. Parameters can be declared in any order, and
+those that are not needed can be excluded. In fact, most parameters are not necessary because the same objects
+are available as [script globals](#script_globals), for instance `session` and `target`.
 
-Those parameters that are present must have names matching the specification below, and there must not be unspecified,
-required parameters (those without a default value). (Extra optional parameters are allowed but will never be passed any
-value other than the default, unless you call the function yourself from within the script.)
+Those parameters that are present must have names matching the specification below, and there must not be
+additional unspecified, required parameters (those without a default value). Extra optional parameters are
+allowed but will never be passed any value other than the default, unless you call the function yourself from
+within the script.
 
 
 ### will_connect
@@ -222,9 +223,26 @@ Ignored.
 
 ### will_start_debug_core
 
+Notification hook for before core debug is enabled.
+
+```
+will_start_debug_core(core: CoreTarget) -> None
+```
+
+**Parameters** \
+*core* - A `CoreTarget` object about to be initialized. \
+**Result** \
+Ignored.
+
+This hook is called during connection, prior to any register accesses being performed on the
+indicated core (aside from the CoreSight peripheral ID registers that were read to identify
+the core's presence during discovery).
+
+### start_debug_core
+
 Hook to enable debug for the given core.
 ```
-will_start_debug_core(core: CoreTarget) -> Optional[bool]
+start_debug_core(core: CoreTarget) -> Optional[bool]
 ```
 
 **Parameters** \
@@ -235,7 +253,7 @@ will_start_debug_core(core: CoreTarget) -> Optional[bool]
 
 ### did_start_debug_core
 
-Post-initialization hook.
+Notification hook that core debug has been enabled.
 ```
 did_start_debug_core(core: CoreTarget) -> None
 ```
@@ -245,11 +263,26 @@ did_start_debug_core(core: CoreTarget) -> None
 **Result** \
 Ignored.
 
+This hook method is called once a debug has been enabled for a core, and it has been fully
+identified.
+
 ### will_stop_debug_core
 
-Pre-cleanup hook for the core.
+Pre core disconnect notification hook for the core.
 ```
-will_stop_debug_core(core: CoreTarget) -> Optional[bool]
+will_stop_debug_core(core: CoreTarget) -> None
+```
+
+**Parameters** \
+*core* - A `CoreTarget` object. \
+**Result** \
+Ignored.
+
+### stop_debug_core
+
+Core debug disable hook.
+```
+stop_debug_core(core: CoreTarget) -> Optional[bool]
 ```
 
 **Parameters** \
@@ -260,7 +293,7 @@ will_stop_debug_core(core: CoreTarget) -> Optional[bool]
 
 ### did_stop_debug_core
 
-Post-cleanup notification for the core.
+Post core disconnect notification hook for the core.
 ```
 did_stop_debug_core(core: CoreTarget) -> None
 ```

--- a/pyocd/core/target_delegate.py
+++ b/pyocd/core/target_delegate.py
@@ -20,6 +20,7 @@ from typing import (Optional, TYPE_CHECKING)
 if TYPE_CHECKING:
     from .session import Session
     from .soc_target import SoCTarget
+    from .core_target import CoreTarget
     from .target import Target
     from ..board.board import Board
     from ..utility.sequencer import CallSequence
@@ -76,36 +77,61 @@ class TargetDelegateInterface:
         """
         pass
 
-    def will_start_debug_core(self, core: "Target") -> DelegateResult:
-        """@brief Hook to enable debug for the given core.
+    def will_start_debug_core(self, core: "CoreTarget") -> None:
+        """@brief Notification hook for before core debug is enabled.
+
+        This hook is called during connection, prior to any register accesses being performed on the
+        indicated core (aside from the CoreSight peripheral ID registers that were read to identify
+        the core's presence during discovery).
+
         @param self
-        @param core A CortexM object about to be initialized.
+        @param core A CoreTarget object about to be initialized.
+        @return Ignored.
+        """
+        pass
+
+    def start_debug_core(self, core: "CoreTarget") -> DelegateResult:
+        """@brief Core debug initialization hook.
+        @param self
+        @param core A CoreTarget object.
         @retval True Do not perform the normal procedure to start core debug.
         @retval "False or None" Continue with normal behaviour.
         """
         pass
 
-    def did_start_debug_core(self, core: "Target") -> None:
-        """@brief Post-initialization hook.
+    def did_start_debug_core(self, core: "CoreTarget") -> None:
+        """@brief Notification hook that core debug has been enabled.
+
+        This hook method is called once a debug has been enabled for a core, and it has been fully
+        identified.
+
         @param self
-        @param core A CortexM object.
+        @param core A CoreTarget object.
         @return Ignored.
         """
         pass
 
-    def will_stop_debug_core(self, core: "Target") -> DelegateResult:
-        """@brief Pre-cleanup hook for the core.
+    def will_stop_debug_core(self, core: "CoreTarget") -> None:
+        """@brief Pre core disconnect notification hook for the core.
         @param self
-        @param core A CortexM object.
+        @param core A CoreTarget object.
+        @return Ignored.
+        """
+        pass
+
+    def stop_debug_core(self, core: "CoreTarget") -> DelegateResult:
+        """@brief Core debug disable hook.
+        @param self
+        @param core A CoreTarget object.
         @retval True Do not perform the normal procedure to disable core debug.
         @retval "False or None" Continue with normal behaviour.
         """
         pass
 
-    def did_stop_debug_core(self, core: "Target") -> None:
-        """@brief Post-cleanup hook for the core.
+    def did_stop_debug_core(self, core: "CoreTarget") -> None:
+        """@brief Post core disconnect notification hook for the core.
         @param self
-        @param core A CortexM object.
+        @param core A CoreTarget object.
         @return Ignored.
         """
         pass
@@ -146,7 +172,7 @@ class TargetDelegateInterface:
         """
         pass
 
-    def set_reset_catch(self, core: "Target", reset_type: "Target.ResetType") -> DelegateResult:
+    def set_reset_catch(self, core: "CoreTarget", reset_type: "Target.ResetType") -> DelegateResult:
         """@brief Hook to prepare target for halting on reset.
         @param self
         @param core A CortexM instance.
@@ -156,7 +182,7 @@ class TargetDelegateInterface:
         """
         pass
 
-    def clear_reset_catch(self, core: "Target", reset_type: "Target.ResetType") -> None:
+    def clear_reset_catch(self, core: "CoreTarget", reset_type: "Target.ResetType") -> None:
         """@brief Hook to clean up target after a reset and halt.
         @param self
         @param core A CortexM instance.

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -330,14 +330,14 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         """
         self.call_delegate('will_start_debug_core', core=self)
 
+        # Enable debug
+        if not self.call_delegate('start_debug_core', core=self):
+            self.write32(self.DHCSR, self.DBGKEY | self.C_DEBUGEN)
+
         # Examine this CPU.
         self._read_core_type()
         self._check_for_fpu()
         self._build_registers()
-
-        # Enable debug
-        if not self.call_delegate('start_debug_core', core=self):
-            self.write32(self.DHCSR, self.DBGKEY | self.C_DEBUGEN)
 
         self.sw_bp.init()
 

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -173,13 +173,18 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
 
     # Media and FP Feature Register 0
     MVFR0 = 0xE000EF40
+    MVFR0_SINGLE_PRECISION_MASK = 0x000000f0
+    MVFR0_SINGLE_PRECISION_SHIFT = 4
+    MVFR0_SINGLE_PRECISION_SUPPORTED = 2
     MVFR0_DOUBLE_PRECISION_MASK = 0x00000f00
     MVFR0_DOUBLE_PRECISION_SHIFT = 8
+    MVFR0_DOUBLE_PRECISION_SUPPORTED = 2
 
     # Media and FP Feature Register 2
     MVFR2 = 0xE000EF48
     MVFR2_VFP_MISC_MASK = 0x000000f0
     MVFR2_VFP_MISC_SHIFT = 4
+    MVFR2_VFP_MISC_SUPPORTED = 4
 
     _RESET_RECOVERY_SLEEP_INTERVAL = 0.01 # 10 ms
 
@@ -410,34 +415,37 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
             self.has_fpu = False
             return
 
-        originalCpacr = self.read32(CortexM.CPACR)
-        cpacr = originalCpacr | CortexM.CPACR_CP10_CP11_MASK
-        self.write32(CortexM.CPACR, cpacr)
-
-        cpacr = self.read32(CortexM.CPACR)
-        self.has_fpu = (cpacr & CortexM.CPACR_CP10_CP11_MASK) != 0
-
-        # Restore previous value.
-        self.write32(CortexM.CPACR, originalCpacr)
+        # Determine presence of an FPU by checking if single- and/or double-precision floating
+        # point operations are supported.
+        #
+        # Note that one of the recommended tests for an FPU was to attempt enabling the FPU via a
+        # write to CPACR and checking the result. This test has the unfortunate property of not
+        # working on certain cores when the core is held in reset, because CPACR is not accessible
+        # under reset on all cores. Thus we use MVFR0.
+        mvfr0 = self.read32(CortexM.MVFR0)
+        sp_val = (mvfr0 & CortexM.MVFR0_SINGLE_PRECISION_MASK) >> CortexM.MVFR0_SINGLE_PRECISION_SHIFT
+        dp_val = (mvfr0 & CortexM.MVFR0_DOUBLE_PRECISION_MASK) >> CortexM.MVFR0_DOUBLE_PRECISION_SHIFT
+        self.has_fpu = ((sp_val == self.MVFR0_SINGLE_PRECISION_SUPPORTED) or
+                (dp_val == self.MVFR0_DOUBLE_PRECISION_SUPPORTED))
 
         if self.has_fpu:
             self._extensions.append(CortexMExtension.FPU)
 
-            # Now check whether double-precision is supported.
-            # (Minimal tests to distinguish current permitted ARMv7-M and
-            # ARMv8-M FPU types; used for printing only).
-            mvfr0 = self.read32(CortexM.MVFR0)
-            dp_val = (mvfr0 & CortexM.MVFR0_DOUBLE_PRECISION_MASK) >> CortexM.MVFR0_DOUBLE_PRECISION_SHIFT
+            # Now check the VFP version by looking for support for the misc FP instructions added in
+            # FPv5 (VMINNM, VMAXNM, etc).
 
             mvfr2 = self.read32(CortexM.MVFR2)
             vfp_misc_val = (mvfr2 & CortexM.MVFR2_VFP_MISC_MASK) >> CortexM.MVFR2_VFP_MISC_SHIFT
 
-            if dp_val >= 2:
+            if dp_val == self.MVFR0_DOUBLE_PRECISION_SUPPORTED:
+                # FPv5 with double-precision
                 fpu_type = "FPv5-D16-M"
                 self._extensions.append(CortexMExtension.FPU_DP)
-            elif vfp_misc_val >= 4:
+            elif vfp_misc_val == self.MVFR2_VFP_MISC_SUPPORTED:
+                # FPv5 with only single-precision
                 fpu_type = "FPv5-SP-D16-M"
             else:
+                # FPv4 has only single-precision, only present on the CM4F.
                 fpu_type = "FPv4-SP-D16-M"
             LOG.info("FPU present: " + fpu_type)
 


### PR DESCRIPTION
Fix some issues with core start/stop delegate methods, plus some connect behaviour that was improved.

Delegate changes:
- The `will_start_debug_core()` and `will_stop_debug_core()` delegate methods are now effectively notifications and hooks for inserting extra behaviour.
- Core init/shutdown calls required for basic class functionality are always performed.
- Add new `start_debug_core` and `stop_debug_core` delegate methods that control debug state init/shutdown (`DHCSR` and `DEMCR` registers).

These changes are related to coming support for CMSIS DFP debug sequence.

The `DHCSR.C_DEBUGEN` bit to turn on core debug is set before anything else is done to access the core.

Finally, a fix is included that changes how FPU presence is determined. On certain cores and implementations, notably the STM32H7xx family, `CPACR` is not accessible when the core is under reset. This causes an undesired exception. So, `MVFR0` is used instead to determine FPU presence.