### PR TITLE
packaging: setuptools_scm: fix GPG parse issue and .gitarchival template

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@
 requires = [
     "setuptools>=51",
     "wheel",
-    "setuptools_scm[toml]>=6.0",
+    "setuptools_scm[toml]>=6.0,<7.0; python_version < \"3.7\"",
+    "setuptools_scm[toml]>=7.0; python_version >= \"3.7\"",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This patch applies two fixes related to setuptools_scm, the package used to automatically set the pyocd package version at build or install time based on git tags.

1. Set the minimum setuptools_scm version  7.0 for building pyocd on Python 3.7 to fix a GPG output parsing issue. See pypa/setuptools_scm#548 for details. For Python 3.6, the minimum setuptools_scm version remains 6.0 since version doesn't support Python 3.6
2. Migrate the template in `.gitarchival.txt` to the one required by the built-in git archive support. (Previously archives were supported through a separate setuptools_scm plugin.)

Fixes #1400
