### PR TITLE
coresight: dap: revert API change to add DebugPort param to DPConnector constructor

### DIFF
--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -202,9 +202,8 @@ class DPConnector:
     DP IDR register. The probe must be already connected for the desired wire protocol.
     """
 
-    def __init__(self, probe: DebugProbe, dp: "DebugPort") -> None:
+    def __init__(self, probe: DebugProbe) -> None:
         self._probe = probe
-        self._dp = dp
         self._idr = DPIDR(0, 0, 0, 0, 0)
 
         # Make sure we have a session, since we get the session from the probe and probes have their session set
@@ -282,7 +281,8 @@ class DPConnector:
 
     def read_idr(self) -> DPIDR:
         """@brief Read IDR register and get DP version"""
-        dpidr = self._dp.read_dp(DP_IDR, now=True)
+        dpidr = self._probe.read_dp(DP_IDR, now=True)
+        TRACE.debug("DPConnector read DP_IDR = 0x%08x", dpidr)
         dp_partno = (dpidr & DPIDR_PARTNO_MASK) >> DPIDR_PARTNO_SHIFT
         dp_version = (dpidr & DPIDR_VERSION_MASK) >> DPIDR_VERSION_SHIFT
         dp_revision = (dpidr & DPIDR_REVISION_MASK) >> DPIDR_REVISION_SHIFT
@@ -461,7 +461,7 @@ class DebugPort(DelegateHavingMixIn):
         probe_conn.connect(self._protocol)
 
         # Attempt to connect DP.
-        connector = DPConnector(self.probe, self)
+        connector = DPConnector(self.probe)
         if not self.connect_debug_port_hook():
             connector.connect()
             self.dpidr = connector.idr


### PR DESCRIPTION
In v0.35, a change was made to require `DebugPort` to be passed into `DPConnector` so that a trace log could be output when reading the DP IDR. Unfortunately, this change broke API compatibility. In addition, having to pass the `DebugPort` to `DPConnector` makes the latter less useful for certain low level cases where you might not even want a `DebugPort` class.

So, this PR reverts the offending change. `DPConnector.read_idr()` now performs its own trace log with the IDR result.

The formatting of the new log message is different, but that's a minor concern.

Fixes #1549 