### PR TITLE
trace: minor trace logging improvements

### DIFF
--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -200,8 +200,9 @@ class DPConnector:
     DP IDR register. The probe must be already connected for the desired wire protocol.
     """
 
-    def __init__(self, probe: DebugProbe) -> None:
+    def __init__(self, probe: DebugProbe, dp: "DebugPort") -> None:
         self._probe = probe
+        self._dp = dp
         self._idr = DPIDR(0, 0, 0, 0, 0)
 
         # Make sure we have a session, since we get the session from the probe and probes have their session set
@@ -266,7 +267,7 @@ class DPConnector:
 
     def read_idr(self) -> DPIDR:
         """@brief Read IDR register and get DP version"""
-        dpidr = self._probe.read_dp(DP_IDR, now=True)
+        dpidr = self._dp.read_dp(DP_IDR, now=True)
         dp_partno = (dpidr & DPIDR_PARTNO_MASK) >> DPIDR_PARTNO_SHIFT
         dp_version = (dpidr & DPIDR_VERSION_MASK) >> DPIDR_VERSION_SHIFT
         dp_revision = (dpidr & DPIDR_REVISION_MASK) >> DPIDR_REVISION_SHIFT
@@ -427,7 +428,7 @@ class DebugPort:
         probe_conn.connect(self._protocol)
 
         # Attempt to connect DP.
-        connector = DPConnector(self.probe)
+        connector = DPConnector(self.probe, self)
         connector.connect()
 
         # Report on DP version.

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -862,7 +862,13 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     @locked
     def flush(self):
-        TRACE.debug("flush: sending cmd:%d; reading %d outstanding", self._crnt_cmd.uid, len(self._commands_to_read))
+        if TRACE.isEnabledFor(logging.DEBUG):
+            if self._crnt_cmd.get_empty() and len(self._commands_to_read):
+                TRACE.debug("flush: reading %d outstanding (cmd:%d is empty)",
+                        len(self._commands_to_read), self._crnt_cmd.uid)
+            elif not self._crnt_cmd.get_empty():
+                TRACE.debug("flush: sending cmd:%d; reading %d outstanding", self._crnt_cmd.uid, len(self._commands_to_read))
+
         # Send current packet
         self._send_packet()
         # Read all backlogged


### PR DESCRIPTION
1. `DPConnector` uses the `DebugPort` object to read the IDR register, which ensure that read will be trace logged.
2. Cleanup of trace log output from the internal CMSIS-DAP flush implementation.