### PR TITLE
coresight: discovery: continue after an AP probe failure occurs

### DIFF
--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -136,7 +136,6 @@ class ADIv5Discovery(CoreSightDiscovery):
             except exceptions.Error as e:
                 LOG.error("Error probing AP#%d: %s", apsel, e,
                     exc_info=self.session.log_tracebacks)
-                break
             apsel += 1
 
         # Update the AP list once we know it's complete.


### PR DESCRIPTION
With this change, the discovery process will continue on even if a fault occurs while reading the IDR of a v1 AP. According to the ADI specification, this should never happen (unless a truly unrecoverable error occurs), but some devices break the spec.