### PR TITLE
target: family: lpc55xx: fix reset halt corner cases with forced halt

### DIFF
--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -587,15 +587,15 @@ class Flash:
             error = True
         if final_fp != expected_fp:
             # Frame pointer should not change
-            LOG.error("Frame pointer should be 0x%x but is 0x%x" % (expected_fp, final_fp))
+            LOG.error("Frame pointer should be 0x%x but is 0x%x", expected_fp, final_fp)
             error = True
         if final_sp != expected_sp:
             # Stack pointer should return to original value after function call
-            LOG.error("Stack pointer should be 0x%x but is 0x%x" % (expected_sp, final_sp))
+            LOG.error("Stack pointer should be 0x%x but is 0x%x", expected_sp, final_sp)
             error = True
         if final_pc != expected_pc:
             # PC should be pointing to breakpoint address
-            LOG.error("PC should be 0x%x but is 0x%x" % (expected_pc, final_pc))
+            LOG.error("PC should be 0x%x but is 0x%x", expected_pc, final_pc)
             error = True
         #TODO - uncomment if Read/write and zero init sections can be moved into a separate flash algo section
         #if not _same(expected_flash_algo, final_flash_algo):
@@ -639,7 +639,7 @@ class Flash:
             self.target.halt()
             ipsr = self.target.read_core_register('ipsr')
             raise exceptions.FlashFailure("target was not halted as expected after calling "
-                                          "flash algorithm routine (IPSR=%d)", ipsr)
+                                          f"flash algorithm routine (IPSR={ipsr})")
 
         # Check stack canary if we have one.
         if self.end_stack is not None:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -26,6 +26,7 @@ import subprocess
 import tempfile
 import threading
 import codecs
+from pathlib import Path
 from pyocd.utility.compatibility import to_str_safe
 
 OBJCOPY = "arm-none-eabi-objcopy"
@@ -40,7 +41,10 @@ def get_test_binary_path(binary_name):
         binary_name = os.environ.get('PYOCD_TEST_BINARY')
         if binary_name is None:
             raise RuntimeError("no test binary available")
-    return os.path.join(TEST_DATA_DIR, "binaries", binary_name)
+    if Path(binary_name).is_absolute():
+        return binary_name
+    else:
+        return os.path.join(TEST_DATA_DIR, "binaries", binary_name)
 
 def get_env_name():
     return os.environ.get('TOX_ENV_NAME', '')


### PR DESCRIPTION
In cases where the user firmware in flash in invalid in one way or another, the halting reset code can fail to successfully halt the core. At the point where the core should be halted through a breakpoint or watchpoint, a forced halt is performed if the core is still running.

This patch also includes some tiny random fixes.