### PR TITLE
udev: add rule for STM32F103C8T6_CMSIS-DAP_SWOC CMSIS-DAP probe

### DIFF
--- a/udev/50-cmsis-dap.rules
+++ b/udev/50-cmsis-dap.rules
@@ -52,6 +52,9 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="216c", MODE:="666"
 # 03eb:2175 Microchip nEDBG CMSIS-DAP
 SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2175", MODE:="666"
 
+# 0483:572a STMicroelectronics CMSIS-DAP
+SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="572a", MODE:="666"
+
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with

--- a/udev/50-cmsis-dap.rules
+++ b/udev/50-cmsis-dap.rules
@@ -52,7 +52,9 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="216c", MODE:="666"
 # 03eb:2175 Microchip nEDBG CMSIS-DAP
 SUBSYSTEM=="usb", ATTR{idVendor}=="03eb", ATTR{idProduct}=="2175", MODE:="666"
 
-# 0483:572a STMicroelectronics CMSIS-DAP
+# 0483:572a RadioOperator STM32F103C8T6_CMSIS-DAP_SWO probe firmware
+# Firmware repository: https://github.com/RadioOperator/STM32F103C8T6_CMSIS-DAP_SWO
+# Note, this firmware uses STMicroelectronic's USB VID.
 SUBSYSTEM=="usb", ATTR{idVendor}=="0483", ATTR{idProduct}=="572a", MODE:="666"
 
 # If you share your linux system with other users, or just don't like the


### PR DESCRIPTION
This PR adds a udev rule for the https://github.com/RadioOperator/STM32F103C8T6_CMSIS-DAP_SWO probe.

```
$ lsusb 
..
Bus 001 Device 015: ID 0483:572a STMicroelectronics CMSIS-DAP
...
Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
```