### PR TITLE
commands: reset: fall back to reset via probe if context has no selected core

### DIFF
--- a/pyocd/commands/commands.py
+++ b/pyocd/commands/commands.py
@@ -391,8 +391,12 @@ class ResetCommand(CommandBase):
             else:
                 self.context.write("Successfully halted device on reset")
         else:
-            self.context.write("Resetting target")
-            self.context.selected_core.reset(self.reset_type)
+            if self.context.selected_core is None:
+                self.context.write("Resetting via probe")
+                self.context.probe.reset()
+            else:
+                self.context.write("Resetting target")
+                self.context.selected_core.reset(self.reset_type)
 
 class DisassembleCommand(CommandBase):
     INFO = {


### PR DESCRIPTION
This is useful if using pyocd commander in `--no-init` mode for low level connection debugging.