### PR TITLE
targets: standardise target type name normalisation

### DIFF
--- a/pyocd/board/board.py
+++ b/pyocd/board/board.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +19,7 @@ import logging
 from typing import (Any, Optional, TYPE_CHECKING)
 
 from ..core import exceptions
-from ..target import TARGET
+from ..target import (TARGET, normalise_target_type_name)
 from ..target.pack import pack_target
 from ..utility.graph import GraphNode
 
@@ -84,7 +84,7 @@ class Board(GraphNode):
         assert target is not None
 
         # Convert dashes to underscores in the target type, and convert to lower case.
-        target = target.replace('-', '_').lower()
+        target = normalise_target_type_name(target)
 
         # Write the effective target type back to options if it's different.
         if target != session.options.get('target_override'):

--- a/pyocd/target/__init__.py
+++ b/pyocd/target/__init__.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2013-2019 Arm Limited
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import string
+
 from .builtin import BUILTIN_TARGETS
 
 ## @brief Dictionary of all targets.
@@ -21,3 +24,26 @@ from .builtin import BUILTIN_TARGETS
 # This table starts off with only the builtin targets. At runtime it may be extended with
 # additional targets from CMSIS DFPs or other sources.
 TARGET = BUILTIN_TARGETS.copy()
+
+## @brief Legal characters in target type names.
+#
+# Basically, C language identifier characters.
+_TARGET_TYPE_NAME_CHARS = string.ascii_letters + string.digits + '_'
+
+def normalise_target_type_name(target_type: str) -> str:
+    """@brief Normalise a target type name.
+
+    The output string has all non-ASCII alphanumeric characters replaced with underscores and is
+    converted to all lowercase. Only one underscore in a row will be inserted in the output. For example,
+    "foo--bar" will be normalised to "foo_bar".
+    """
+    result = ""
+    in_replace = False
+    for c in target_type:
+        if c in _TARGET_TYPE_NAME_CHARS:
+            result += c.lower()
+            in_replace = False
+        elif not in_replace:
+            result += '_'
+            in_replace = True
+    return result

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -124,8 +124,9 @@ from . import target_RP2040
 
 ## @brief Dictionary of all builtin targets.
 #
-# @note Target type names must be all lowercase and use _underscores_ instead of dashes. The code in Board
-#   automatically converts dashes in user-supplied target type names to underscores.
+# @note Target type names must be a valid C identifier, normalised to all lowercase, using _underscores_
+#   instead of dashes punctuation. See pyocd.target.normalise_target_type_name() for the code that
+#   normalises user-provided target type names for comparison with these.
 BUILTIN_TARGETS = {
           'mps3_an522': target_MPS3_AN522.AN522,
           'mps3_an540': target_MPS3_AN540.AN540,

--- a/test/unit/test_cmdline.py
+++ b/test/unit/test_cmdline.py
@@ -1,5 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015,2018-2019 Arm Limited
+# Copyright (c) 2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,6 +25,7 @@ from pyocd.utility.cmdline import (
     convert_session_options,
     )
 from pyocd.core.target import Target
+from pyocd.target import normalise_target_type_name
 
 class TestSplitCommandLine(object):
     def test_split(self):
@@ -141,4 +143,19 @@ class TestConvertSessionOptions(object):
         # Valid
         assert convert_session_options(['test_binary=abc']) == {'test_binary': 'abc'}
 
+class TestTargetTypeNormalisation:
+    def test_passthrough(self):
+        assert normalise_target_type_name("foobar") == "foobar"
+        assert normalise_target_type_name("foo123bar") == "foo123bar"
+        assert normalise_target_type_name("foo_bar") == "foo_bar"
+
+    def test_lower(self):
+        assert normalise_target_type_name("TARGET") == "target"
+        assert normalise_target_type_name("BIGtarget") == "bigtarget"
+        assert normalise_target_type_name("someTARGET123") == "sometarget123"
+
+    def test_trans(self):
+        assert normalise_target_type_name("foo-bar") == "foo_bar"
+        assert normalise_target_type_name("foo--bar") == "foo_bar"
+        assert normalise_target_type_name("foo!@#$%^&*()x") == "foo_x"
 


### PR DESCRIPTION
Fix for not being able to use a target type from a CMSIS Pack where the name includes a dash. Replace inline normalisation with a single `normalise_target_type_name()` implementation.

Normalised target type names contain only ASCII alphanumeric, all lowercase, characters plus underscore. Runs of more than one underscore are not allowed.

A unit test of the `normalise_target_type_name()` function is added.