### PR TITLE
Fix session option parsing for multi type options

### DIFF
--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -161,7 +161,7 @@ def convert_one_session_option(name: str, value: Optional[str]) -> Tuple[str, An
     result = None
 
     # Extract the option's type. If its type is a tuple of types, then take the first type.
-    if info.type is tuple:
+    if typle(info.type) is tuple:
         option_type = cast(tuple, info.type)[0]
     else:
         option_type = info.type

--- a/pyocd/utility/cmdline.py
+++ b/pyocd/utility/cmdline.py
@@ -161,7 +161,7 @@ def convert_one_session_option(name: str, value: Optional[str]) -> Tuple[str, An
     result = None
 
     # Extract the option's type. If its type is a tuple of types, then take the first type.
-    if typle(info.type) is tuple:
+    if isinstance(info.type, tuple):
         option_type = cast(tuple, info.type)[0]
     else:
         option_type = info.type


### PR DESCRIPTION
Session options `logging` and `pack` support multiple datatypes.
The check for a tuple failes, because the variable and not it's type is checked.
The following `issubclass()` failes, because the variable `option_type` holds a tuple of types and not a single type.

The following command triggers this bug:
```
$ pyocd flash a.hex -O pack="path/to/pack.pack"
0000416 C Error: issubclass() arg 1 must be a class [__main__]
Traceback (most recent call last):
  File "/home/sven/.local/lib/python3.10/site-packages/pyocd/__main__.py", line 161, in run
    status = cmd.invoke()
  File "/home/sven/.local/lib/python3.10/site-packages/pyocd/subcommands/load_cmd.py", line 92, in invoke
    options=convert_session_options(self._args.options))
  File "/home/sven/.local/lib/python3.10/site-packages/pyocd/utility/cmdline.py", line 213, in convert_session_options
    name, value = convert_one_session_option(name, value)
  File "/home/sven/.local/lib/python3.10/site-packages/pyocd/utility/cmdline.py", line 176, in convert_one_session_option
    elif issubclass(option_type, bool):
TypeError: issubclass() arg 1 must be a class
```