### PR TITLE
target: family: psoc6: remove unnecessary sleep during reset.

### DIFF
--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -86,7 +86,6 @@ class CortexM_PSoC6(CortexM):
     def reset_and_halt(self, reset_type=None):
         self.halt()
         self.reset(reset_type)
-        sleep(0.5)
         self.halt()
         self.wait_halted()
 


### PR DESCRIPTION
self.reset() have a 0.5 second sleep when using hw reset and other reset types should not require any additional sleep.
by removing this sleep it is possible to aquire targets where the application disable the swd port.