### PR TITLE
dependency: bump minimum cmsis-pack-manager version to 0.5.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ python_requires = >=3.7.0
 # Use hidapi on macOS and Windows, not needed on Linux.
 install_requires =
     capstone>=4.0,<5.0
-    cmsis-pack-manager>=0.4.0,<1.0
+    cmsis-pack-manager>=0.5.2,<1.0
     colorama<1.0
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
     intelhex>=2.0,<3.0


### PR DESCRIPTION
Set minimum cmsis-pack-manager version to 0.5.2 to bring in important fixes:

- Limit concurrent connections to 6 per unique host to prevent activating DDoS protections on servers. This resolves a long-standing issue where a number of mostly NXP and Keil pack descriptors would fail to download.
- Check HTTP response codes for downloaded files.