### PR TITLE
packs: expanded folder support, tilde expanding, exception and other small improvements

### DIFF
--- a/docs/target_support.md
+++ b/docs/target_support.md
@@ -190,3 +190,7 @@ To see the targets provided by a .pack file, run `pyocd list --targets` and pass
 _Note:_ .pack files are simply zip archives with a different extension. To examine the contents of
 a pack, change the extension to .zip and extract.
 
+_Note:_ PyOCD can work with expanded packs just like zipped .pack files. Pass the path to the root directory
+of the pack using the `--pack` argument, as above. This is very useful for cases such as development or
+debugging of a pack, or for working with other CMSIS-Pack managers that store packs in decompressed form.
+

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -95,7 +95,9 @@ class CmsisPack:
         else:
             # Check for an expanded pack as a directory.
             if isinstance(file_or_path, str):
-                path = Path(file_or_path)
+                path = Path(file_or_path).expanduser()
+                file_or_path = str(path) # Update with expanded path.
+
                 self._is_dir = path.is_dir()
                 if self._is_dir:
                     self._dir_path = path

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -21,15 +21,14 @@ from typing import (IO, TYPE_CHECKING, Callable, Iterable, List, Optional, Type,
 
 from .cmsis_pack import (CmsisPack, CmsisPackDevice, MalformedCmsisPackError)
 from ..family import FAMILIES
-from .. import TARGET
+from .. import (normalise_target_type_name, TARGET)
 from ...coresight.coresight_target import CoreSightTarget
 from ...debug.svd.loader import SVDFile
-from .. import normalise_target_type_name
+from ...core.session import Session
 
 if TYPE_CHECKING:
     from zipfile import ZipFile
     from cmsis_pack_manager import CmsisPackRef
-    from ...core.session import Session
     from ...utility.sequencer import CallSequence
 
 try:
@@ -84,9 +83,13 @@ class ManagedPacksImpl:
             cache = cmsis_pack_manager.Cache(True, True)
         results = []
         for pack in ManagedPacks.get_installed_packs(cache=cache):
-            pack_path = os.path.join(cache.data_path, pack.get_pack_name())
-            pack = CmsisPack(pack_path)
-            results += list(pack.devices)
+            try:
+                pack_path = os.path.join(cache.data_path, pack.get_pack_name())
+                pack = CmsisPack(pack_path)
+                results += list(pack.devices)
+            except Exception as err:
+                LOG.error("failure to access managed CMSIS-Pack: %s",
+                        err, exc_info=Session.get_current().log_tracebacks)
         return sorted(results, key=lambda dev:dev.part_number)
 
     @staticmethod
@@ -112,7 +115,7 @@ class _PackTargetMethods:
     """@brief Container for methods added to the dynamically generated pack target subclass."""
 
     @staticmethod
-    def _pack_target__init__(self, session: "Session") -> None: # type:ignore
+    def _pack_target__init__(self, session: Session) -> None: # type:ignore
         """@brief Constructor for dynamically created target class."""
         super(self.__class__, self).__init__(session, self._pack_device.memory_map)
 
@@ -244,7 +247,7 @@ class PackTargets:
         """
         PackTargets.process_targets_from_pack(pack_list, PackTargets.populate_device)
 
-def is_pack_target_available(target_name: str, session: "Session") -> bool:
+def is_pack_target_available(target_name: str, session: Session) -> bool:
     """@brief Test whether a given target type is available."""
     # Create targets from provided CMSIS pack.
     if session.options['pack'] is not None:

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -112,7 +112,11 @@ else:
     ManagedPacks = ManagedPacksStub
 
 class _PackTargetMethods:
-    """@brief Container for methods added to the dynamically generated pack target subclass."""
+    """@brief Container for methods added to the dynamically generated pack target subclass.
+
+    We can't just make a subclass of CoreSightTarget out of these methods, because the superclass
+    is variable based on the possible family class.
+    """
 
     @staticmethod
     def _pack_target__init__(self, session: Session) -> None: # type:ignore
@@ -158,6 +162,7 @@ class PackTargets:
                 # Require the regex to match the entire family name.
                 match = familyInfo.matches.match(compare_name)
                 if match and match.span() == (0, len(compare_name)):
+                    LOG.debug("using family class %s", familyInfo.klass.__name__)
                     return familyInfo.klass
 
         # Didn't match, so return default target superclass.

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -226,8 +226,8 @@ class PackTargets:
         @param cb Callable to run. Must take a CmsisPackDevice object as the sole parameter and return None.
         """
         if not isinstance(pack_list, (list, tuple)):
-            pack_list = [pack_list]
-        for pack_or_path in pack_list:
+            pack_list = [pack_list] # type:ignore
+        for pack_or_path in pack_list: # type:ignore
             if isinstance(pack_or_path, CmsisPack):
                 pack = pack_or_path
             else:


### PR DESCRIPTION
Collection of smaller CMSIS-Pack related improvements.

1. The `--pack` argument can be used with directories resulting from the expansion of `.pack` files (which are just zips).
2. Home directory tildes in pack paths are expanded.
3. Some internal changes to use a callback for reading files in packs, to allow for easier unit testing.
4. Catch exceptions while loading managed packs to present more helpful errors.
5. Ignore a couple minor type errors that can't be easily resolved.
6. Log a debug message when an internal target family class is used as the superclass for a DFP based target.
7. Add a property to get the pack's name and use in exception handlers to identify the problematic pack.