### PR TITLE
Debug probe pins API

### DIFF
--- a/docs/command_reference.md
+++ b/docs/command_reference.md
@@ -15,7 +15,10 @@ that ambiguous because it matches multiple commands, an error will be reported s
 command names. In addition, commonly used commands often have a short alias. The alias takes
 precedence even when it is a prefix of multiple other commands.
 
-<!-- Maintainer note: the following is auto-generated. Edit the command INFO source material. -->
+<!--
+Maintainer note: the following is auto-generated. Edit the command class INFO dict source material,
+then run ./scripts/generate_command_help.py.
+-->
 
 All commands
 ------------
@@ -403,6 +406,16 @@ Print core or peripheral register(s).
 Set the value of a core or peripheral register.
 </td></tr>
 
+<tr><td colspan="3"><b>Rtt</b></td></tr>
+
+<tr><td>
+<a href="#rtt"><tt>rtt</tt></a>
+</td><td>
+rtt {setup,start,stop,channels,server}
+</td><td>
+Control SEGGER RTT compatible interface.
+</td></tr>
+
 <tr><td colspan="3"><b>Semihosting</b></td></tr>
 
 <tr><td>
@@ -469,6 +482,16 @@ Show the target's current state.
 Control thread awareness.
 </td></tr>
 
+<tr><td colspan="3"><b>Utility</b></td></tr>
+
+<tr><td>
+<a href="#sleep"><tt>sleep</tt></a>
+</td><td>
+MILLISECONDS
+</td><td>
+Sleep for a number of milliseconds before continuing.
+</td></tr>
+
 <tr><td colspan="3"><b>Values</b></td></tr>
 
 <tr><td>
@@ -501,6 +524,14 @@ command can be read, written, or both.
 <table>
 
 <tr><th>Value</th><th>Access</th><th>Description</th></tr>
+
+<tr><td>
+<a href="#accessible-pins"><tt>accessible-pins</tt></a>
+</td><td>
+read-write
+</td><td>
+Display which debug probe pins can be read and written with the 'pins' value.
+</td></tr>
 
 <tr><td>
 <a href="#aps"><tt>aps</tt></a>
@@ -613,6 +644,14 @@ The current value of one or more session options.
 read-only
 </td><td>
 List of target peripheral instances.
+</td></tr>
+
+<tr><td>
+<a href="#pins"><tt>pins</tt></a>
+</td><td>
+read-write
+</td><td>
+Current debug probe protocol I/O pin states.
 </td></tr>
 
 <tr><td>
@@ -969,6 +1008,14 @@ Print core or peripheral register(s). If no arguments are provided, the 'general
 Set the value of a core or peripheral register. The REG parameter must be a core register name or a peripheral.register. When a peripheral register is written, if the -r option is passed then it is read back and the updated value printed. The -p option forces evaluating the register name as a peripheral register name. If the -f option is passed, then individual fields of peripheral registers will be printed in addition to the full value.
 
 
+### Rtt
+
+##### `rtt`
+
+**Usage**: rtt rtt {setup,start,stop,channels,server} \
+Control SEGGER RTT compatible interface.
+
+
 ### Semihosting
 
 ##### `arm`
@@ -1023,6 +1070,14 @@ Show the target's current state.
 Control thread awareness.
 
 
+### Utility
+
+##### `sleep`
+
+**Usage**: sleep MILLISECONDS \
+Sleep for a number of milliseconds before continuing.
+
+
 ### Values
 
 ##### `set`
@@ -1040,6 +1095,12 @@ Display a value.
 
 Value details
 -------------
+
+##### `accessible-pins`
+
+**Access**: read-write \
+**Usage**: show accessible-pins, set accessible-pins VALUE \
+Display which debug probe pins can be read and written with the 'pins' value.
 
 ##### `aps`
 
@@ -1129,6 +1190,12 @@ The current value of one or more session options. When setting, each argument sh
 **Access**: read-only \
 **Usage**: show peripherals \
 List of target peripheral instances.
+
+##### `pins`
+
+**Access**: read-write \
+**Usage**: show pins, set pins VALUE \
+Current debug probe protocol I/O pin states. The pins value is a mask containing the state of all accessible protocol pins. See the `accessible-pins` value for protocol pins that can be read and written by the connected debug probe.
 
 ##### `probe-uid`
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -340,7 +340,7 @@ class CMSISDAPProtocol(object):
         cmd = []
         cmd.append(Command.DAP_SWJ_PINS)
         cmd.append(output & 0xff)
-        cmd.append(pins)
+        cmd.append(pins & 0xff)
         cmd.append(wait & 0xff)
         cmd.append((wait >> 8) & 0xff)
         cmd.append((wait >> 16) & 0xff)

--- a/pyocd/probe/pydapaccess/dap_access_api.py
+++ b/pyocd/probe/pydapaccess/dap_access_api.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018-2019 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -285,6 +285,10 @@ class DAPAccessIntf(object):
 
     def is_reset_asserted(self):
         """@brief Returns True if the target reset line is asserted or False if de-asserted"""
+        raise NotImplementedError()
+
+    def pin_access(self, mask: int, value: int) -> int:
+        """@brief Read/write probe pins"""
         raise NotImplementedError()
 
     def set_deferred_transfer(self, enable):

--- a/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
+++ b/pyocd/probe/pydapaccess/dap_access_cmsis_dap.py
@@ -1,7 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2006-2013,2018-2021 Arm Limited
 # Copyright (c) 2020 Koji Kitayama
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -819,6 +819,11 @@ class DAPAccessCMSISDAP(DAPAccessIntf):
 
     def get_unique_id(self):
         return self._unique_id
+
+    @locked
+    def pin_access(self, mask: int, value: int) -> int:
+        self.flush()
+        return self._protocol.set_swj_pins(value, mask)
 
     @locked
     def assert_reset(self, asserted):


### PR DESCRIPTION
This patch adds a new API to the `DebugProbe` abstract class to enable reading and writing of pins provided by the debug probe. Presence of this API is indicated by the probe having the `DebugProbe.Capability.PIN_ACCESS` capability.

This pins API is quite simple and rather limited in some ways. For protocol-type pins, it's fine. But for GPIO you'd probably want more explicit control.

Support is included for the CMSIS-DAP and Segger JLink probe drivers.

New API methods:

`DebugProbe.get_accessible_pins(group: PinGroup) -> None` \
Returns the readable and writable for a given pin group.

`DebugProbe.read_pins(group: PinGroup, mask: int) -> int` \
Read a selection of pins from one group.

`DebugProbe.write_pins(group: PinGroup, mask: int, value: int) -> None` \
Write a selection of pins from one group.

There are currently two pin groups defined:

1. `DebugProbe.PinGroup.PROTOCOL_PINS` — the usual SWD/JTAG/reset pins
2. `DebugProbe.PinGroup.GPIO_PINS` — reserved for future access of GPIO pins provided by a debug probe, not implemented by any debug probe driver yet (it's possible for JLink, but I don't have a JLink with GPIO so couldn't test)

Other changes:
- Added `accessible-pins` and `pins` values to use with `set` and `show` commands.
- Fixed type errors in JLink probe driver.