### PR TITLE
Refactor RTT and add RTT support to gdbserver

### DIFF
--- a/pyocd/core/exceptions.py
+++ b/pyocd/core/exceptions.py
@@ -158,3 +158,7 @@ class CommandError(Error):
     """@brief Raised when a command encounters an error."""
     pass
 
+class RTTError(Error):
+    """@brief Error encountered when transfering data through RTT."""
+    pass
+

--- a/pyocd/debug/rtt.py
+++ b/pyocd/debug/rtt.py
@@ -1,0 +1,488 @@
+# pyOCD debugger
+# Copyright (c) 2021 mikisama
+# Copyright (C) 2021 Ciro Cattuto <ciro.cattuto@gmail.com>
+# Copyright (C) 2021 Simon D. Levy <simon.d.levy@gmail.com>
+# Copyright (C) 2022 Johan Carlsson <johan.carlsson@teenage.engineering>
+# Copyright (c) 2022 Samuel Dewan
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+from ctypes import Structure, c_char, c_int32, c_uint32, sizeof
+import struct
+from typing import Optional, Sequence
+
+from ..core.memory_map import MemoryMap, MemoryRegion, MemoryType
+from ..core.soc_target import SoCTarget
+from ..core import exceptions
+
+
+class SEGGER_RTT_BUFFER_UP(Structure):
+    """@brief `SEGGER RTT Ring Buffer` target to host."""
+
+    _fields_ = [
+        ("sName", c_uint32),
+        ("pBuffer", c_uint32),
+        ("SizeOfBuffer", c_uint32),
+        ("WrOff", c_uint32),
+        ("RdOff", c_uint32),
+        ("Flags", c_uint32),
+    ]
+
+class SEGGER_RTT_BUFFER_DOWN(Structure):
+    """@brief `SEGGER RTT Ring Buffer` host to target."""
+
+    _fields_ = [
+        ("sName", c_uint32),
+        ("pBuffer", c_uint32),
+        ("SizeOfBuffer", c_uint32),
+        ("WrOff", c_uint32),
+        ("RdOff", c_uint32),
+        ("Flags", c_uint32),
+    ]
+
+class SEGGER_RTT_CB(Structure):
+    """@brief `SEGGER RTT control block` structure. """
+
+    _fields_ = [
+        ("acID", c_char * 16),
+        ("MaxNumUpBuffers", c_int32),
+        ("MaxNumDownBuffers", c_int32)
+    ]
+
+
+
+class RTTUpChannel(ABC):
+    """@brief Wrapper for an RTT up channel for target to host data transfer. """
+
+    name: Optional[str]
+    size: int
+
+    @abstractmethod
+    def read(self) -> bytes:
+        """@brief Read all available data from RTT channel. """
+
+
+class RTTDownChannel(ABC):
+    """@brief Wrapper for an RTT down channel for host to target data transfer. """
+
+    name: Optional[str]
+    size: int
+
+    @abstractmethod
+    def write(self, data: bytes, blocking = False) -> int:
+        """@brief Write data to RTT channel.
+
+        Write as much of the provided data as possible to an the RTT down
+        channel.
+
+        @param data The data to be written.
+        @param blocking If true will block until all data is sent.
+
+        @return The number of bytes written to the target.
+        """
+
+
+class RTTControlBlock(ABC):
+    """@brief Represents an RTT control block.
+
+    This helper class can be used to search for and parse an RTT control block.
+    Once the control block is found and parsed (using the start() method)
+    RTTUpChannel and RTTDownChannel objects will be created to facilitate
+    communication with the target.
+    """
+
+    up_channels: Sequence[RTTUpChannel]
+    down_channels: Sequence[RTTDownChannel]
+
+    @abstractmethod
+    def start(self):
+        """@brief Find the RTT control block on the target.
+
+        Searches for the RTT control block. Once found, the up_channels and
+        down_channels lists are populated with RTTUpChannel and RTTDownChannel
+        objects that can be used to communicate with the target.
+        """
+        pass
+
+    @classmethod
+    def from_target(cls, target: SoCTarget, address: int = None,
+                    size: int = None, control_block_id: bytes = b'SEGGER RTT'):
+        """@brief Create an RTTControlBlock object using a given target.
+
+        This function creates an instance of an appropriate RTTControlBlock
+        subclass depending on the provided target.
+
+        @param target The target with which RTT communication is desired.
+        @param address Base address for control block search range.
+        @param size Control block search range. If 0 the control block will be
+                    expected to be located at the provided address.
+        @param control_block_id The control block ID string to search for. Must
+                                be at most 16 bytes long.  Will be padded with
+                                zeroes if less than 16 bytes.
+
+        @return An instance of an appropriate RTTControlBlock subclass.
+        """
+        # TODO: Handle targets connected with jlink differently
+        return GenericRTTControlBlock(target, address = address, size = size,
+                                      control_block_id = control_block_id)
+
+
+
+
+class GenericRTTUpChannel(RTTUpChannel):
+    """@brief Software implementation of RTT up channel. Does not require any
+              support from interface.
+    """
+
+    _target: SoCTarget
+    name: Optional[str]
+    _buffer_address: int
+    size: int
+    _offsets_addr: int
+    _desc_addr: int
+
+    def __init__(self, target: SoCTarget, desc_addr: int):
+        """
+        @param target Target to communicate with.
+        @param desc_addr Address of up buffer descriptor.
+        """
+        self._target = target
+        self._desc_addr = desc_addr
+        self._offsets_addr = self._desc_addr + SEGGER_RTT_BUFFER_UP.WrOff.offset
+
+        self._read_descriptor()
+
+    def _read_descriptor(self):
+        # Get buffer descriptor
+        up_buffer_words = sizeof(SEGGER_RTT_BUFFER_UP) // 4
+        data = self._target.read_memory_block32(self._desc_addr, up_buffer_words)
+        descriptor: SEGGER_RTT_BUFFER_UP = SEGGER_RTT_BUFFER_UP(*data)
+
+        # Get name if there is one
+        if descriptor.sName != 0:
+            data = b''
+            while True:
+                data += bytes(self._target.read_memory_block8(descriptor.sName, 32))
+                name_length = data.find(b'\0')
+                if name_length != -1:
+                    self.name = data[:name_length].decode("utf-8", "backslashreplace")
+                    break
+                elif len(data) >= 512:
+                    # Give up, this probably isn't a valid string
+                    self.name = data.decode("utf-8", "backslashreplace")
+                    break
+        else:
+            self.name = None
+
+        self._buffer_address = descriptor.pBuffer
+        self.size = descriptor.SizeOfBuffer
+
+    @property
+    def bytes_available(self) -> int:
+        """@brief Number of bytes available to be read from up channel. """
+        if (self.size == 0) or (self._buffer_address == 0):
+            # descriptor is not yet populated
+            self._read_descriptor()
+            if (self.size == 0) or (self._buffer_address == 0):
+                # descriptor is still not populated
+                return 0
+
+        # Get offsets
+        write_off, read_off = self.target.read_memory_block32(self._offsets_addr, 2)
+
+        if (write_off >= self.size) or (read_off >= self.size):
+            raise exceptions.RTTError("Invalid up buffer")
+        elif write_off == self.read_off:
+            return 0
+        elif write_off > read_off:
+            return write_off - read_off
+        else:
+            return (self.size - read_off) + write_off
+
+    def read(self) -> bytes:
+        """@brief Read all available data from RTT channel. """
+        if (self.size == 0) or (self._buffer_address == 0):
+            # descriptor is not yet populated
+            self._read_descriptor()
+            if (self.size == 0) or (self._buffer_address == 0):
+                # descriptor is still not populated
+                return b''
+
+        # Get offsets
+        write_off, read_off = self._target.read_memory_block32(self._offsets_addr, 2)
+
+        if (write_off >= self.size) or (read_off >= self.size):
+            raise exceptions.RTTError("Invalid up buffer")
+        elif write_off == read_off:
+            # empty
+            return b''
+        elif write_off > read_off:
+            """
+            |oooooo|xxxxxxxxxxxx|oooooo|
+            0    rdOff        WrOff    SizeOfBuffer
+            """
+            data = self._target.read_memory_block8(self._buffer_address + read_off,
+                                                   write_off - read_off)
+        else:
+            """
+            |xxxxxx|oooooooooooo|xxxxxx|
+            0    WrOff        RdOff    SizeOfBuffer
+            """
+            data = self._target.read_memory_block8(self._buffer_address + read_off,
+                                                   self.size - read_off)
+            data += self._target.read_memory_block8(self._buffer_address, write_off)
+
+        # Update read offset
+        self._target.write32(self._offsets_addr + 4, write_off)
+        return bytes(data)
+
+
+class GenericRTTDownChannel(RTTDownChannel):
+    """@brief Software implementation of RTT down channel. Does not require any
+              support from interface.
+    """
+
+    _target: SoCTarget
+    name: Optional[str]
+    _buffer_address: int
+    size: int
+    _offsets_addr: int
+    _desc_addr: int
+
+    def __init__(self, target: SoCTarget, desc_addr: int):
+        """
+        @param target Target to communicate with.
+        @param desc_addr Address of down buffer descriptor.
+        """
+        self._target = target
+        self._desc_addr = desc_addr
+        self._offsets_addr = self._desc_addr + SEGGER_RTT_BUFFER_DOWN.WrOff.offset
+
+        self._read_descriptor()
+
+    def _read_descriptor(self):
+        # Get buffer descriptor
+        up_buffer_words = sizeof(SEGGER_RTT_BUFFER_DOWN) // 4
+        data = self._target.read_memory_block32(self._desc_addr, up_buffer_words)
+        descriptor: SEGGER_RTT_BUFFER_DOWN = SEGGER_RTT_BUFFER_DOWN(*data)
+
+        # Get name if there is one
+        if descriptor.sName != 0:
+            data = b''
+            while True:
+                data += bytes(self._target.read_memory_block8(descriptor.sName, 64))
+                name_length = data.find(b'\0')
+                if name_length != -1:
+                    self.name = data[:name_length].decode("utf-8", "backslashreplace")
+                    break
+                elif len(data) > 512:
+                    # Give up, this probably isn't a valid string
+                    self.name = data.decode("utf-8", "backslashreplace")
+                    break
+        else:
+            self.name = None
+
+        self._buffer_address = descriptor.pBuffer
+        self.size = descriptor.SizeOfBuffer
+
+    @property
+    def bytes_free(self) -> int:
+        """@brief Number of bytes free in RTT down channel ring buffer."""
+        if (self.size == 0) or (self._buffer_address == 0):
+            # descriptor is not yet populated
+            self._read_descriptor()
+            if (self.size == 0) or (self._buffer_address == 0):
+                # descriptor is still not populated
+                return 0
+
+        # Get offsets
+        write_off, read_off = self._target.read_memory_block32(self._offsets_addr, 2)
+
+        if (write_off >= self.size) or (read_off >= self.size):
+            raise exceptions.RTTError("Invalid down buffer")
+        elif write_off == self.read_off:
+            return self.size
+        elif write_off > read_off:
+            return (self.size - write_off) + (read_off - 1)
+        else:
+            return read_off - write_off - 1
+
+    def write(self, data: bytes, blocking = False) -> int:
+        """@brief Write data to RTT channel.
+
+        Write as much of the provided data as possible to an the RTT down
+        channel.
+
+        @param data The data to be written.
+        @param blocking If true will block until all data is sent.
+
+        @return The number of bytes written to the target.
+        """
+        if (self.size == 0) or (self._buffer_address == 0):
+            # descriptor is not yet populated
+            self._read_descriptor()
+            if (self.size == 0) or (self._buffer_address == 0):
+                # descriptor is still not populated
+                return 0
+
+        if blocking:
+            # Call non-blocking version until all data is written
+            while data:
+                bytes_sent: int = self.write(data, blocking = False)
+                data = data[bytes_sent:]
+            return
+
+        # Get offsets
+        write_off, read_off = self._target.read_memory_block32(self._offsets_addr, 2)
+
+        if (write_off >= self.size) or (read_off >= self.size):
+            raise exceptions.RTTError("Invalid down buffer")
+
+
+        bytes_written: int = 0
+        if write_off >= read_off:
+            # There is some space to fill at the top of the buffer
+            free_space: int = self.size - write_off
+            if read_off == 0:
+                # Can't use the last element in the buffer
+                free_space -= 1
+            data_to_write: bytes = data[:free_space]
+            self._target.write_memory_block8(self._buffer_address + write_off,
+                                             data_to_write)
+            bytes_written = len(data_to_write)
+            data = data[bytes_written:]
+            write_off = (write_off + bytes_written) % self.size
+
+        free_space: int = read_off - write_off - 1
+        if free_space < 0:
+            free_space = 0
+
+        bytes_to_write: int = min(free_space, len(data))
+        self._target.write_memory_block8(self._buffer_address + write_off,
+                                         data[:bytes_to_write])
+        bytes_written += bytes_to_write
+        write_off += bytes_to_write
+
+        # Store new write offset
+        self._target.write32(self._offsets_addr, write_off)
+        return bytes_written
+
+
+class GenericRTTControlBlock(RTTControlBlock):
+    """@brief Software implementation of RTT control block helper. Does not
+              require any support from interface.
+    """
+
+    target: SoCTarget
+    _cb_search_address: int
+    _cb_search_size_words: int
+    _control_block_id: Sequence[int]
+
+    def __init__(self, target: SoCTarget, address: int = None,
+                 size: int = None, control_block_id: bytes = b'SEGGER RTT'):
+        """
+        @param target The target with which RTT communication is desired.
+        @param address Base address for control block search range.
+        @param size Control block search range. If 0 the control block will be
+                    expected to be located at the provided address.
+        @param control_block_id The control block ID string to search for. Must
+                                be at most 16 bytes long.  Will be padded with
+                                zeroes if less than 16 bytes.
+        """
+        self.target = target
+        self.up_channels = list()
+        self.down_channels = list()
+
+        if address is None:
+            memory_map: MemoryMap = self.target.get_memory_map()
+            ram_region: MemoryRegion = memory_map.get_default_region_of_type(MemoryType.RAM)
+
+            self._cb_search_address = ram_region.start
+            if size is None:
+                size = ram_region.length
+        else:
+            self._cb_search_address = address
+
+        if size is None:
+            # Address was specified, but size was not. Assume that the control
+            # block is located exactly at the provided address.
+            self._cb_search_size_words = 0
+        else:
+            self._cb_search_size_words = size // 4
+
+        extra_id_bytes = SEGGER_RTT_CB.acID.size - len(control_block_id)
+        control_block_bytes = control_block_id + b'\0' * extra_id_bytes
+        self._control_block_id = struct.unpack("<IIII", control_block_bytes)
+
+    def _find_control_block(self) -> Optional[int]:
+        addr: int = self._cb_search_address & ~0x3
+        search_size: int  = self._cb_search_size_words
+        if search_size < len(self._control_block_id):
+            search_size = len(self._control_block_id)
+
+        id_len = len(self._control_block_id)
+        offset: int = 0
+
+        while search_size:
+            read_size = min(search_size, 32)
+            data = self.target.read_memory_block32(addr, read_size)
+
+            if not data:
+                break
+
+            for word in data:
+                if word == self._control_block_id[offset]:
+                    offset += 1
+                    if offset == id_len:
+                        break
+                else:
+                    num_skip_words = (offset + 1)
+                    addr += (num_skip_words * 4)
+                    search_size -= num_skip_words
+                    offset = 0
+
+            if offset == id_len:
+                break
+
+        return addr if offset == id_len else None
+
+    def start(self):
+        """@brief Find the RTT control block on the target.
+
+        Searches for the RTT control block. Once found, the up_channels and
+        down_channels lists are populated with RTTUpChannel and RTTDownChannel
+        objects that can be used to communicate with the target.
+        """
+
+        cb_addr = self._find_control_block()
+
+        if cb_addr is None:
+            raise exceptions.RTTError("Control block not found")
+
+        # Get control block info
+        num_up_buffs = self.target.read32(cb_addr + SEGGER_RTT_CB.MaxNumUpBuffers.offset)
+        num_down_buffs = self.target.read32(cb_addr + SEGGER_RTT_CB.MaxNumDownBuffers.offset)
+
+        # Setup up channels
+        up_base = cb_addr + sizeof(SEGGER_RTT_CB)
+        for i in range(num_up_buffs):
+            addr = up_base + (i * sizeof(SEGGER_RTT_BUFFER_UP))
+            self.up_channels.append(GenericRTTUpChannel(self.target, addr))
+
+        # Setup down channels
+        down_base = up_base + num_up_buffs * sizeof(SEGGER_RTT_BUFFER_UP)
+        for i in range(num_down_buffs):
+            addr = down_base + (i * sizeof(SEGGER_RTT_BUFFER_DOWN))
+            self.down_channels.append(GenericRTTDownChannel(self.target, addr))

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -33,6 +33,7 @@ from ..utility.compatibility import (to_bytes_safe, to_str_safe)
 from ..utility.server import StreamServer
 from ..utility.timeout import Timeout
 from ..trace.swv import SWVReader
+from ..utility.rtt_server import RTTServer
 from ..utility.sockets import ListenerSocket
 from .syscall import GDBSyscallIOHandler
 from ..debug import semihost
@@ -195,6 +196,9 @@ class GDBServer(threading.Thread):
             semihost_console = semihost_io_handler
         self.semihost = semihost.SemihostAgent(self.target_context, io_handler=semihost_io_handler, console=semihost_console)
 
+        # Start with RTT disabled
+        self.rtt_server: Optional[RTTServer] = None
+
         #
         # If SWV is enabled, create a SWVReader thread. Note that we only do
         # this if the core is 0: SWV is not a per-core construct, and can't
@@ -295,6 +299,9 @@ class GDBServer(threading.Thread):
         if self._swv_reader:
             self._swv_reader.stop()
             self._swv_reader = None
+        if self.rtt_server:
+            self.rtt_server.stop()
+            self.rtt_server = None
         self.abstract_socket.cleanup()
 
     def _cleanup_for_next_connection(self):
@@ -616,6 +623,9 @@ class GDBServer(threading.Thread):
 
             try:
                 state = self.target.get_state()
+
+                if self.rtt_server:
+                    self.rtt_server.poll()
 
                 # If we were able to successfully read the target state after previously receiving a fault,
                 # then clear the timeout.

--- a/pyocd/gdbserver/gdbserver_commands.py
+++ b/pyocd/gdbserver/gdbserver_commands.py
@@ -19,6 +19,7 @@ import logging
 
 from ..core import exceptions
 from ..commands.base import CommandBase
+from ..utility.rtt_server import RTTServer
 
 LOG = logging.getLogger(__name__)
 
@@ -125,3 +126,127 @@ class GdbserverMonitorExitCommand(CommandBase):
     def execute(self):
         for server in self.context.session.gdbservers.values():
             server.stop(wait=False)
+
+class RTTCommand(CommandBase):
+    INFO = {
+            'names': ['rtt'],
+            'group': 'gdbserver',
+            'category': 'rtt',
+            'nargs': "*",
+            'usage': "rtt {setup,start,stop,channels,server}",
+            'help': "Control SEGGER RTT compatible interface.",
+            }
+
+    def parse(self, args):
+        if len(args) < 1:
+            raise exceptions.CommandError("too few arguments")
+
+        if args[0] == 'setup':
+            if len(args) < 4:
+                raise exceptions.CommandError("too few arguments")
+
+            try:
+                self.addr = int(args[1], 0)
+                self.size = int(args[2], 0)
+                self.id = " ".join(args[3:]).encode("utf-8")
+            except ValueError as e:
+                raise exceptions.CommandError("invalid action") from e
+        elif args[0] == 'start' or args[0] == 'stop' or args[0] == 'channels':
+            if len(args) > 1:
+                raise exceptions.CommandError("too many arguments")
+        elif args[0] == 'server':
+            if len(args) < 2:
+                    raise exceptions.CommandError("too few arguments")
+
+            if args[1] == 'start':
+                if len(args) < 4:
+                    raise exceptions.CommandError("too few arguments")
+                elif len(args) > 4:
+                    raise exceptions.CommandError("too many arguments")
+
+                try:
+                    self.port = int(args[2], 0)
+                    self.channel = int(args[3], 0)
+                except ValueError as e:
+                    raise exceptions.CommandError("invalid action*") from e
+            elif args[1] == 'stop':
+                if len(args) < 3:
+                    raise exceptions.CommandError("too few arguments")
+                elif len(args) > 3:
+                    raise exceptions.CommandError("too many arguments")
+
+                try:
+                    self.port = int(args[2], 0)
+                except ValueError as e:
+                    raise exceptions.CommandError("invalid action") from e
+            else:
+                raise exceptions.CommandError("invalid action")
+
+            self.server_action = args[1]
+        else:
+            raise exceptions.CommandError("invalid action")
+
+        self.action = args[0]
+
+    def execute(self):
+        # Get the gdbserver for the selected core.
+        core_number = self.context.selected_core.core_number
+        try:
+            gdbserver = self.context.session.gdbservers[core_number]
+        except KeyError:
+            raise exceptions.CommandError("no gdbserver for core #%i" % core_number)
+
+        if self.action == "setup":
+            if gdbserver.rtt_server is not None:
+                if gdbserver.rtt_server.running:
+                    raise exceptions.CommandError("rtt is already running")
+                else:
+                    gdbserver.rtt_server = None
+
+            try:
+                gdbserver.rtt_server = RTTServer(gdbserver.target, address = self.addr,
+                                                 size = self.size,
+                                                 control_block_id = self.id)
+            except exceptions.RTTError as e:
+                raise exceptions.CommandError(str(e)) from e
+        elif self.action == "start":
+            if gdbserver.rtt_server is None:
+                raise exceptions.CommandError("rtt is not configured")
+
+            try:
+                gdbserver.rtt_server.start()
+            except exceptions.RTTError as e:
+                raise exceptions.CommandError(str(e)) from e
+
+            self.context.write(f"Found RTT control block.")
+        elif self.action == "stop":
+            if gdbserver.rtt_server is not None:
+                gdbserver.rtt_server.stop()
+        elif self.action == "channels":
+            control_block = gdbserver.rtt_server.control_block
+            self.context.write(f"Channels: up={len(control_block.up_channels)}, "
+                               f"down={len(control_block.down_channels)}")
+            self.context.write("Up-channels:")
+            for i, chan in enumerate(control_block.up_channels):
+                name = chan.name if chan.name is not None else ""
+                self.context.write(f"{i}: {name} {chan.size}")
+            self.context.write("Down-channels:")
+            for i, chan in enumerate(control_block.up_channels):
+                name = chan.name if chan.name is not None else ""
+                self.context.write(f"{i}: {name} {chan.size}")
+        elif self.action == "server":
+            if gdbserver.rtt_server is None:
+                raise exceptions.CommandError("rtt is not configured")
+            elif not gdbserver.rtt_server.running:
+                raise exceptions.CommandError("rtt is not yet started")
+
+            if self.server_action == "start":
+                try:
+                    gdbserver.rtt_server.add_server(self.port, self.channel)
+                except exceptions.RTTError as e:
+                    raise exceptions.CommandError(str(e)) from e
+            elif self.server_action == "stop":
+                try:
+                    gdbserver.rtt_server.stop_server(self.port)
+                except exceptions.RTTError as e:
+                    raise exceptions.CommandError(str(e)) from e

--- a/pyocd/utility/rtt_server.py
+++ b/pyocd/utility/rtt_server.py
@@ -1,0 +1,251 @@
+# pyOCD debugger
+# Copyright (c) 2022 Samuel Dewan
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import ABC, abstractmethod
+import selectors
+import socket
+from typing import Optional, Sequence
+
+from ..core.soc_target import SoCTarget
+from ..core import exceptions
+from ..debug.rtt import RTTControlBlock, RTTUpChannel, RTTDownChannel
+
+
+class RTTChanWorker(ABC):
+    """@brief Source and sink for data to be transferred over RTT. """
+
+    @abstractmethod
+    def write_up_data(self, data: bytes) -> int:
+        """@brief Write data that has been received from an up channel to the
+                  correct destination.
+
+        @param data The data to be written.
+        @return The number of bytes that were successfully written.
+        """
+        pass
+
+    @abstractmethod
+    def get_down_data(self) -> bytes:
+        """@brief Get data that should be written to a down channel if there is
+                  any.
+
+        @return Data to be written to down channel.
+        """
+        pass
+
+    @abstractmethod
+    def close(self):
+        """@brief Cleanup channel worker and close any file descriptors."""
+        pass
+
+
+class RTTChanTCPWorker(RTTChanWorker):
+    """@brief Implementation of channel worker that forwards RTT data via a TCP
+              socket. """
+
+    port: int
+
+    def __init__(self, port: int, listen: bool = True):
+        """
+        @param port The port to connect to or to listen for connects on.
+        @param listen If true a server will be started to accept one connection
+                      at a time on the given port. If false a connection will be
+                      made as a TCP client to a server running on the given
+                      port on localhost.
+        """
+        if listen:
+            self.server = socket.socket()
+            self.server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            self.server.bind(('localhost', port))
+            self.server.listen(1)
+            self.server.setblocking(False)
+            self.client = None
+        else:
+            self.server = None
+            self.client = socket.create_connection(('localhost', port), timeout = 1.0)
+            self.client.setblocking(False)
+
+        self.port = port
+
+    def _check_for_new_client(self):
+        if self.server is None:
+            return
+
+        sel = selectors.DefaultSelector()
+        sel.register(self.server, selectors.EVENT_READ, None)
+        events = sel.select(timeout = 0)
+        for key, _ in events:
+            if key.fileobj == self.server:
+                self.client, _ = self.server.accept()
+                self.client.setblocking(False)
+
+    def write_up_data(self, data: bytes):
+        if self.client is None:
+            self._check_for_new_client()
+            if self.client is None:
+                return 0
+
+        return self.client.send(data)
+
+    def get_down_data(self):
+        if self.client is None:
+            self._check_for_new_client()
+            if self.client is None:
+                return b''
+
+        sel = selectors.DefaultSelector()
+        sel.register(self.client, selectors.EVENT_READ, None)
+        events = sel.select(timeout = 0)
+        for key, _ in events:
+            if key.fileobj == self.client:
+                data = self.client.recv(4096)
+                if not data:
+                    # client socket closed at other end
+                    self.client.close()
+                    self.client = None
+                return data
+
+        return bytes()
+
+    def close(self):
+        if self.server is not None:
+            self.server.close()
+        if self.client is not None:
+            self.client.close()
+
+class RTTChanFileWorker(RTTChanWorker):
+    """@brief Implementation of channel worker that write data from RTT channel
+              to a file and optionally reads data from a file into an RTT
+              channel. """
+
+
+class RTTServer:
+    """@brief Keeps track of polling for multiple active RTT channels and the
+              sources and sinks of data for each channel. """
+    control_block: RTTControlBlock
+    workers: Optional[Sequence[Optional[RTTChanWorker]]]
+    up_buffers: Optional[Sequence[bytes]]
+    down_buffers: Optional[Sequence[bytes]]
+
+    def __init__(self, target: SoCTarget, address: int, size: int,
+                 control_block_id: bytes):
+        """
+        @param target The target with which RTT communication is desired.
+        @param address Base address for control block search range.
+        @param size Control block search range. If 0 the control block will be
+                    expected to be located at the provided address.
+        @param control_block_id The control block ID string to search for. Must
+                                be at most 16 bytes long.  Will be padded with
+                                zeroes if less than 16 bytes.
+        """
+        self.control_block = RTTControlBlock.from_target(target, address = address,
+                                    size = size, control_block_id = control_block_id)
+
+        self.workers = None
+        self.up_buffers = None
+        self.down_buffers = None
+
+    def poll(self):
+        """@brief Reads from and writes to active RTT channels. """
+        if not self.running:
+            # not yet started
+            return
+
+        for i, worker in enumerate(self.workers):
+            if worker is None:
+                continue
+
+            # Read from up channel
+            try:
+                up_chan: RTTUpChannel = self.control_block.up_channels[i]
+            except IndexError:
+                pass
+            else:
+                self.up_buffers[i] += up_chan.read()
+
+            # Write to worker
+            bytes_written = worker.write_up_data(self.up_buffers[i])
+            self.up_buffers[i] = self.up_buffers[i][bytes_written:]
+
+            # Read from worker
+            self.down_buffers[i] += worker.get_down_data()
+
+            # Write data to down channel
+            try:
+                down_chan: RTTDownChannel = self.control_block.down_channels[i]
+            except IndexError:
+                pass
+            else:
+                bytes_out: int = down_chan.write(self.down_buffers[i])
+                self.down_buffers[i] = self.down_buffers[i][bytes_out:]
+
+    def start(self):
+        """@brief Find and parse RTT control block. """
+        self.control_block.start()
+
+        num_up_chans: int = len(self.control_block.up_channels)
+        num_down_chans: int = len(self.control_block.down_channels)
+        num_chans: int = max(num_up_chans, num_down_chans)
+
+        self.workers = [None] * num_chans
+        self.up_buffers = [bytes()] * num_up_chans
+        self.down_buffers = [bytes()] * num_down_chans
+
+    def stop(self):
+        """@brief Close all RTT workers. """
+        if not self.running:
+            return
+
+        for i, worker in enumerate(self.workers):
+            if worker is not None:
+                worker.close()
+
+        self.workers = None
+        self.up_buffers = None
+        self.down_buffers = None
+
+    @property
+    def running(self):
+        """@brief True if RTT is started. """
+        return self.workers is not None
+
+    def add_server(self, port: int, channel: int):
+        """@brief Start a new TCP server to communicate with a given RTT channel.
+
+        @param port The port on which the server should listen for new connections.
+        @param channel The RTT channel which should be exposed over TCP.
+        """
+        if not self.running:
+            raise exceptions.RTTError("RTT is not yet started")
+        elif self.workers[channel] is not None:
+            raise exceptions.RTTError(f"RTT is already started for channel {channel}")
+
+        self.workers[channel] = RTTChanTCPWorker(port, listen = True)
+
+    def stop_server(self, port: int):
+        """@brief Stop a TCP server.
+
+        @param port The port of the server to be stopped.
+        """
+
+        if not self.running:
+            return
+
+        for i, worker in enumerate(self.workers):
+            if isinstance(worker, RTTChanTCPWorker):
+                if worker.port == port:
+                    worker.close()
+                    self.workers[i] = None


### PR DESCRIPTION
This PR moves the RTT implementation into a separate file so that it can be used by other modules and scripts. It also adds RTT support to the GDB server in a fashion modelled after openocd.

**Testing done:**
- Manual testing performed on an ST Nucleo-G071RB with its ST link reprogrammed as a J-Link and on an NXP LPCXpresso55S69. On the target side I used SEGGER's RTT implementation from the J-Link software and documentation package version 7.70.
- Unit tests pass.
- I am unable to run the automated test suite, I encounter the error `Skipping board <serial> due to missing test binary`.

**Some concerns:**
- I have significantly changed the behaviour of the RTT subcommand. Previously it would wait for a newline before sending any data to the target. If a line was too large to fit in the target buffer it would silently fail and stop sending data to the target entirely. In my opinion this behaviour is incorrect. I have modified the subcommand such that characters are sent to the target as they are received. This matches the behaviour of SEGGER's RTT viewer application and allows for much smaller down buffers to be used (like for example the default configuration for SEGGER's RTT implementation which uses a 16 byte down buffer for channel 0).
- My new gdbserver command implementation is very messy. Is there a better way to implement this?

**Future directions:**
- This PR does not make the RTT settings available as session options. The only way to configure RTT for use with the gdbserver is via monitor commands.
- This PR does not add support for using the native RTT capabilities of J-Link interfaces, but it does lay the groundwork to make it easy in the future. pylink supports the required functionality, but I have not yet looked in to how to expose it to the RTT code.
- This PR also lays the groundwork to do different things with the RTT data rather than just making it available via a TCP server. In the future the data could be written to/read from a file or pyOCD could connect as a client to an existing TCP server.