### PR TITLE
coresight: cortex-m: CPU type detection improvements

### DIFF
--- a/pyocd/coresight/core_ids.py
+++ b/pyocd/coresight/core_ids.py
@@ -73,6 +73,8 @@ class CortexMExtension(Enum):
     DSP = "DSP" # Digital Signal Processing instructions
     FPU_DP = "FPU_DP" # Double-Precision floating point
     FPU_HP = "FPU_HP" # Half-Precision floating point
+    FPU_V4 = "FPUv4" # FPv4, only present in Cortex-M4F
+    FPU_V5 = "FPUv5" # FPv5 single or double precision
     SEC = "SEC" # Security Extension
     SEC_V81 = "SEC_V81" # v8.1-M additions to the Security Extension
     MVE = "MVE" # M-profile Vector Extension, with integer support
@@ -80,10 +82,5 @@ class CortexMExtension(Enum):
     UDE = "UDE" # Unprivileged Debug Extension
     RAS = "RAS" # Reliability, Serviceability, and Availability
     PMU = "PMU" # Performance Monitoring Unit
-    LOB = "LOB" # Low-Overhead loops and Branch Future
-    PXN = "PXN" # Privileged eXecute-Never
-    MAIN = "MAIN" # Main Extension
     MPU = "MPU" # Memory Protection Unit
-    DIT = "DIT" # Data-Independent Timing
-    FPCXT = "FPCXT" # Floating Point Context
     PACBTI = "PACBTI" # Pointer Authentication and Branch Target Identification

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -17,7 +17,7 @@
 
 import logging
 from time import sleep
-from typing import (Any, Callable, List, Optional, Set, overload, Sequence, TYPE_CHECKING, Union, cast)
+from typing import (Any, Callable, List, Optional, Set, Tuple, overload, Sequence, TYPE_CHECKING, Union, cast)
 from typing_extensions import Literal
 
 from ..core.target import Target
@@ -186,6 +186,17 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
     MVFR2_VFP_MISC_SHIFT = 4
     MVFR2_VFP_MISC_SUPPORTED = 4
 
+    # Instruction Set Attribute Register 3
+    ISAR3 = 0xE000ED6C
+    ISAR3_SIMD_MASK = 0x000000f0
+    ISAR3_SIMD_SHIFT = 4
+    ISAR3_SIMD__DSP = 0x3 # SIMD instructions from DSP extension are present
+
+    # MPU Type register
+    MPU_TYPE = 0xE000ED90
+    MPU_TYPE_DREGIONS_MASK = 0x0000ff00
+    MPU_TYPE_DREGIONS_SHIFT = 8
+
     _RESET_RECOVERY_SLEEP_INTERVAL = 0.01 # 10 ms
 
     @classmethod
@@ -220,6 +231,7 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         CoreSightCoreComponent.__init__(self, ap, cmpid, address)
 
         self._architecture: CoreArchitecture = CoreArchitecture.ARMv6M
+        self._arch_version: Tuple[int, int] = (0, 0)
         self._extensions: List[CortexMExtension] = []
         self.core_type = 0
         self.has_fpu: bool = False
@@ -279,6 +291,11 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
     def architecture(self) -> CoreArchitecture:
         """@brief @ref pyocd.coresight.core_ids.CoreArchitecture "CoreArchitecture" for this core."""
         return self._architecture
+
+    @property
+    def architecture_version(self) -> Tuple[int, int]:
+        """@brief Architecture major and minor version numbers."""
+        return self._arch_version
 
     @property
     def extensions(self) -> List[CortexMExtension]:
@@ -369,6 +386,7 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         self._check_for_fpu()
         self._init_reset_types()
         self._build_registers()
+        self._log_core_description()
         self.get_vector_catch() # Cache the current vector cache settings.
         self.sw_bp.init()
 
@@ -432,23 +450,39 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
     def _read_core_type(self) -> None:
         """@brief Read the CPUID register and determine core type and architecture."""
         # Read CPUID register
-        cpuid = self.read32(CortexM.CPUID)
+        cpuid_cb = self.read32(CortexM.CPUID, now=False)
+        isar3_cb = self.read32(CortexM.ISAR3, now=False)
+        mpu_type_cb = self.read32(CortexM.MPU_TYPE, now=False)
 
+        # Check CPUID
+        cpuid = cpuid_cb()
         implementer = (cpuid & CortexM.CPUID_IMPLEMENTER_MASK) >> CortexM.CPUID_IMPLEMENTER_POS
         arch = (cpuid & CortexM.CPUID_ARCHITECTURE_MASK) >> CortexM.CPUID_ARCHITECTURE_POS
         self.core_type = (cpuid & CortexM.CPUID_PARTNO_MASK) >> CortexM.CPUID_PARTNO_POS
         self.cpu_revision = (cpuid & CortexM.CPUID_VARIANT_MASK) >> CortexM.CPUID_VARIANT_POS
         self.cpu_patch = (cpuid & CortexM.CPUID_REVISION_MASK) >> CortexM.CPUID_REVISION_POS
 
+        # Check for DSP extension
+        isar3 = isar3_cb()
+        isar3_simd = (isar3 & self.ISAR3_SIMD_MASK) >> self.ISAR3_SIMD_SHIFT
+        if isar3_simd == self.ISAR3_SIMD__DSP:
+            self._extensions.append(CortexMExtension.DSP)
+
+        # Check for MPU extension
+        mpu_type = mpu_type_cb()
+        mpu_type_dregions = (mpu_type & self.MPU_TYPE_DREGIONS_MASK) >> self.MPU_TYPE_DREGIONS_SHIFT
+        if mpu_type_dregions > 0:
+            self._extensions.append(CortexMExtension.MPU)
+
         # Set the arch version.
         if arch == CortexM.ARMv7M:
             self._architecture = CoreArchitecture.ARMv7M
+            self._arch_version = (7, 0)
         else:
             self._architecture = CoreArchitecture.ARMv6M
+            self._arch_version = (6, 0)
 
         self._core_name = CORE_TYPE_NAME.get((implementer, self.core_type), f"Unknown (CPUID={cpuid:#010x})")
-
-        LOG.info("CPU core #%d is %s r%dp%d", self.core_number, self._core_name, self.cpu_revision, self.cpu_patch)
 
     def _check_for_fpu(self) -> None:
         """@brief Determine if a core has an FPU.
@@ -467,7 +501,10 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         # write to CPACR and checking the result. This test has the unfortunate property of not
         # working on certain cores when the core is held in reset, because CPACR is not accessible
         # under reset on all cores. Thus we use MVFR0.
-        mvfr0 = self.read32(CortexM.MVFR0)
+        mvfr0_cb = self.read32(CortexM.MVFR0, now=False)
+        mvfr2_cb = self.read32(CortexM.MVFR2, now=False)
+
+        mvfr0 = mvfr0_cb()
         sp_val = (mvfr0 & CortexM.MVFR0_SINGLE_PRECISION_MASK) >> CortexM.MVFR0_SINGLE_PRECISION_SHIFT
         dp_val = (mvfr0 & CortexM.MVFR0_DOUBLE_PRECISION_MASK) >> CortexM.MVFR0_DOUBLE_PRECISION_SHIFT
         self.has_fpu = ((sp_val == self.MVFR0_SINGLE_PRECISION_SUPPORTED) or
@@ -479,20 +516,40 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
             # Now check the VFP version by looking for support for the misc FP instructions added in
             # FPv5 (VMINNM, VMAXNM, etc).
 
-            mvfr2 = self.read32(CortexM.MVFR2)
+            mvfr2 = mvfr2_cb()
             vfp_misc_val = (mvfr2 & CortexM.MVFR2_VFP_MISC_MASK) >> CortexM.MVFR2_VFP_MISC_SHIFT
 
             if dp_val == self.MVFR0_DOUBLE_PRECISION_SUPPORTED:
                 # FPv5 with double-precision
-                fpu_type = "FPv5-D16-M"
                 self._extensions.append(CortexMExtension.FPU_DP)
+                self._extensions.append(CortexMExtension.FPU_V5)
             elif vfp_misc_val == self.MVFR2_VFP_MISC_SUPPORTED:
                 # FPv5 with only single-precision
-                fpu_type = "FPv5-SP-D16-M"
+                self._extensions.append(CortexMExtension.FPU_V5)
+            else:
+                # FPv4 has only single-precision, only present on the CM4F.
+                self._extensions.append(CortexMExtension.FPU_V4)
+
+    def _log_core_description(self) -> None:
+        core_desc = f"CPU core #{self.core_number}: {self._core_name} r{self.cpu_revision}p{self.cpu_patch}, v{self.architecture_version[0]}.{self.architecture_version[1]}-M architecture"
+        LOG.info(core_desc)
+
+        if self._extensions:
+            exts_desc = f"  Extensions: [{', '.join(sorted(x.name for x in self._extensions))}]"
+            LOG.info(exts_desc)
+
+        if self.has_fpu:
+            if CortexMExtension.FPU_V5 in self._extensions:
+                if CortexMExtension.FPU_DP in self._extensions:
+                    # FPv5 with double-precision
+                    fpu_type = "FPv5-D16-M"
+                else:
+                    # FPv5 with only single-precision
+                    fpu_type = "FPv5-SP-D16-M"
             else:
                 # FPv4 has only single-precision, only present on the CM4F.
                 fpu_type = "FPv4-SP-D16-M"
-            LOG.info("FPU present: " + fpu_type)
+            LOG.info("  FPU present: " + fpu_type)
 
     def _init_reset_types(self) -> None:
         """@brief Adjust supported reset types based on the architecture."""


### PR DESCRIPTION
- Use a common method to log the CPU description. It logs the arch version, extensions, and FPU type. This changes the logging of FPU type so it comes after CPU type.
- Add `.architecture_version` property returning a tuple of major/minor version.
- Use deferred reads when reading CPU ID registers.
- Detect DSP, PMU, MPU, PACBTI, FP16, RAS, UDE extensions.
- Add extensions for FPU v4/5.
- Remove a few extension enums that are less important for a debugger, most of which can be determined by arch version.