### PR TITLE
commands: reinit: set exec context attrs to defaults

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -1362,6 +1362,7 @@ class ReinitCommand(CommandBase):
 
     def execute(self):
         self.context.target.init()
+        self.context.set_context_defaults()
 
 class WhereCommand(CommandBase):
     INFO = {

--- a/pyocd/commands/execution_context.py
+++ b/pyocd/commands/execution_context.py
@@ -213,28 +213,37 @@ class CommandExecutionContext:
 
         # Select the first core's MEM-AP by default.
         if not self._no_init:
-            try:
-                # Selected core defaults to the target's default selected core.
-                if self.selected_core is None:
-                    self.selected_core = self.target.selected_core
-
-                # Get the AP for the selected core.
-                if self.selected_core is not None:
-                    self.selected_ap_address = self.selected_core.ap.address
-            except IndexError:
-                pass
-
-            # Fall back to the first MEM-AP.
-            if self.selected_ap_address is None:
-                for ap_num in sorted(self.target.aps.keys()):
-                    if isinstance(self.target.aps[ap_num], MEM_AP):
-                        self.selected_ap_address = ap_num
-                        break
+            self.set_context_defaults()
 
         # Add user-defined commands once we know we have a session created.
         self.command_set.add_command_group('user')
 
         return True
+
+    def set_context_defaults(self) -> None:
+        """@brief Sets context attributes to their default values.
+
+        Sets the selected core and selected MEM-AP to the default values.
+        """
+        assert self.target
+
+        try:
+            # Selected core defaults to the target's default selected core.
+            if self.selected_core is None:
+                self.selected_core = self.target.selected_core
+
+            # Get the AP for the selected core.
+            if self.selected_core is not None:
+                self.selected_ap_address = self.selected_core.ap.address
+        except IndexError:
+            pass
+
+        # Fall back to the first MEM-AP.
+        if self.selected_ap_address is None:
+            for ap_num in sorted(self.target.aps.keys()):
+                if isinstance(self.target.aps[ap_num], MEM_AP):
+                    self.selected_ap_address = ap_num
+                    break
 
     @property
     def session(self):


### PR DESCRIPTION
After reinitialising the target, also reinit the command execution context's selected `core` and `mem-ap` attributes. This is done so those attributes will get a valid value after reinit if the didn't have one before (eg, because no cores had been discovered). The value of the attributes is not changed if they were already set.

To support this, the relevant code in `CommandExecutionContext.attach_session()` was extracted to `.set_context_defaults()`.