### PR TITLE
Patch max32660 double buffer address

### DIFF
--- a/pyocd/target/builtin/target_MAX32660.py
+++ b/pyocd/target/builtin/target_MAX32660.py
@@ -58,7 +58,7 @@ FLASH_ALGO = {
     'page_size' : 0x400,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000,
-    'page_buffers' : [0x20001000, 0x20002000],   # Enable double buffering
+    'page_buffers' : [0x20001000, 0x20003000],   # Enable double buffering
     'min_program_length' : 0x400,
 
     # Relative region addresses and sizes

--- a/pyocd/target/builtin/target_MAX32660.py
+++ b/pyocd/target/builtin/target_MAX32660.py
@@ -58,7 +58,7 @@ FLASH_ALGO = {
     'page_size' : 0x400,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000,
-    'page_buffers' : [0x20001000, 0x20001400],   # Enable double buffering
+    'page_buffers' : [0x20001000, 0x20002000],   # Enable double buffering
     'min_program_length' : 0x400,
 
     # Relative region addresses and sizes


### PR DESCRIPTION
correction on double buffer start offset.
buffer offset is adjusted so that each has 0x2000 bytes, same as sector size
