### PR TITLE
target: family: remove part number match for NXP MIMXRTxxxx series family

### DIFF
--- a/pyocd/target/family/__init__.py
+++ b/pyocd/target/family/__init__.py
@@ -39,7 +39,6 @@ class FamilyInfo(NamedTuple):
 # present), or the 'Dname' or 'Dvariant' part numbers. The comparisons are performed in order from
 # specific to general, starting with the part number.
 FAMILIES = [
-    FamilyInfo("NXP",                   re.compile(r'MIMXRT[0-9]{4}.*'),    target_imxrt.IMXRT              ),
     FamilyInfo("NXP",                   re.compile(r'MK[LEVWS]?.*'),        target_kinetis.Kinetis          ),
     FamilyInfo("Nordic Semiconductor",  re.compile(r'nRF52[0-9]+.*'),       target_nRF52.NRF52              ),
     FamilyInfo("Nordic Semiconductor",  re.compile(r'nRF91[0-9]+.*'),       target_nRF91.NRF91              ),


### PR DESCRIPTION
The IMXRT family class isn't needed for pack-based targets any more now that pyOCD supports the debug sequences present in the IMXRT packs.