### PR TITLE
subcommands: disable debug.traceback option by default, unless debug logging is enabled

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -152,9 +152,11 @@ Log details of loaded .FLM flash algos.
 
 <tr><td>debug.traceback</td>
 <td>bool</td>
-<td>True</td>
+<td>False</td>
 <td>
-Print tracebacks for exceptions.
+Print tracebacks for exceptions, including errors that are only logged as well as critical errors that cause pyocd to terminate.
+
+Disabled by default, unless the log level is raised to Debug.
 </td></tr>
 
 <tr><td>enable_multicore_debug</td>

--- a/pyocd/commands/commander.py
+++ b/pyocd/commands/commander.py
@@ -214,10 +214,11 @@ class PyOCDCommander:
                         connect_mode=connect_mode,
                         frequency=self.args.frequency,
                         options=options,
-                        option_defaults=dict(
-                            auto_unlock=False,
-                            resume_on_disconnect=False,
-                            )
+                        option_defaults={
+                            'auto_unlock': False,
+                            'resume_on_disconnect': False,
+                            'debug.traceback': logging.getLogger('pyocd').isEnabledFor(logging.DEBUG),
+                            }
                         )
 
         if not self._post_connect():

--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -64,7 +64,7 @@ BUILTIN_OPTIONS = [
         "When switching between SWD and JTAG, use the SWJ sequence from ADIv5.2 that utilizes a new dormant state."),
     OptionInfo('debug.log_flm_info', bool, False,
         "Log details of loaded .FLM flash algos."),
-    OptionInfo('debug.traceback', bool, True,
+    OptionInfo('debug.traceback', bool, False,
         "Print tracebacks for exceptions."),
     OptionInfo('enable_multicore_debug', bool, False,
         "Whether to put pyOCD into multicore debug mode. Doing so changes the default software reset type of "

--- a/pyocd/subcommands/base.py
+++ b/pyocd/subcommands/base.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2021 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +17,7 @@
 import argparse
 import logging
 import prettytable
-from typing import (List, Optional, Type)
+from typing import (Any, Dict, List, Optional, Type)
 
 from ..utility.cmdline import convert_frequency
 
@@ -168,5 +168,18 @@ class SubcommandBase:
         pt.hrules = prettytable.HEADER
         pt.vrules = prettytable.NONE
         return pt
+
+    def _modified_option_defaults(self) -> Dict[str, Any]:
+        """@brief Returns a dict of session option defaults.
+
+        @return A dict containing updated default values for session options, based on common
+            subcommand arguments. It is intended to be passed as the `option_defaults` argument when
+            creating a `Session` instance.
+        @precondition Logging must have been configured.
+        """
+        return {
+            # Change 'debug.traceback' default to True if debug logging is enabled.
+            'debug.traceback': logging.getLogger('pyocd').isEnabledFor(logging.DEBUG),
+        }
 
 

--- a/pyocd/subcommands/erase_cmd.py
+++ b/pyocd/subcommands/erase_cmd.py
@@ -85,7 +85,9 @@ class EraseSubcommand(SubcommandBase):
                             frequency=self._args.frequency,
                             blocking=(not self._args.no_wait),
                             connect_mode=self._args.connect_mode,
-                            options=convert_session_options(self._args.options))
+                            options=convert_session_options(self._args.options),
+                            option_defaults=self._modified_option_defaults(),
+                            )
         if session is None:
             LOG.error("No device available to erase")
             return 1

--- a/pyocd/subcommands/gdbserver_cmd.py
+++ b/pyocd/subcommands/gdbserver_cmd.py
@@ -183,7 +183,9 @@ class GdbserverSubcommand(SubcommandBase):
                 target_override=self._args.target_override,
                 frequency=self._args.frequency,
                 connect_mode=self._args.connect_mode,
-                options=sessionOptions)
+                options=sessionOptions,
+                option_defaults=self._modified_option_defaults(),
+            )
             if session is None:
                 LOG.error("No probe selected.")
                 return 1

--- a/pyocd/subcommands/load_cmd.py
+++ b/pyocd/subcommands/load_cmd.py
@@ -91,7 +91,9 @@ class LoadSubcommand(SubcommandBase):
                             frequency=self._args.frequency,
                             blocking=(not self._args.no_wait),
                             connect_mode=self._args.connect_mode,
-                            options=convert_session_options(self._args.options))
+                            options=convert_session_options(self._args.options),
+                            option_defaults=self._modified_option_defaults(),
+                            )
         if session is None:
             LOG.error("No target device available")
             return 1

--- a/pyocd/subcommands/reset_cmd.py
+++ b/pyocd/subcommands/reset_cmd.py
@@ -84,7 +84,9 @@ class ResetSubcommand(SubcommandBase):
                             connect_mode=self._args.connect_mode,
                             resume_on_disconnect=not self._args.halt,
                             reset_type=self._args.reset_type,
-                            options=convert_session_options(self._args.options))
+                            options=convert_session_options(self._args.options),
+                            option_defaults=self._modified_option_defaults(),
+                            )
         if session is None:
             LOG.error("No target device available to reset")
             sys.exit(1)

--- a/pyocd/subcommands/rtt_cmd.py
+++ b/pyocd/subcommands/rtt_cmd.py
@@ -80,7 +80,9 @@ class RTTSubcommand(SubcommandBase):
                 frequency=self._args.frequency,
                 blocking=(not self._args.no_wait),
                 connect_mode=self._args.connect_mode,
-                options=convert_session_options(self._args.options))
+                options=convert_session_options(self._args.options),
+                option_defaults=self._modified_option_defaults(),
+                )
 
             if session is None:
                 LOG.error("No target device available")


### PR DESCRIPTION
This patch changes the default value of `debug.tracebacks` to False. This will cause errors/exceptions to be logged without the full Python traceback by default. However, if debug logging is enabled (eg, `-vv` from most subcommands) then `debug.tracebacks` defaults to True.