### PR TITLE
session: add missing MemoryLoader to Python namespace

### DIFF
--- a/docs/user_scripts.md
+++ b/docs/user_scripts.md
@@ -11,9 +11,9 @@ completely override the default behaviour.
 
 If a file named `pyocd_user.py` or `.pyocd_user.py` is placed in the project directory, pyOCD will
 automatically detect it and load it as a user script. If you prefer another name, you can set the
-`user_script` option. Another alternative is to provide the filename using the `--script` command
-line argument. If a relative path is set either with the option or command line, it will be searched
-for in the project directory.
+`user_script` session option, for example in a [config file]({% link _docs/configuration.md %}), or
+by passing the `--script=<path>` command line argument. If a relative path is set either with the
+option or command line, it will be searched for in the project directory.
 
 
 ## Examples
@@ -113,46 +113,54 @@ def vectable(base: int):
 A number of useful symbols are made available in the global namespace of user scripts. These include
 both target related objects, as well as parts of the pyOCD Python API.
 
+The usual Python builtins are available.
+
+### Objects and functions
+
 | Symbol | Description |
 |--------|-------------|
-| `__file__` | Path to the user script. |
-| `__name__` | Module name of the user script. |
 | `aps` | Dictionary of CoreSight Access Port (AP) objects. The keys are the APSEL value. |
 | `board` | The `Board` object. |
-| `BreakpointType` | Enumeration of breakpoint types. |
 | `command` | Decorator for defining new commands. See [user-defined commands](#user_defined_commands) for details. |
-| `DeviceRegion` | Device-type memory region class. |
 | `debug` | Log a debug message. |
 | `dp` | The CoreSight Debug Port (DP) object. |
+| `error` | Output an error log. |
+| `info` | Output an info-level log message. |
+| `LOG` | `Logger` object for the user script. |
+| `options` | The session options dictionary. |
+| `probe` | The connected debug probe object. |
+| `session` | The session object, which is the root of the connection object graph. |
+| `target` | The `CoreSightTarget` or subclass instance representing the MCU. |
+| `warning` | Log a warning. |
+
+### Modules and classes
+
+| Symbol | Description |
+|--------|-------------|
+| `BreakpointType` | Enumeration of breakpoint types. |
+| `DeviceRegion` | Device-type memory region class. |
 | `Error` | The base class for all pyOCD exceptions. |
 | `Event` | Enumeration of notification event types. |
 | `exceptions` | Module containing the exception classes. |
-| `error` | Output an error log. |
-| `info` | Output an info-level log message. |
 | `FileProgrammer` | Utility class to program files to target flash. |
 | `FlashEraser` | Utility class to erase target flash. |
-| `FlashLoader` | Utility class to program raw binary data to target flash. |
+| `FlashLoader` | Utility class to program raw binary data to target memory. Deprecated, use `MemoryLoader` instead. |
 | `FlashRegion` | Flash memory region. |
 | `HaltReason` | Enumeration of halt reasons. |
-| `LOG` | `Logger` object for the user script. |
+| `MemoryLoader` | Utility class to program raw binary data to target memory. |
 | `MemoryMap` | Class representing the device's memory map. |
 | `MemoryType` | Memory region type enumeration. |
-| `options` | The session options dictionary. |
-| `probe` | The connected debug probe object. |
-| `pyocd` | The root pyOCD package. |
+| `pyocd` | The root pyOCD module. |
 | `RamRegion` | RAM memory region. |
 | `ResetType` | Reset type enumeration. |
 | `RomRegion` | ROM memory region. |
 | `RunType` | Enumeration of types of run operations (step or run). |
 | `SecurityState` | Enumeration of core security states. |
-| `session` | The session object, which is the root of the connection object graph. |
 | `State` | Enumeration of target state. |
-| `Target` | Base class, mostly useful for numerous constants that are defined within the class. |
-| `target` | The `CoreSightTarget` or subclass instance representing the MCU. |
+| `Target` | Base target class. |
 | `TransferError` | Exception class for all transfer errors. |
-| `TransferFaultError` | Exception subclass of `TransferError` for bus faults. |
+| `TransferFaultError` | Exception subclass of `TransferError` for memory transfer faults. |
 | `VectorCatch` | Namespace class containing bit mask constants for vector catch options. |
-| `warning` | Log a warning. |
 | `WatchpointType` | Enumeration of watchpoint types. |
 
 

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -436,6 +436,7 @@ class Session(Notifier):
             'RunType': target.Target.RunType,
             'HaltReason': target.Target.HaltReason,
             'ResetType': target.Target.ResetType,
+            'MemoryLoader': loader.MemoryLoader,
             'MemoryType': memory_map.MemoryType,
             'MemoryMap': memory_map.MemoryMap,
             'RamRegion': memory_map.RamRegion,
@@ -444,7 +445,7 @@ class Session(Notifier):
             'DeviceRegion': memory_map.DeviceRegion,
             'FileProgrammer': file_programmer.FileProgrammer,
             'FlashEraser': eraser.FlashEraser,
-            'FlashLoader': loader.FlashLoader,
+            'FlashLoader': loader.FlashLoader, # deprecated
             # User script info
             '__name__': script_name,
             '__file__': script_path,


### PR DESCRIPTION
This patch adds the `MemoryLoader` class to the Python namespace used by user scripts and Python "$" commands.

Docs are updated, and mention that `FlashLoader` is deprecated. As part of the docs update, the table of Python namespace globals is split into two tables, "Objects and functions" and "Modules and classes", to make it easier to understand.