### PR TITLE
do not use bare except

### DIFF
--- a/pyocd/commands/values.py
+++ b/pyocd/commands/values.py
@@ -723,7 +723,7 @@ class ClockFrequencyValue(ValueBase):
             raise exceptions.CommandError("no clock frequency provided")
         try:
             freq_Hz = convert_frequency(args[0])
-        except:
+        except Exception:
             raise exceptions.CommandError("invalid frequency")
         self.context.probe.set_clock(freq_Hz)
         if self.context.probe.wire_protocol == DebugProbe.Protocol.SWD:
@@ -837,4 +837,3 @@ class ResetTypeValue(ValueBase):
             raise exceptions.CommandError("invalid reset type")
 
         self.context.session.options['reset_type'] = new_reset_type
-

--- a/pyocd/debug/elf/decoder.py
+++ b/pyocd/debug/elf/decoder.py
@@ -202,7 +202,7 @@ class DwarfAddressDecoder(object):
                             if fromAddr == toAddr:
                                 toAddr += 1
                             self.line_tree.addi(fromAddr, toAddr, info)
-                    except:
+                    except Exception:
                         LOG.debug("Problematic lineprog:")
                         self._dump_lineprog(lineprog)
                         raise
@@ -234,5 +234,3 @@ class DwarfAddressDecoder(object):
                 high_pc = 0xffffffff
             filename = os.path.basename(prog._parent.attributes['DW_AT_name'].value.replace('\\', '/'))
             LOG.debug("%s%s%08x %08x %s", name, (' ' * (50-len(name))), low_pc, high_pc, filename)
-
-

--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -136,7 +136,7 @@ class PicoLink(object):
             'B', self._qulen.to_bytes(4, 'little'))
         try:
             self._wr_ep.write(self._queue)
-        except:
+        except Exception:
             # Anything from the USB layer assumes probe is no longer connected
             raise exceptions.ProbeDisconnected(
                 'Cannot access probe ' + self._probe_id)

--- a/test/commands_test.py
+++ b/test/commands_test.py
@@ -228,7 +228,7 @@ def commands_test(board_id):
             try:
                 print("\nTEST: %s" % cmd)
                 context.process_command_line(cmd)
-            except:
+            except Exception:
                 if print_result:
                     print("TEST FAILED")
                 failed_commands.append(cmd)
@@ -285,4 +285,3 @@ if __name__ == "__main__":
     logging.basicConfig(level=level)
     DAPAccess.set_args(args.daparg)
     commands_test(args.uid)
-

--- a/test/gdb_test_script.py
+++ b/test/gdb_test_script.py
@@ -481,7 +481,7 @@ def run_test():
             print("Test completed with %i errors" % fail_count)
         else:
             print("Test completed successfully")
-    except:
+    except Exception:
         print("Main Error:")
         traceback.print_exc()
         fail_count += 1
@@ -528,7 +528,7 @@ def run_generator(event):
     stop_delay = 0
     try:
         stop_delay = generator.send(event)
-    except:
+    except Exception:
         print("Error")
         traceback.print_exc()
     interrupt_arg = {"aborted": False}

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -196,7 +196,7 @@ class RecordingLogHandler(logging.Handler):
         try:
             message = self.format(record)
             self.stream.write(six.u(message + "\n"))
-        except:
+        except Exception:
             self.handleError(record)
 
 class TestResult(object):
@@ -308,4 +308,3 @@ class Test(object):
         if len(result_list) <= 0:
             passed = False
         return passed
-

--- a/test/user_script_test.py
+++ b/test/user_script_test.py
@@ -98,7 +98,7 @@ def user_script_test(board_id):
             try:
                 print("\nTEST: %s" % cmd)
                 context.process_command_line(cmd)
-            except:
+            except Exception:
                 print("TEST FAILED")
                 traceback.print_exc(file=sys.stdout)
                 return False
@@ -140,4 +140,3 @@ if __name__ == "__main__":
     session = ConnectHelper.session_with_chosen_probe(**get_session_options())
     test = UserScriptTest()
     result = [test.run(session.board)]
-


### PR DESCRIPTION
replace all uses of bare excepts with "except Exception" to avoid catching exceptions like KeyboardInterrupt and SystemExit.