### PR TITLE
debug: sequences: support [uU] suffix on integer literals

### DIFF
--- a/pyocd/debug/sequences/sequences.lark
+++ b/pyocd/debug/sequences/sequences.lark
@@ -108,7 +108,7 @@ fncall:                 IDENT "("  ")"
 !_compound_assign_op: "+=" | "-=" | "*=" | "/=" | "%=" | "&=" | "|=" | "^=" | "<<=" | ">>=" | "="
 
 BINDIGIT: "0".."1"
-INTLIT: "0x" HEXDIGIT+ | "0b" BINDIGIT+ | DIGIT+
+INTLIT: ( "0x" HEXDIGIT+ | "0b" BINDIGIT+ | DIGIT+ ) ( "u" | "U" )?
 
 STRLIT: ESCAPED_STRING
 

--- a/pyocd/debug/sequences/sequences.py
+++ b/pyocd/debug/sequences/sequences.py
@@ -70,7 +70,7 @@ class _ConvertLiterals(lark.visitors.Transformer):
     such as during optimization.
     """
     def INTLIT(self, tok: LarkToken) -> int: # pylint: disable=invalid-name
-        return int(tok.value, base=0)
+        return int(tok.value.upper().rstrip('U'), base=0)
 
     def STRLIT(self, tok: LarkToken) -> LarkToken:
         tok.value = tok.value.strip('"')

--- a/test/unit/test_debug_sequences.py
+++ b/test/unit/test_debug_sequences.py
@@ -289,6 +289,15 @@ class TestDebugSequenceParser:
         assert e.children[2].children[0] == LarkToken('PLUS', '+')
         assert e.children[2].children[1] == 1
 
+    @pytest.mark.parametrize("literal", [
+            "1000", "0x3e8", "0x3E8", "0b1111101000",
+            "1000u", "1000U", "0x3e8u", "0x3e8U", "0b1111101000u", "0b1111101000U",
+        ])
+    def test_unsigned_int_lit(self, literal):
+        ast = Parser().parse(f"{literal};")
+        print("ast=", ast)
+        assert ast.children[0].children[0] == 1000
+
 class TestDebugSequenceBlockExecute:
     def test_semicolons(self, block_context):
         block_context.current_scope.set("a", 0)


### PR DESCRIPTION
This isn't specified in the Open-CMSIS-Pack specification, but is of course supported by C, and is used by at least the NXP.RT685_DFP pack.