### PR TITLE
core: soc_target: options to control memory and register cache enablement

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -2,7 +2,7 @@
 title: Session options list
 ---
 
-_**Note:** The names of these options are expected to change before the 1.0 release of pyOCD, so
+_**Note:** The names of these options are expected to change with the 1.0 release of pyOCD, so
 they will be better normalized and grouped._
 
 ## General options
@@ -27,7 +27,7 @@ takes precedence over this option if set.
 <td>bool</td>
 <td>False</td>
 <td>
-Prevents raising an error if no core were found after CoreSight discovery.
+Prevents raising an error if no cores were found after CoreSight discovery.
 </td></tr>
 
 <tr><td>auto_unlock</td>
@@ -36,6 +36,22 @@ Prevents raising an error if no core were found after CoreSight discovery.
 <td>
 If the target is locked, it will by default be automatically mass erased in order to gain debug
 access. Set this option to False to disable auto unlock.
+</td></tr>
+
+<tr><td>cache.enable_memory</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Enable the memory read cache. Affects memory accesses made through the target debug context, including the
+gdbserver.
+</td></tr>
+
+<tr><td>cache.enable_register</td>
+<td>bool</td>
+<td>True</td>
+<td>
+Enable the core register cache. Affects core register accesses made through the target debug context,
+including the gdbserver.
 </td></tr>
 
 <tr><td>cache.read_code_from_elf</td>

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -32,9 +32,13 @@ BUILTIN_OPTIONS = [
         "If this number of invalid APs is found in a row, then AP scanning will stop. The 'scan_all_aps' option "
         "takes precedence over this option if set."),
     OptionInfo('allow_no_cores', bool, False,
-        "Prevents raising an error if no core were found after CoreSight discovery."),
+        "Prevents raising an error if no cores were found after CoreSight discovery."),
     OptionInfo('auto_unlock', bool, True,
         "Whether to unlock secured target by erasing."),
+    OptionInfo('cache.enable_memory', bool, True,
+        "Enable the memory read cache. Default is enabled."),
+    OptionInfo('cache.enable_register', bool, True,
+        "Enable the core register cache. Default is enabled."),
     OptionInfo('cache.read_code_from_elf', bool, True,
         "Controls whether reads of code sections will be taken from an attached ELF file instead of the "
         "target memory."),

--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ from .target import (Target, TargetGraphNode)
 from .core_target import CoreTarget
 from ..flash.eraser import FlashEraser
 from ..debug.cache import CachingDebugContext
+from ..debug.context import DebugContext
 from ..debug.elf.elf import ELFBinaryFile
 from ..debug.elf.elf_reader import ElfReaderContext
 from ..utility.sequencer import CallSequence
@@ -124,7 +125,12 @@ class SoCTarget(TargetGraphNode):
 
     def add_core(self, core: CoreTarget) -> None:
         core.delegate = self.delegate
-        core.set_target_context(CachingDebugContext(core))
+        ctx = CachingDebugContext(
+                core,
+                enable_memory=self.session.options['cache.enable_memory'],
+                enable_register=self.session.options['cache.enable_register'],
+                )
+        core.set_target_context(ctx)
         self.cores[core.core_number] = core
         self.add_child(core)
 

--- a/pyocd/debug/cache.py
+++ b/pyocd/debug/cache.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2016-2019 Arm Limited
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,10 +22,12 @@ from ..cache.register import RegisterCache
 class CachingDebugContext(DebugContext):
     """@brief Debug context combining register and memory caches."""
 
-    def __init__(self, parent):
-        super(CachingDebugContext, self).__init__(parent)
-        self._regcache = RegisterCache(parent, self.core)
-        self._memcache = MemoryCache(parent, self.core)
+    def __init__(self, parent, enable_memory: bool = True, enable_register: bool = True) -> None:
+        super().__init__(parent)
+        self._enable_memory = enable_memory
+        self._enable_register = enable_register
+        self._regcache = RegisterCache(parent, self.core) if enable_register else parent
+        self._memcache = MemoryCache(parent, self.core) if enable_memory else parent
 
     def write_memory(self, addr, value, transfer_size=32):
         return self._memcache.write_memory(addr, value, transfer_size)
@@ -51,8 +54,10 @@ class CachingDebugContext(DebugContext):
         return self._regcache.write_core_registers_raw(reg_list, data_list)
 
     def invalidate(self):
-        self._regcache.invalidate()
-        self._memcache.invalidate()
+        if self._enable_register:
+            self._regcache.invalidate()
+        if self._enable_memory:
+            self._memcache.invalidate()
 
 
 


### PR DESCRIPTION
Add `cache.enable_memory` and `cache.enable_register` options. Both default to true (as before).