### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -27,7 +27,6 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.6"
         - "3.7"
         - "3.8"
         - "3.9"
@@ -44,8 +43,8 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    # This requires pip 20.1+. The current ubuntu-latest as of 28 Feb 2021 has pip 21.0.1 by default
-    # for all Python versions 3.6-3.9.
+    # This requires pip 20.1+. As of 28 Feb 2021 this condition is met for all supported
+    # Python versions on all OSes.
     - name: Get pip cache dir
       id: pip-cache
       run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ classifiers =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -44,13 +43,12 @@ project_urls =
 zip_safe = True
 include_package_data = True
 packages = find:
-python_requires = >=3.6.0
+python_requires = >=3.7.0
 # Use hidapi on macOS and Windows, not needed on Linux.
 install_requires =
     capstone>=4.0,<5.0
     cmsis-pack-manager>=0.4.0,<1.0
     colorama<1.0
-    dataclasses; python_version < "3.7"
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
     intelhex>=2.0,<3.0
     intervaltree>=3.0.2,<4.0


### PR DESCRIPTION
Python 3.6 is not supported by upstream anymore.

Adjust minimum Python version in `setup.cfg` to be 3.7, and remove the `dataclasses` backport for 3.6.
Also remove Python 3.6 from the basic_test workflow matrix.

Note: this patch is based on #1330 with a few minor changes.