### PR TITLE
workflow: basic_test_skipped: add matching matrix to basic_test so the job names are the same

### DIFF
--- a/.github/workflows/basic_test_skipped.yaml
+++ b/.github/workflows/basic_test_skipped.yaml
@@ -14,6 +14,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # Note: this must have the same runs-on and strategy as the actual 'basic test' workflow, or
+    # the workflow names will not match.
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        - windows-latest
+        python-version:
+        - "3.7"
+        - "3.8"
+        - "3.9"
+        - "3.10"
+        - "3.11"
     steps:
       - run: 'echo "Skipped due to path filter."'


### PR DESCRIPTION
This fixes the issue with basic_test_skipped not properly generating passed tests for PRs that don't affect code.