### PR TITLE
CMSIS Pack: Use pdsc-relative path for resource files, fixes #1460

### DIFF
--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -129,6 +129,13 @@ class CmsisPack:
             opened (due to particularities of the ZipFile implementation).
         """
         filename = filename.replace('\\', '/')
+
+        # Some vendors place their pdsc in some subdirectories of the pack archive,
+        # use relative directory to the pdsc file while reading other files.
+        pdsc_base = self._pdscName.rsplit('/', 1)
+        if len(pdsc_base) == 2:
+            filename = f'{pdsc_base[0]}/{filename}'
+
         return io.BytesIO(self._pack_file.read(filename))
 
 class CmsisPackDescription:


### PR DESCRIPTION
This patch will try to read resource files (e.g. FLMs) using relative path to the pdsc file, which is used when some hardware vendors places their pdscs under subdirectory of a pack archive, and somehow valid for Keil MDK.

Signed-off-by: Yilin Sun <imi415@imi.moe>