### PR TITLE
cleanup: annotations future

### DIFF
--- a/pyocd/core/soc_target.py
+++ b/pyocd/core/soc_target.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
 
 import logging
 from typing import (Callable, Dict, List, Optional, overload, Sequence, Union, TYPE_CHECKING)
@@ -59,7 +61,7 @@ class SoCTarget(TargetGraphNode):
 
     VENDOR = "Generic"
 
-    def __init__(self, session: "Session", memory_map: Optional["MemoryMap"] = None) -> None:
+    def __init__(self, session: Session, memory_map: Optional[MemoryMap] = None) -> None:
         super().__init__(session, memory_map)
         self.vendor: str = self.VENDOR
         self.part_families: List[str] = getattr(self, 'PART_FAMILIES', [])
@@ -133,7 +135,7 @@ class SoCTarget(TargetGraphNode):
         return self.selected_core_or_raise.supported_security_states
 
     @property
-    def core_registers(self) -> "CoreRegistersIndex":
+    def core_registers(self) -> CoreRegistersIndex:
         return self.selected_core_or_raise.core_registers
 
     def add_core(self, core: CoreTarget) -> None:
@@ -241,25 +243,25 @@ class SoCTarget(TargetGraphNode):
     def read_memory_block32(self, addr: int, size: int) -> Sequence[int]:
         return self.selected_core_or_raise.read_memory_block32(addr, size)
 
-    def read_core_register(self, id: "CoreRegisterNameOrNumberType") -> "CoreRegisterValueType":
+    def read_core_register(self, id: CoreRegisterNameOrNumberType) -> CoreRegisterValueType:
         return self.selected_core_or_raise.read_core_register(id)
 
-    def write_core_register(self, id: "CoreRegisterNameOrNumberType", data: "CoreRegisterValueType") -> None:
+    def write_core_register(self, id: CoreRegisterNameOrNumberType, data: CoreRegisterValueType) -> None:
         return self.selected_core_or_raise.write_core_register(id, data)
 
-    def read_core_register_raw(self, reg: "CoreRegisterNameOrNumberType") -> int:
+    def read_core_register_raw(self, reg: CoreRegisterNameOrNumberType) -> int:
         return self.selected_core_or_raise.read_core_register_raw(reg)
 
-    def read_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"]) -> List[int]:
+    def read_core_registers_raw(self, reg_list: Sequence[CoreRegisterNameOrNumberType]) -> List[int]:
         return self.selected_core_or_raise.read_core_registers_raw(reg_list)
 
-    def write_core_register_raw(self, reg: "CoreRegisterNameOrNumberType", data: int) -> None:
+    def write_core_register_raw(self, reg: CoreRegisterNameOrNumberType, data: int) -> None:
         self.selected_core_or_raise.write_core_register_raw(reg, data)
 
-    def write_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"], data_list: Sequence[int]) -> None:
+    def write_core_registers_raw(self, reg_list: Sequence[CoreRegisterNameOrNumberType], data_list: Sequence[int]) -> None:
         self.selected_core_or_raise.write_core_registers_raw(reg_list, data_list)
 
-    def find_breakpoint(self, addr: int) -> Optional["Breakpoint"]:
+    def find_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         return self.selected_core_or_raise.find_breakpoint(addr)
 
     def set_breakpoint(self, addr: int, type: Target.BreakpointType = Target.BreakpointType.AUTO) -> bool:
@@ -305,7 +307,7 @@ class SoCTarget(TargetGraphNode):
     def get_vector_catch(self) -> int:
         return self.selected_core_or_raise.get_vector_catch()
 
-    def get_target_context(self, core: Optional[int] = None) -> "DebugContext":
+    def get_target_context(self, core: Optional[int] = None) -> DebugContext:
         if core is not None:
             core_obj = self.cores[core]
         else:
@@ -318,7 +320,7 @@ class SoCTarget(TargetGraphNode):
     def trace_stop(self):
         self.call_delegate('trace_stop', target=self, mode=0)
 
-    def add_target_command_groups(self, command_set: "CommandSet"):
+    def add_target_command_groups(self, command_set: CommandSet):
         """@brief Hook for adding target-specific commands to a command set."""
         self.call_delegate('add_target_command_groups', target=self, command_set=command_set)
 

--- a/pyocd/core/target.py
+++ b/pyocd/core/target.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2006-2019 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,8 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
-from typing import (Any, Callable, List, Optional, Sequence, TYPE_CHECKING, Set)
+from typing import (Callable, List, Optional, Sequence, TYPE_CHECKING, Set)
 
 from .memory_interface import MemoryInterface
 from .memory_map import MemoryMap
@@ -187,7 +189,7 @@ class Target(MemoryInterface, DelegateHavingMixIn):
         ## PMU event. v8.1-M only.
         PMU = 7
 
-    def __init__(self, session: "Session", memory_map: Optional[MemoryMap] = None) -> None:
+    def __init__(self, session: Session, memory_map: Optional[MemoryMap] = None) -> None:
         self._session = session
         # Make a target-specific copy of the memory map. This is safe to do without locking
         # because the memory map may not be mutated until target initialization.
@@ -196,11 +198,11 @@ class Target(MemoryInterface, DelegateHavingMixIn):
         self._svd_device: Optional[SVDDevice] = None
 
     @property
-    def session(self) -> "Session":
+    def session(self) -> Session:
         return self._session
 
     @property
-    def svd_device(self) -> Optional["SVDDevice"]:
+    def svd_device(self) -> Optional[SVDDevice]:
         return self._svd_device
 
     @property
@@ -208,7 +210,7 @@ class Target(MemoryInterface, DelegateHavingMixIn):
         raise NotImplementedError()
 
     @property
-    def core_registers(self) -> "CoreRegistersIndex":
+    def core_registers(self) -> CoreRegistersIndex:
         raise NotImplementedError()
 
     @property
@@ -219,7 +221,7 @@ class Target(MemoryInterface, DelegateHavingMixIn):
     def is_locked(self) -> bool:
         return False
 
-    def create_init_sequence(self) -> "CallSequence":
+    def create_init_sequence(self) -> CallSequence:
         raise NotImplementedError()
 
     def init(self) -> None:
@@ -245,25 +247,25 @@ class Target(MemoryInterface, DelegateHavingMixIn):
     def mass_erase(self) -> None:
         raise NotImplementedError()
 
-    def read_core_register(self, id: "CoreRegisterNameOrNumberType") -> "CoreRegisterValueType":
+    def read_core_register(self, id: CoreRegisterNameOrNumberType) -> CoreRegisterValueType:
         raise NotImplementedError()
 
-    def write_core_register(self, id: "CoreRegisterNameOrNumberType", data: "CoreRegisterValueType") -> None:
+    def write_core_register(self, id: CoreRegisterNameOrNumberType, data: CoreRegisterValueType) -> None:
         raise NotImplementedError()
 
-    def read_core_register_raw(self, reg: "CoreRegisterNameOrNumberType") -> int:
+    def read_core_register_raw(self, reg: CoreRegisterNameOrNumberType) -> int:
         raise NotImplementedError()
 
-    def read_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"]) -> List[int]:
+    def read_core_registers_raw(self, reg_list: Sequence[CoreRegisterNameOrNumberType]) -> List[int]:
         raise NotImplementedError()
 
-    def write_core_register_raw(self, reg: "CoreRegisterNameOrNumberType", data: int) -> None:
+    def write_core_register_raw(self, reg: CoreRegisterNameOrNumberType, data: int) -> None:
         raise NotImplementedError()
 
-    def write_core_registers_raw(self, reg_list: Sequence["CoreRegisterNameOrNumberType"], data_list: Sequence[int]) -> None:
+    def write_core_registers_raw(self, reg_list: Sequence[CoreRegisterNameOrNumberType], data_list: Sequence[int]) -> None:
         raise NotImplementedError()
 
-    def find_breakpoint(self, addr: int) -> Optional["Breakpoint"]:
+    def find_breakpoint(self, addr: int) -> Optional[Breakpoint]:
         raise NotImplementedError()
 
     def set_breakpoint(self, addr: int, type: BreakpointType = BreakpointType.AUTO) -> bool:
@@ -315,12 +317,12 @@ class Target(MemoryInterface, DelegateHavingMixIn):
     def get_vector_catch(self) -> int:
         raise NotImplementedError()
 
-    def get_target_context(self, core: Optional[int] = None) -> "DebugContext":
+    def get_target_context(self, core: Optional[int] = None) -> DebugContext:
         raise NotImplementedError()
 
 class TargetGraphNode(Target, GraphNode):
     """@brief Abstract class for a target that is a graph node."""
 
-    def __init__(self, session: "Session", memory_map: Optional[MemoryMap] = None) -> None:
+    def __init__(self, session: Session, memory_map: Optional[MemoryMap] = None) -> None:
         Target.__init__(self, session, memory_map)
         GraphNode.__init__(self)

--- a/pyocd/coresight/dap.py
+++ b/pyocd/coresight/dap.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2015-2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # Copyright (c) 2022 Clay McClure
 # Copyright (c) 2022 Toshiba Electronic Devices & Storage Corporation
 # SPDX-License-Identifier: Apache-2.0
@@ -16,6 +16,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
 
 import logging
 from enum import Enum
@@ -310,9 +312,9 @@ class DebugPort(DelegateHavingMixIn):
         self.target = target
         assert target.session
         self._session = target.session
-        self.valid_aps: Optional[List["APAddressBase"]] = None
+        self.valid_aps: Optional[List[APAddressBase]] = None
         self.dpidr = DPIDR(0, 0, 0, 0, 0)
-        self.aps: Dict["APAddressBase", "AccessPort"] = {}
+        self.aps: Dict[APAddressBase, AccessPort] = {}
         self._access_number: int = 0
         self._cached_dp_select: Optional[int] = None
         self._protocol: Optional[DebugProbe.Protocol] = None
@@ -340,7 +342,7 @@ class DebugPort(DelegateHavingMixIn):
         return self._probe
 
     @property
-    def session(self) -> "Session":
+    def session(self) -> Session:
         return self._session
 
     @property
@@ -353,7 +355,7 @@ class DebugPort(DelegateHavingMixIn):
         return self._base_addr
 
     @property
-    def apacc_memory_interface(self) -> "APAccessMemoryInterface":
+    def apacc_memory_interface(self) -> APAccessMemoryInterface:
         """@brief Memory interface for performing APACC transactions."""
         if self._apacc_mem_interface is None:
             self._apacc_mem_interface = APAccessMemoryInterface(self)
@@ -602,7 +604,7 @@ class DebugPort(DelegateHavingMixIn):
         """@brief Invalidate cached DP registers."""
         self._cached_dp_select = None
 
-    def _reset_did_occur(self, notification: "Notification") -> None:
+    def _reset_did_occur(self, notification: Notification) -> None:
         """@brief Handles reset notifications to invalidate register cache.
 
         The cache is cleared on all resets just to be safe. On most devices, warm resets do not reset
@@ -1040,7 +1042,7 @@ class APAccessMemoryInterface(memory_interface.MemoryInterface):
     Only 32-bit transfers are supported.
     """
 
-    def __init__(self, dp: DebugPort, ap_address: Optional["APAddressBase"] = None) -> None:
+    def __init__(self, dp: DebugPort, ap_address: Optional[APAddressBase] = None) -> None:
         """@brief Constructor.
 
         @param self

--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
 
 from time import sleep
 import logging
@@ -55,7 +57,7 @@ class _TemporaryOpen:
         self._suppress_exceptions = suppress_exceptions
         self._did_open_link: bool = False
 
-    def __enter__(self) -> "_TemporaryOpen":
+    def __enter__(self) -> _TemporaryOpen:
         try:
             # Temporarily open the device if not already opened.
             if not self._device.is_open:
@@ -69,7 +71,7 @@ class _TemporaryOpen:
 
         return self
 
-    def __exit__(self, exc_type: Optional[type], exc_value: Optional[Exception], traceback: Optional["TracebackType"]) -> bool:
+    def __exit__(self, exc_type: Optional[type], exc_value: Optional[Exception], traceback: Optional[TracebackType]) -> bool:
         # Close the device if we had to open it.
         if self._did_open_link:
             self._device.close()
@@ -134,14 +136,14 @@ class CMSISDAPProbe(DebugProbe):
                 cls,
                 unique_id: Optional[str] = None,
                 is_explicit: bool = False
-            ) -> Sequence["DebugProbe"]:
+            ) -> Sequence[DebugProbe]:
         try:
             return [cls(dev) for dev in DAPAccess.get_connected_devices()]
         except DAPAccess.Error as exc:
             raise cls._convert_exception(exc) from exc
 
     @classmethod
-    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional["DebugProbe"]:
+    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional[DebugProbe]:
         try:
             dap_access = DAPAccess.get_device(unique_id)
             if dap_access is not None:
@@ -208,7 +210,7 @@ class CMSISDAPProbe(DebugProbe):
         return self._caps
 
     @property
-    def associated_board_info(self) -> Optional["BoardInfo"]:
+    def associated_board_info(self) -> Optional[BoardInfo]:
         """@brief Info about the board associated with this probe, if known."""
         # Get internal board info if available.
         if (self.board_id is not None) and (self.board_id in BOARD_ID_TO_INFO):
@@ -242,7 +244,7 @@ class CMSISDAPProbe(DebugProbe):
 
         return info
 
-    def create_associated_board(self) -> Optional["Board"]:
+    def create_associated_board(self) -> Optional[Board]:
         assert self.session is not None
 
         board_info = self.associated_board_info
@@ -659,7 +661,7 @@ class CMSISDAPProbe(DebugProbe):
 
         if now:
             TRACE.debug("trace: read_ap_multi(addr=%#010x, count=%i) -> [%s]", addr, count,
-                    ", ".join(["%#010x" % v for v in result]))
+                    ", ".join(["%#010x" % v for v in result])) # type: ignore # result is always iterable if now is True
             return result
         else:
             return read_ap_repeat_callback

--- a/pyocd/probe/debug_probe.py
+++ b/pyocd/probe/debug_probe.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
 
 from enum import (Enum, IntFlag)
 import threading
@@ -141,7 +143,7 @@ class DebugProbe:
                 cls,
                 unique_id: Optional[str] = None,
                 is_explicit: bool = False
-            ) -> Sequence["DebugProbe"]:
+            ) -> Sequence[DebugProbe]:
         """@brief Returns a list of DebugProbe instances.
 
         To filter the list of returned probes, the `unique_id` parameter may be set to a string with a full or
@@ -160,7 +162,7 @@ class DebugProbe:
         raise NotImplementedError()
 
     @classmethod
-    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional["DebugProbe"]:
+    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional[DebugProbe]:
         """@brief Returns a DebugProbe instance for a probe with the given unique ID.
 
         If no probe is connected with a fully matching unique ID, then None will be returned.
@@ -174,16 +176,16 @@ class DebugProbe:
 
     def __init__(self) -> None:
         """@brief Constructor."""
-        self._session: Optional["Session"] = None
+        self._session: Optional[Session] = None
         self._lock = threading.RLock()
 
     @property
-    def session(self) -> Optional["Session"]:
+    def session(self) -> Optional[Session]:
         """@brief Session associated with this probe."""
         return self._session
 
     @session.setter
-    def session(self, the_session: "Session") -> None:
+    def session(self, the_session: Session) -> None:
         self._session = the_session
 
     @property
@@ -245,11 +247,11 @@ class DebugProbe:
         raise NotImplementedError()
 
     @property
-    def associated_board_info(self) -> Optional["BoardInfo"]:
+    def associated_board_info(self) -> Optional[BoardInfo]:
         """@brief Info about the board associated with this probe, if known."""
         return None
 
-    def create_associated_board(self) -> Optional["Board"]:
+    def create_associated_board(self) -> Optional[Board]:
         """@brief Create a board instance representing the board of which the probe is a component.
 
         If the probe is part of a board, then this method will create a Board instance that
@@ -503,7 +505,7 @@ class DebugProbe:
         """@brief Write one AP register multiple times."""
         raise NotImplementedError()
 
-    def get_memory_interface_for_ap(self, ap_address: "APAddressBase") -> Optional["MemoryInterface"]:
+    def get_memory_interface_for_ap(self, ap_address: APAddressBase) -> Optional[MemoryInterface]:
         """@brief Returns a @ref pyocd.core.memory_interface.MemoryInterface "MemoryInterface" for
             the specified AP.
 

--- a/pyocd/probe/stlink_probe.py
+++ b/pyocd/probe/stlink_probe.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2018-2020,2022 Arm Limited
-# Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import annotations
 
 from time import sleep
 from typing import (Any, Callable, Dict, List, Optional, Sequence, Union, TYPE_CHECKING)
@@ -44,11 +46,11 @@ class StlinkProbe(DebugProbe):
 
     @classmethod
     def get_all_connected_probes(cls, unique_id: Optional[str] = None,
-            is_explicit: bool = False) -> List["StlinkProbe"]:
+            is_explicit: bool = False) -> List[StlinkProbe]:
         return [cls(dev) for dev in STLinkUSBInterface.get_all_connected_devices()]
 
     @classmethod
-    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional["StlinkProbe"]:
+    def get_probe_with_id(cls, unique_id: str, is_explicit: bool = False) -> Optional[StlinkProbe]:
         for dev in STLinkUSBInterface.get_all_connected_devices():
             if dev.serial_number == unique_id:
                 return cls(dev)
@@ -65,7 +67,7 @@ class StlinkProbe(DebugProbe):
         self._caps = set()
 
     @property
-    def board_id(self) -> str:
+    def board_id(self) -> Optional[str]:
         """@brief Lazily loaded 4-character board ID."""
         if self._board_id is None:
             self._board_id = self._get_board_id()
@@ -136,7 +138,7 @@ class StlinkProbe(DebugProbe):
         return self._caps
 
     @property
-    def associated_board_info(self) -> Optional["BoardInfo"]:
+    def associated_board_info(self) -> Optional[BoardInfo]:
         if (self.board_id is not None) and (self.board_id in BOARD_ID_TO_INFO):
             return BOARD_ID_TO_INFO[self.board_id]
         else:


### PR DESCRIPTION
This patch migrates a few key modules to use the annotations future so forward type annotations don't have to be strings.

As part of this change, the `@command()` decorator for user scripts will work now if the user script uses the annotations future. It doesn't, however, support type annotations that are strings in the source. But since the valid set of type is very small for commands, it's not a real problem.

Also fixed some type warnings in `CortexM` related to core register read return values being either int or float, though they weren't actual errors.