### PR TITLE
tools: lists: update probe listing to use board info and fix issues

### DIFF
--- a/test/json_lists_test.py
+++ b/test/json_lists_test.py
@@ -189,7 +189,7 @@ def json_lists_test(board_id, testing_standalone=False):
     out = subprocess.check_output(['pyocd', 'json', '--probes'])
     data = json.loads(out)
     test_count += 2
-    if validate_basic_keys(data):
+    if validate_basic_keys(data, minor_version=1):
         test_pass_count += 1
     if validate_boards(data):
         test_pass_count += 1


### PR DESCRIPTION
Fixes issues caused by creating a session for each probe, such as having an unknown target type set for a probe config. This is done by switching to use the probe's associated board info instead of getting that info through a session.

Adds `board_vendor` key to probe info dict, and bumps probe list data version to 1.1. `json_lists_test.py` is updated to expect this version.