### PR TITLE
NRF52: Ensure core discovery after mass erase on locked targets

### DIFF
--- a/pyocd/target/family/target_nRF52.py
+++ b/pyocd/target/family/target_nRF52.py
@@ -103,7 +103,7 @@ class NRF52(CoreSightTarget):
                     raise exceptions.TargetError("unable to unlock device")
                 # Cached badness from create_ap run during AP lockout prevents create_cores from
                 # succeeding.
-                self.dp.create_1_ap(AHB_AP_NUM)
+                self._discoverer._create_1_ap(AHB_AP_NUM)
             else:
                 LOG.warning("%s APPROTECT enabled: not automatically unlocking", self.part_number)
         else:


### PR DESCRIPTION
This addresses issue #723

At some point, the `create_1_ap()` method must have been moved from the `DebugPort` class to the discoverer.