### PR TITLE
align second double buffer to size of one sector

### DIFF
--- a/pyocd/target/builtin/target_MAX32660.py
+++ b/pyocd/target/builtin/target_MAX32660.py
@@ -58,7 +58,7 @@ FLASH_ALGO = {
     'page_size' : 0x400,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000,
-    'page_buffers' : [0x20001000, 0x20001400],   # Enable double buffering
+    'page_buffers' : [0x20001000, 0x20002000],   # Enable double buffering
     'min_program_length' : 0x400,
 
     # Relative region addresses and sizes


### PR DESCRIPTION
The MAX32660 has a flash sector size of 8kB but the flash RAM buffer for double buffering assumes each buffer to be 1kB.
During flash writing, the first sector has incorrect data starting from 0x400 (1kB), comparing with the source file this incorrect data matches data that should be at 0x2000.
All MAX32660 variants should have at least 32kB so I think there shouldn't be a problem increasing the RAM size.