### PR TITLE
core: session: load the user script after the board is constructed

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -207,15 +207,16 @@ class Session(Notifier):
         self._configure_logging()
 
         # Bail early if we weren't provided a probe.
+        # TODO Should the user script still be loaded?
         if probe is None:
             self._board = None
             return
 
-        # Load the user script.
-        self._load_user_script()
-
         # Ask the probe if it has an associated board, and if not then we create a generic one.
         self._board = probe.create_associated_board() or Board(self)
+
+        # Load the user script.
+        self._load_user_script()
 
     def _get_config(self) -> Dict[str, Any]:
         # Load config file if one was provided via options, and no_config option was not set.


### PR DESCRIPTION
It's not clear why, originally, the user script was loaded before the board is created. In any case, the namespace update on .open() is retained. Even though all the objects added to the namespace are available now when the user script is loaded, they aren't really usable since nothing is opened/connected/inited.