### PR TITLE
semihosting: SYS_GET_CMDLINE, feature bits, tilde expansion, type fixes

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -476,6 +476,13 @@ Whether to use GDB syscalls for semihosting file access operations, or to have p
 operations. This is most useful if GDB is running on a remote system.
 </td></tr>
 
+<tr><td>semihost.commandline</td>
+<td>str</td>
+<td><i>Empty</i></td>
+<td>
+Program command line string, used for the SYS_GET_CMDLINE semihosting request.
+</td></tr>
+
 <tr><td>step_into_interrupt</td>
 <td>bool</td>
 <td>False</td>

--- a/docs/semihosting.md
+++ b/docs/semihosting.md
@@ -123,6 +123,7 @@ These are the session options that control semihosting:
 
 - `enable_semihosting` - Set to true to handle semihosting requests.
 - `semihost_console_type` - If set to 'telnet' then the semihosting telnet server will be started. If set to 'console' then semihosting will print to pyOCD's console.
+- `semihost.commandline` - Command line string return to the target for the `SYS_GET_CMDLINE` request.
 - `semihost_use_syscalls` - Whether to use GDB syscalls for semihosting file access operations, or to have pyOCD perform the operations.)
 - `telnet_port` - Base TCP port number for the semihosting telnet server. The core number, which will be 0 for the primary core, is added to this value.
 
@@ -135,6 +136,10 @@ The majority of standard Arm-defined semihosting requests are supported by pyOCD
     - The special file name `:tt` is used to open standard I/O files, per the Arm semihosting specification. The open
     mode selects which standard I/O file is opened. "r" (0) is stdin, "w" (4) is stdout, "a" (8) is stderr. With pyOCD's
     implementation, explicitly opening the standard I/O files is not required.
+    - The special file name `:semihosting-features` will open the semihosting feature bits file. Supported
+        feature bits are:
+        - `SH_EXT_EXIT_EXTENDED` (byte 0 bit 0): =0, meaning `SYS_EXIT_EXTENDED` is not supported
+        - `SH_EXT_STDOUT_STDERR` (byte 0 bit 1): =1, meaning both stdout and stderr are supported
     - Standard I/O files opened via this request are only accessible when not routing console to the telnet server.
 - `SYS_CLOSE` (0x02): syscall
 - `SYS_WRITEC` (0x03): console
@@ -151,6 +156,9 @@ The majority of standard Arm-defined semihosting requests are supported by pyOCD
     object was created, so this will not line up with timestamps in pyOCD's log output)
 - `SYS_TIME` (0x11): returns the number of seconds since midnight, January 1, 1970
 - `SYS_ERRNO` (0x13): syscall
+- `SYS_GET_CMDLINE` (0x15): returns the value of the `semihost.commandline` session option. If that option
+    is not set, the request fails (returns -1).
+- `SYS_HEAPINFO` (0x16): stubbed to return all 0 values
 
 
 The following semihosting requests are not supported. If invoked, the return code is -1 and pyOCD logs a
@@ -159,10 +167,9 @@ warning message, such as "Semihost: unimplemented request pc=\<x> r0=\<y> r1=\<z
 - `SYS_ISERROR` (0x08)
 - `SYS_TMPNAM` (0x0d)
 - `SYS_SYSTEM` (0x12)
-- `SYS_GET_CMDLINE` (0x15)
-- `SYS_HEAPINFO` (0x16)
 - `angel_SWIreason_EnterSVC` (0x17)
 - `SYS_EXIT` (0x18), also called `angel_SWIreason_ReportException`
+- `SYS_EXIT_EXTENDED` (0x20)
 - `SYS_ELAPSED` (0x30)
 - `SYS_TICKFREQ` (0x31)
 

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -166,6 +166,8 @@ BUILTIN_OPTIONS = [
         "semihosting will print to the console."),
     OptionInfo('semihost_use_syscalls', bool, False,
         "Whether to use GDB syscalls for semihosting file access operations."),
+    OptionInfo('semihost.commandline', str, "",
+        "Program command line string, used for the SYS_GET_CMDLINE semihosting request."),
     OptionInfo('step_into_interrupt', bool, False,
         "Enable interrupts when performing step operations."),
     OptionInfo('swv_clock', int, 1000000,

--- a/pyocd/debug/semihost.py
+++ b/pyocd/debug/semihost.py
@@ -423,6 +423,7 @@ class SemihostAgent:
         assert isinstance(pc, int)
 
         # Are we stopped due to one of our own breakpoints?
+        # TODO check against watchpoints too!?
         bp = self.context.core.find_breakpoint(pc)
         if bp:
             return False
@@ -617,9 +618,29 @@ class SemihostAgent:
         return 0
 
     def handle_sys_heapinfo(self, args: int) -> int:
-        raise NotImplementedError()
+        """@brief Stub implementation of SYS_HEAPINFO.
+
+        The args (r1) value is the address of a pointer to a four-word data block, to be filled in
+        by the host.
+
+        ```c
+        struct block {
+            int heap_base;
+            int heap_limit;
+            int stack_base;
+            int stack_limit;
+        };
+        ```
+
+        This implementation simply fills in the value 0 for each field. Zero is legal, and tells the
+        caller that the host was unable to determine the value.
+        """
+        info_block = self._get_args(args, 1)
+        self.context.write_memory_block32(info_block, [0, 0, 0, 0])
+        return 0
 
     def handle_sys_exit(self, args: int) -> int:
+        # TODO handle SYS_EXIT for a 'pyocd run' subcommand
         raise NotImplementedError()
 
     def handle_sys_exit_extended(self, args: int) -> int:

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -22,7 +22,7 @@ from time import sleep
 import sys
 import io
 from xml.etree.ElementTree import (Element, SubElement, tostring)
-from typing import (Dict, List, Optional)
+from typing import (Dict, List, Optional, Tuple)
 
 from ..core import exceptions
 from ..core.target import Target
@@ -1148,10 +1148,9 @@ class GDBServer(threading.Thread):
         resp = b'$' + data + b'#' + checksum(data)
         return resp
 
-    def syscall(self, op):
-        op = to_bytes_safe(op)
+    def syscall(self, op: str) -> Tuple[int, int]:
         LOG.debug("GDB server syscall: %s", op)
-        request = self.create_rsp_packet(b'F' + op)
+        request = self.create_rsp_packet(b'F' + op.encode())
         self.packet_io.send(request)
 
         while not self.packet_io.interrupt_event.is_set():

--- a/test/unit/test_semihosting.py
+++ b/test/unit/test_semihosting.py
@@ -112,6 +112,7 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
             return None
 
     def write(self, fd, ptr, length):
+        assert self.agent
         if fd not in self._out_data:
             self._out_data[fd] = b''
         assert self.agent
@@ -120,6 +121,7 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
         return 0
 
     def read(self, fd, ptr, length):
+        assert self.agent
         if fd not in self._in_data:
             return length
         d = self._in_data[fd][:length]
@@ -164,7 +166,7 @@ class SemihostRequestBuilder:
         return self.ramrgn.start + 0x200
 
     def do_open(self, filename, mode):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_OPEN)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_OPEN)
 
         # Write filename
         filename = bytearray(six.ensure_binary(filename) + b'\x00')
@@ -181,7 +183,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_close(self, fd):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_CLOSE)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_CLOSE)
         self.ctx.write32(argsptr, fd)
 
         was_semihost = run_til_halt(self.tgt, self.semihostagent)
@@ -191,7 +193,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_write(self, fd, data):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_WRITE)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_WRITE)
 
         # Write data
         data = six.ensure_binary(data)
@@ -209,7 +211,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_writec(self, c):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_WRITEC)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_WRITEC)
         self.ctx.write8(argsptr, ord(c))
 
         was_semihost = run_til_halt(self.tgt, self.semihostagent)
@@ -219,7 +221,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_write0(self, data):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_WRITE0)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_WRITE0)
 
         data = data + b'\x00'
         self.ctx.write_memory_block8(argsptr, data)
@@ -231,7 +233,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_read(self, fd, length):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_READ)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_READ)
 
         # Clear read buffer.
         self.ctx.write_memory_block8(argsptr + 12, bytearray(b'\x00') * length)
@@ -252,7 +254,7 @@ class SemihostRequestBuilder:
         return result, data
 
     def do_seek(self, fd, pos):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_SEEK)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_SEEK)
 
         self.ctx.write32(argsptr, fd) # fd
         self.ctx.write32(argsptr + 4, pos) # pos
@@ -266,7 +268,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_flen(self, fd):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_FLEN)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_FLEN)
 
         self.ctx.write32(argsptr, fd) # fd
         self.ctx.flush()
@@ -279,7 +281,7 @@ class SemihostRequestBuilder:
         return result
 
     def do_istty(self, fd):
-        argsptr = self.setup_semihost_request(semihost.TARGET_SYS_ISTTY)
+        argsptr = self.setup_semihost_request(semihost.SemihostingRequests.SYS_ISTTY)
 
         self.ctx.write32(argsptr, fd) # fd
         self.ctx.flush()
@@ -446,28 +448,28 @@ class TestSemihosting:
 
         console.set_input_data(semihost.STDIN_FD, 'x')
 
-        result = semihost_builder.do_no_args_call(semihost.TARGET_SYS_READC)
+        result = semihost_builder.do_no_args_call(semihost.SemihostingRequests.SYS_READC)
         assert chr(result) == 'x'
 
     def test_clock(self, semihost_builder):
-        result = semihost_builder.do_no_args_call(semihost.TARGET_SYS_CLOCK)
+        result = semihost_builder.do_no_args_call(semihost.SemihostingRequests.SYS_CLOCK)
         assert result != -1
         assert result != 0
         logging.info("clock = %d cs", result)
 
-        result2 = semihost_builder.do_no_args_call(semihost.TARGET_SYS_CLOCK)
+        result2 = semihost_builder.do_no_args_call(semihost.SemihostingRequests.SYS_CLOCK)
         assert result2 != -1
         assert result2 != 0
         assert result2 > result
         logging.info("clock = %d cs", result2)
 
     def test_time(self, semihost_builder):
-        result = semihost_builder.do_no_args_call(semihost.TARGET_SYS_TIME)
+        result = semihost_builder.do_no_args_call(semihost.SemihostingRequests.SYS_TIME)
         assert result != 0
         logging.info("time = %d sec", result)
 
     def test_errno_no_err(self, semihost_builder):
-        result = semihost_builder.do_no_args_call(semihost.TARGET_SYS_ERRNO)
+        result = semihost_builder.do_no_args_call(semihost.SemihostingRequests.SYS_ERRNO)
         assert result == 0
 
     @pytest.mark.parametrize(("fd"), [
@@ -533,7 +535,7 @@ def semihost_telnet_builder(tgt, semihost_telnet_agent, ramrgn):
 
 # class TestSemihostingTelnet:
 #     def test_connect(self, semihost_telnet_builder, telnet_conn):
-#         result = semihost_telnet_builder.do_no_args_call(semihost.TARGET_SYS_ERRNO)
+#         result = semihost_telnet_builder.do_no_args_call(semihost.SemihostingRequests.TARGET_SYS_ERRNO)
 #         assert result == 0
 
 #     def test_write(self, semihost_telnet_builder, telnet_conn):
@@ -572,7 +574,7 @@ def semihost_telnet_builder(tgt, semihost_telnet_agent, ramrgn):
 #         telnet_conn.write(b'xyz')
 
 #         for c in 'xyz':
-#             rc = semihost_telnet_builder.do_no_args_call(semihost.TARGET_SYS_READC)
+#             rc = semihost_telnet_builder.do_no_args_call(semihost.SemihostingRequests.TARGET_SYS_READC)
 #             assert chr(rc) == c
 
 class TestSemihostAgent:

--- a/test/unit/test_semihosting.py
+++ b/test/unit/test_semihosting.py
@@ -114,6 +114,7 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
     def write(self, fd, ptr, length):
         if fd not in self._out_data:
             self._out_data[fd] = b''
+        assert self.agent
         s = self.agent.get_data(ptr, length)
         self._out_data[fd] += s
         return 0
@@ -123,6 +124,7 @@ class RecordingSemihostIOHandler(semihost.SemihostIOHandler):
             return length
         d = self._in_data[fd][:length]
         self._in_data[fd] = self._in_data[fd][length:]
+        assert self.agent
         self.agent.context.write_memory_block8(ptr, bytearray(six.ensure_binary(d)))
         return length - len(d)
 


### PR DESCRIPTION
Several small features and some cleanup of the semihosting code.

- `SYS_GET_CMDLINE` request is handled, returning the value of the `semihost.commandline` session option.
- `SYS_HEAPINFO` is stubbed to return all zeroes.
- Tilde expansion for home directories in all file paths.
- Type annotations and type fixes.
- The `:semihosting-features` special file is supported. Added a unit test case for this. Supported feature bits are:
        - `SH_EXT_EXIT_EXTENDED` (byte 0 bit 0): =0, meaning `SYS_EXIT_EXTENDED` is not supported
        - `SH_EXT_STDOUT_STDERR` (byte 0 bit 1): =1, meaning both stdout and stderr are supported
    