### PR TITLE
probe: cmsis-dap: set retry count to max value by default

### DIFF
--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -294,7 +294,7 @@ class CMSISDAPProtocol(object):
 
         return resp[1]
 
-    def transfer_configure(self, idle_cycles=0x02, wait_retry=0x0050, match_retry=0x0000):
+    def transfer_configure(self, idle_cycles=0x02, wait_retry=0xFFFF, match_retry=0x0000):
         cmd = []
         cmd.append(Command.DAP_TRANSFER_CONFIGURE)
         cmd.append(idle_cycles)


### PR DESCRIPTION
This patch sets the retry count for DAP transfers to the highest value by default.
This is needed since flash erase will stall a read operation for a long time on the nRF9160.