### PR TITLE
Migrate away from deprecated pkg_resources

### DIFF
--- a/pyocd/core/plugin.py
+++ b/pyocd/core/plugin.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pkg_resources
 import logging
+from importlib_metadata import entry_points
 from typing import (
     Any,
     Dict,
@@ -92,7 +92,7 @@ def load_plugin_classes_of_type(plugin_group: str, plugin_dict: Dict[str, Any], 
     @param plugin_dict Dictionary to fill with loaded plugin classes.
     @param base_class The required superclass for plugin implementation classes.
     """
-    for entry_point in pkg_resources.iter_entry_points(plugin_group):
+    for entry_point in entry_points(group=plugin_group):
         # Instantiate the plugin class.
         plugin = entry_point.load()()
         if not isinstance(plugin, Plugin):

--- a/pyocd/debug/svd/loader.py
+++ b/pyocd/debug/svd/loader.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 
 import threading
 import logging
-import pkg_resources
+import importlib_resources
 import zipfile
 
 from .parser import SVDParser
@@ -31,7 +31,8 @@ class SVDFile(object):
     @classmethod
     def from_builtin(cls, svd_name):
         try:
-            zip_stream = pkg_resources.resource_stream("pyocd", BUILTIN_SVD_DATA_PATH)
+            zip_ref = importlib_resources.files("pyocd").joinpath(BUILTIN_SVD_DATA_PATH)
+            zip_stream = zip_ref.open('rb')
             zip = zipfile.ZipFile(zip_stream, 'r')
             return SVDFile(zip.open(svd_name))
         except (KeyError, FileNotFoundError, zipfile.BadZipFile) as err:

--- a/pyocd/tools/lists.py
+++ b/pyocd/tools/lists.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 import os
-import pkg_resources
+from importlib_metadata import entry_points
 
 from .. import __version__
 from ..core.session import Session
@@ -235,7 +235,7 @@ class ListGenerator(object):
                 'plugins': plugin_list,
                 }
 
-            for entry_point in pkg_resources.iter_entry_points(group_name):
+            for entry_point in entry_points(group=group_name):
                 klass = entry_point.load()
                 plugin = klass()
                 info = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,11 +46,16 @@ include_package_data = True
 packages = find:
 python_requires = >=3.7.0
 # Use hidapi on macOS and Windows, not needed on Linux.
+#
+# importlib_resources is used instead of stdlib importlib.resources because we
+# want the selectable entry_points API, which is not present until Python 3.10.
 install_requires =
     capstone>=4.0,<5.0
     cmsis-pack-manager>=0.5.2,<1.0
     colorama<1.0
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
+    importlib_metadata>=3.6
+    importlib_resources
     intelhex>=2.0,<3.0
     intervaltree>=3.0.2,<4.0
     libusb-package>=1.0,<2.0

--- a/test/unit/test_svd.py
+++ b/test/unit/test_svd.py
@@ -1,0 +1,34 @@
+# pyOCD debugger
+# Copyright (c) 2023 Chris Reed
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pyocd.debug.svd.loader import (
+    SVDFile,
+    SVDLoader,
+)
+
+class TestIntervalSvdAccess:
+    def builtin_svd(self, name: str) -> SVDLoader:
+        def completion(dev):
+            pass
+        loader = SVDLoader(SVDFile.from_builtin(name), completion)
+        loader.run()
+        return loader
+
+    def test_load(self):
+        loader = self.builtin_svd('Musca_B1.svd')
+        assert loader.device
+        assert [p for p in loader.device.peripherals if p.name == 'UART0']
+


### PR DESCRIPTION
This patch replaces use of `pkg_resources` with the replacements, `importlib.resources` and `importlib_metadata`. Note that `importlib_metadata` is used instead of the standard lib `importlib.metadata` because the selectable `.entry_points()` API is desired, and that is only available from `importlib_metadata` version 3.6 included since Python 3.10.

A small unit test for loading builtin SVD data is added.