### PR TITLE
debug: sequences:  assignment expressions

### DIFF
--- a/pyocd/debug/sequences/sequences.lark
+++ b/pyocd/debug/sequences/sequences.lark
@@ -1,6 +1,6 @@
 // Lark grammar for debug sequence expressions
 //
-// Copyright (c) 2020-2021 Chris Reed
+// Copyright (c) 2020-2023 Chris Reed
 // SPDX-License-Identifier: Apache-2.0
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,25 +29,26 @@
 // 11. &&
 // 12. ||
 // 13. ?:
+// 14. assignments: = += -= *= /= %= &= |= ^= <<= >>=
 
 start:                  statement*
 
 ?statement:             decl_stmt ";"?
-    |                   assign_stmt ";"?
     |                   expr_stmt ";"?
 
 // Allow __var declarations with no initialiser expression even though this is disallowed
 // by the specification, for greater compatibility.
 decl_stmt:              "__var" IDENT ["=" expr]
 
-assign_stmt:            IDENT _compound_assign_op expr
-
 // This creates a tree node for expression statements that is easy to identify.
 expr_stmt:              expr
 
 ?expr:                  logical_or_expr
     |                   ternary_expr
+    |                   assign_expr
     |                   STRLIT
+
+assign_expr:            IDENT _compound_assign_op expr
 
 ternary_expr:           expr "?" expr ":" expr
 

--- a/pyocd/debug/sequences/sequences.py
+++ b/pyocd/debug/sequences/sequences.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -670,7 +670,7 @@ class SemanticChecker:
                 raise DebugSequenceSemanticError(
                         f"line {tree.meta.line}: cannot store a string to variable '{name}'")
 
-        def assign_stmt(self, tree: LarkTree) -> None:
+        def assign_expr(self, tree: LarkTree) -> None:
             # Assigned variable must have been previously declared.
             # TODO disabled until declarations are fully tracked in scopes.
             assert _is_token(tree.children[0], 'IDENT')
@@ -827,7 +827,7 @@ class Interpreter:
 
             self._scope.set(name, value)
 
-        def assign_stmt(self, tree: LarkTree) -> None:
+        def assign_expr(self, tree: LarkTree) -> int:
             values = self.visit_children(tree)
 
             name = values[0].value
@@ -843,6 +843,9 @@ class Interpreter:
                 value = _BINARY_OPS[op](left, value)
 
             self._scope.set(name, value)
+
+            # Return the variable's value as the assignment expression's value.
+            return value
 
         def expr_stmt(self, tree: LarkTree) -> int:
             values = self.visit_children(tree)


### PR DESCRIPTION
Support C-style assignment expressions, such that variables can be assigned to in the middle of other expressions. Just as in C, the value of an assignment expression is the value assigned to the variable. While this syntax isn't documented in the Open-CMSIS-Pack specification, it is used in the Keil.LPC800_DFP pack and therefore is implicitly supported by debug sequences.

The patch replaces the assign_stmt AST node with assign_expr, with the lowest precedence (same precedence as in C).

Fixes #1563 