### PR TITLE
RTOS: Catch TransferErrors during kernel state checks

### DIFF
--- a/pyocd/rtos/argon.py
+++ b/pyocd/rtos/argon.py
@@ -440,8 +440,12 @@ class ArgonThreadProvider(ThreadProvider):
     def get_is_running(self):
         if self.g_ar is None:
             return False
-        flags = self._target_context.read32(self.g_ar + KERNEL_FLAGS_OFFSET)
-        return (flags & IS_RUNNING_MASK) != 0
+        try:
+            flags = self._target_context.read32(self.g_ar + KERNEL_FLAGS_OFFSET)
+            return (flags & IS_RUNNING_MASK) != 0
+        except exceptions.TransferFaultError:
+            LOG.warn("Argon: read kernel flags failed, target memory might not be initialized yet.")
+            return False
 
 class ArgonTraceEvent(events.TraceEvent):
     """@brief Argon kernel trace event."""

--- a/pyocd/rtos/freertos.py
+++ b/pyocd/rtos/freertos.py
@@ -508,7 +508,12 @@ class FreeRTOSThreadProvider(ThreadProvider):
     def get_is_running(self):
         if self._symbols is None:
             return False
-        return self._target_context.read32(self._symbols['xSchedulerRunning']) != 0
+        try:
+            return self._target_context.read32(self._symbols['xSchedulerRunning']) != 0
+        except exceptions.TransferFaultError:
+            LOG.warn("FreeRTOS: read running state failed, target memory might not be initialized yet.")
+            return False
+
 
     def _get_elf_symbol_size(self, name, addr, calculated_size):
         if self._target.elf is not None:

--- a/pyocd/rtos/threadx.py
+++ b/pyocd/rtos/threadx.py
@@ -481,7 +481,11 @@ class ThreadXThreadProvider(ThreadProvider):
         # safer to compare it with TX_INITIALIZE_IN_PROGRESS.
         if self._system_state is None:
             return False
-        return self._target_context.read32(self._system_state) < self.TX_INITIALIZE_IN_PROGRESS
+        try:
+            return self._target_context.read32(self._system_state) < self.TX_INITIALIZE_IN_PROGRESS
+        except exceptions.TransferFaultError:
+            LOG.warn("ThreadX: read system state failed, target memory might not be initialized yet.")
+            return False
 
     @property
     def current_thread(self):


### PR DESCRIPTION
In some cases, RTOS data structures needs to be loaded to external memory space after the program is started or by some kind of booloader, and these memory spaces might not be available at post reset event. This patch try to address this issue for some RTOS ports (RTX5 already has exception rescue routine so is not affected).

** Note: Only FreeRTOS is tested for now. **