### PR TITLE
gdbserver: fix some error responses

### DIFF
--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -413,8 +413,8 @@ class GDBServer(threading.Thread):
             try:
                 handler, msgStart = self.COMMANDS[msg[1:2]]
             except (KeyError, IndexError):
-                LOG.error("Unknown RSP packet: %s", msg)
-                return self.create_rsp_packet(b""), 0
+                LOG.error("Unknown RSP command (%s)", msg[1:2])
+                return self.create_rsp_packet(b"")
 
             with self.lock:
                 if msgStart == 0:
@@ -427,7 +427,7 @@ class GDBServer(threading.Thread):
         except Exception as e:
             LOG.error("Unhandled exception in handle_message (%s): %s",
                     msg[1:2], e, exc_info=self.session.log_tracebacks)
-            return self.create_rsp_packet(b"E01"), 0
+            return self.create_rsp_packet(b"E01")
 
     def extended_remote(self):
         LOG.debug("extended remote enabled")


### PR DESCRIPTION
- Fix the "Unexpected exception: a bytes-like object is required, not 'tuple'" error log if the gdbserver gets an unexpected exception or receives an unknown command from gdb.
- Replace the `GDBError` exception class with error logs and appropriate response packets (if any).
- `GDBServer.get_symbol()` logs the error and returns None to the caller.
- Cleaned up `qXfer` command handling. The annex value is checked, and some incorrect error responses are fixed.