### PR TITLE
Fix/1553 rtt cb not found

### DIFF
--- a/pyocd/debug/rtt.py
+++ b/pyocd/debug/rtt.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2021 Simon D. Levy <simon.d.levy@gmail.com>
 # Copyright (C) 2022 Johan Carlsson <johan.carlsson@teenage.engineering>
 # Copyright (c) 2022 Samuel Dewan
+# Copyright (C) 2023 Tejaswini Dasika <tejaswinidasika@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -387,7 +388,7 @@ class GenericRTTControlBlock(RTTControlBlock):
 
     target: SoCTarget
     _cb_search_address: int
-    _cb_search_size_words: int
+    _cb_search_size_bytes: int
     _control_block_id: Sequence[int]
 
     def __init__(self, target: SoCTarget, address: int = None,
@@ -418,14 +419,14 @@ class GenericRTTControlBlock(RTTControlBlock):
         if size is None:
             # Address was specified, but size was not. Assume that the control
             # block is located exactly at the provided address.
-            self._cb_search_size_words = 0
+            self._cb_search_size_bytes = 0
         else:
-            self._cb_search_size_words = size // 4
+            self._cb_search_size_bytes = size
         self._control_block_id = control_block_id
 
     def _find_control_block(self) -> Optional[int]:
         addr: int = self._cb_search_address & ~0x3
-        search_size: int  = self._cb_search_size_words
+        search_size: int  = self._cb_search_size_bytes
         if search_size < len(self._control_block_id):
             search_size = len(self._control_block_id)
 
@@ -433,7 +434,7 @@ class GenericRTTControlBlock(RTTControlBlock):
         offset: int = 0
 
         while search_size:
-            read_size = min(search_size, 8)
+            read_size = min(search_size, 32)
             data = self.target.read_memory_block8(addr, read_size)
 
             if not data:


### PR DESCRIPTION
pyocd is always searching for control_block_id with 16 bytes length (when the block id is less than 16 bytes, it is padding with ‘\0’)
So, when ‘SEGGER RTT’ is the block id to be found, it is searching for 4 words (16 bytes) with zero padding instead of 10 bytes(’SEGGER RTT’),  where some junk characters may be present and resulting in failure ‘Control block not found'

Fixing it by searching for only the length of the control block ID provided while setting up rtt