### PR TITLE
flash: catch exceptions while fetching state

### DIFF
--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2013-2020 Arm Limited
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2023 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -622,9 +623,14 @@ class Flash:
         state = Target.State.RUNNING # lgtm[py/multiple-definition]
         with Timeout(timeout) as time_out:
             while time_out.check():
-                state = self.target.get_state()
-                if state != Target.State.RUNNING:
-                    break
+                try:
+                    state = self.target.get_state()
+                    if state != Target.State.RUNNING:
+                        break
+                except exceptions.TransferTimeoutError:
+                    LOG.debug("target.get_state probe timeout")
+                except exceptions.TransferFaultError:
+                    LOG.debug("target.get_state probe fault")
             else:
                 # Operation timed out.
                 self.target.halt()

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -294,7 +294,7 @@ class CMSISDAPProtocol(object):
 
         return resp[1]
 
-    def transfer_configure(self, idle_cycles=0x02, wait_retry=0xFFFF, match_retry=0x0000):
+    def transfer_configure(self, idle_cycles=0x02, wait_retry=0x0050, match_retry=0x0000):
         cmd = []
         cmd.append(Command.DAP_TRANSFER_CONFIGURE)
         cmd.append(idle_cycles)


### PR DESCRIPTION
This patch catches (DAPLink) probe timeouts while waiting for a flash operation. These timeouts can occur on targets that are stalled for a long time. It also reverts my previous attempt to fix the issue, which is unnecessary now and might cause other timeouts.