### PR TITLE
flash: fix issues when overriding a flash region's algo with an FLM

### DIFF
--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -454,6 +454,10 @@ class FlashRegion(MemoryRegion):
     def flm(self, flm_path: str) -> None:
         self._flm = flm_path
 
+        # Clear the flash algo dict when a new FLM is assigned. This makes it possible to override
+        # a built-in/default flash algo.
+        self._algo = None
+
     @property
     def flash_class(self) -> Type["Flash"]:
         return self._flash_class

--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -252,7 +252,9 @@ class Session(Notifier):
         # Look for default filenames if a path wasn't provided.
         if filePath is None:
             for filename in filename_list:
-                thisPath = os.path.join(self.project_dir, filename)
+                thisPath = os.path.expanduser(filename)
+                if not os.path.isabs(thisPath):
+                    thisPath = os.path.join(self.project_dir, filename)
                 if os.path.isfile(thisPath):
                     filePath = thisPath
                     break

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -200,7 +200,7 @@ class CoreSightTarget(SoCTarget):
                 if isinstance(region.flm, (str, PurePath)):
                     flm_path = self.session.find_user_file(None, [str(region.flm)])
                     if flm_path is not None:
-                        LOG.info("creating flash algo from: %s", flm_path)
+                        LOG.info("creating flash algo for region %s from: %s", region.name, flm_path)
                         pack_algo = PackFlashAlgo(flm_path)
                     else:
                         LOG.warning("Failed to find FLM file: %s", region.flm)


### PR DESCRIPTION
Several fixes and/or improvements for when the `.flm` attribute of a flash memory region is overridden, most likely by a user script, with an FLM file path.

1. When `.flm` is set, the `.algo` attribute is cleared to None. If this is not done, the FLM won't be loaded. (Previously it had to be done manually.)
2. "~" and "~user" path expansion is performed for the FLM path.
3. The log message indicating the FLM was loaded now includes the name of the flash region for which is was loaded.