### PR TITLE
cortex-m: only clear DEMCR and invoke stop_core_debug delegate if resuming core on disconnect

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -365,7 +365,11 @@ Timeout in seconds for waiting for the core to halt after a reset and halt.
 <td>bool</td>
 <td>True</td>
 <td>
-Whether to resume a halted target when disconnecting.
+Whether to disable debug control and resume the target when disconnecting.
+
+When True, then upon disconnect all CPUs are resumed, and DWT and other trace related blocks are disabled (`DEMCR` system register is cleared).
+If False, the target CPU states are left unchanged and any enabled debug hardware (DWT, ITM) remains enabled.
+In all cases, breakpoints and watchpoints are removed prior to disconnect.
 </td></tr>
 
 <tr><td>scan_all_aps</td>

--- a/docs/user_scripts.md
+++ b/docs/user_scripts.md
@@ -231,6 +231,25 @@ did_init_target(target: SoCTarget) -> None
 **Result** \
 Ignored.
 
+### unlock_device
+
+Hook to perform any required unlock sequence.
+```
+unlock_device(target: SoCTarget) -> None
+```
+
+**Parameters** \
+*target* - An `SoCTarget` object. \
+**Result** \
+Ignored.
+
+Called after the DP is initialised but prior to discovery. This hook delegate can be used to unlock debug
+access to the target. It can also be used to perform other pre-discovery actions.
+
+Note that because this hoook is called prior to discovery, APs and cores are not yet created. This means
+that any register accesses must be performed through the DP's methods. (However, it's possible to create
+a temporary instance of 'AccessPort' or one of its subclasses, such as `MEM_AP`.)
+
 ### will_start_debug_core
 
 Notification hook for before core debug is enabled.
@@ -300,6 +319,10 @@ stop_debug_core(core: CoreTarget) -> Optional[bool]
 **Result** \
 *True* Do not perform the normal procedure to disable core debug. \
 *False/None* Continue with normal behaviour.
+
+This delegate is only called if resuming the core on disconnect, e.g. the `resume_on_disconnect` session
+option is True. Therefore, the delegate should ensure that the core has properly resumed execution if it
+returns True.
 
 ### did_stop_debug_core
 


### PR DESCRIPTION
Leave `DEMCR` untouched if `resume_on_disconnect` session option is False (default is True). This ensures the DWT and other trace related hardware, especially the cycle counter (`DWT.CYCCNT`) remains active.

Also only call the `stop_core_debug` delegate / `DebugCoreStop` debug sequence when resuming on disconnect. This delegate (and more importantly, the debug sequence) assumes it must resume the core.