### PR TITLE
probe: cmsis-dap: use test binary from builtin board data for v2.1 based board info

### DIFF
--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -238,7 +238,11 @@ class CMSISDAPProbe(DebugProbe):
                         assert target_device_name
                         board = "Generic " + (part_number or target_device_name)
 
-                    info = BoardInfo(name=board, target=target_device_name, vendor=vendor)
+                    # If we also have the ID based info, then use the test binary from that.
+                    binary_name = info.binary if (info is not None) else None
+
+                    # Create a new board info object with the data from the probe.
+                    info = BoardInfo(name=board, target=target_device_name, vendor=vendor, binary=binary_name)
 
         return info
 


### PR DESCRIPTION
If a CMSIS-DAP probe supports the v2.1 board and target info, but the board also has builtin board ID based data, then use the test binary name from the builtin data with the probe-supplied data.

This only affects the functional tests.