### PR TITLE
commands: show accessible-pins: fix function call, print GPIO pins

### DIFF
--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -61,6 +61,9 @@ class DebugProbe:
     - swd_sequence(): Capability.SWD_SEQUENCE
     - jtag_sequence(): Capability.JTAG_SEQUENCE
     - swo_*(): Capability.SWO
+    - get_accessible_pins(): Capability.PIN_ACCESS
+    - read_pins(): Capability.PIN_ACCESS
+    - write_pins(): Capability.PIN_ACCESS
     """
 
     class Protocol(Enum):


### PR DESCRIPTION
Fix missing pin group argument in call to probe's `.get_accessible_pins()` method.

Not really a fix, but also print GPIO pins if any are accessible.