### PR TITLE
[Dependencies] Bump Pylink

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     natsort>=8.0.0,<9.0
     prettytable>=2.0,<4.0
     pyelftools<1.0
-    pylink-square>=0.11.1,<1.0
+    pylink-square>=0.11.1,<2.0
     pyusb>=1.2.1,<2.0
     pyyaml>=6.0,<7.0
     six>=1.15.0,<2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,7 @@ install_requires =
     natsort>=8.0.0,<9.0
     prettytable>=2.0,<4.0
     pyelftools<1.0
-    pylink-square>=0.11.1,<2.0
+    pylink-square>=1.0,<2.0
     pyusb>=1.2.1,<2.0
     pyyaml>=6.0,<7.0
     six>=1.15.0,<2.0


### PR DESCRIPTION
Pylink 1.0 has the following breaking change:

@denravonska: Changed .flash() to no longer erase chip on flash; users will now need to ensure they call .erase() prior to flashing a non-erased region of flash.

However, pyOCD doesn't use JLinks's flash routines so there is no call in the codebase to `.flash()` from `pylink`. This makes it safe to allow `pylink` packages with a major version of 1.