### PR TITLE
Allow FlashBuilder to work when program page size is larger than sector erase size.

### DIFF
--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -937,7 +937,7 @@ class FlashBuilder(MemoryBuilder):
             for sector in self.sector_list:
                 if sector.are_any_pages_not_same():
                     # Erase the sector
-                    for addr in self.sector.addrs:
+                    for addr in sector.addrs:
                         self.flash.erase_sector(addr)
 
                     # Update progress

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2015-2019 Arm Limited
 # Copyright (c) 2021 Chris Reed
+# Copyright (c) 2023 Brian Pugh
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -94,12 +94,22 @@ def _stub_progress(percent):
 
 class _FlashSector:
     """@brief Info about an erase sector and all pages to be programmed within it."""
-    def __init__(self, sector_info):
+    def __init__(self, sector_info, n_subsectors: int = 1):
         self.addr: int = sector_info.base_addr
-        self.size: int = sector_info.size
+        self._subsector_size: int = sector_info.size
         self.max_page_count: int = 0
         self.page_list: List[_FlashPage] = []
         self.erase_weight: float = sector_info.erase_weight
+        self.n_subsectors = n_subsectors
+
+    @property
+    def size(self):
+        return self.n_subsectors * self._subsector_size
+
+    @property
+    def addrs(self):
+        for i in range(self.n_subsectors):
+            yield self.addr + (i * self._subsector_size)
 
     def add_page(self, page):
         # The first time a page is added, compute the page count for this sector. This
@@ -122,8 +132,8 @@ class _FlashSector:
             page.same = False
 
     def __repr__(self):
-        return "<_FlashSector@%x addr=%x size=%x wgt=%g pages=%s>" % (
-            id(self), self.addr, self.size, self.erase_weight, self.page_list)
+        return "<_FlashSector@%x addr=%x size=%x wgt=%g pages=%s, subsectors=%d>" % (
+            id(self), self.addr, self.size, self.erase_weight, self.page_list, self.n_subsectors)
 
 class _FlashPage:
     """@brief A page to be programmed and its data."""
@@ -187,8 +197,8 @@ class FlashBuilder(MemoryBuilder):
         self.flash = flash
         self.flash_start = flash.region.start
         self.flash_operation_list = []
-        self.sector_list = []
-        self.page_list = []
+        self.sector_list: List[_FlashSector] = []
+        self.page_list: List[_FlashPage] = []
         self.perf = ProgrammingInfo()
         self.enable_double_buffering = True
         self.log_performance = True
@@ -285,11 +295,23 @@ class FlashBuilder(MemoryBuilder):
         if page_info is None:
             raise FlashFailure("attempt to program invalid flash address", address=flash_addr)
 
-        current_sector = _FlashSector(sector_info)
-        self.sector_list.append(current_sector)
+        def create_flash_sector(sector_info, page_info):
+            if page_info.size > sector_info.size:
+                assert page_info.size % sector_info.size == 0, \
+                    f"Sector ({sector_info.size} bytes) do not fit evenly into page ({page_info.size} bytes)"
+                n_subsectors = page_info.size // sector_info.size
+            else:
+                n_subsectors = 1
+
+            return _FlashSector(sector_info, n_subsectors=n_subsectors)
+
         current_page = _FlashPage(page_info)
-        current_sector.add_page(current_page)
+        current_sector = create_flash_sector(sector_info, page_info)
+
         self.page_list.append(current_page)
+        self.sector_list.append(current_sector)
+
+        current_sector.add_page(current_page)
 
         def fill_end_of_page_gap():
             # Fill the gap at the end of the soon to be previous page if there is one
@@ -314,7 +336,7 @@ class FlashBuilder(MemoryBuilder):
                     sector_info = self.flash.get_sector_info(flash_addr)
                     if sector_info is None:
                         raise FlashFailure("attempt to program invalid flash address", address=flash_addr)
-                    current_sector = _FlashSector(sector_info)
+                    current_sector = create_flash_sector(sector_info, page_info)
                     self.sector_list.append(current_sector)
 
                 # Check if operation is in a different page
@@ -807,11 +829,11 @@ class FlashBuilder(MemoryBuilder):
 
         for sector in self.sector_list:
             if sector.are_any_pages_not_same():
-
                 if self.region.is_erasable:
                     # Erase the sector
                     self.flash.init(self.flash.Operation.ERASE)
-                    self.flash.erase_sector(sector.addr)
+                    for addr in sector.addrs:
+                        self.flash.erase_sector(addr)
                     self.flash.uninit()
 
                     actual_sector_erase_weight += sector.erase_weight
@@ -909,14 +931,14 @@ class FlashBuilder(MemoryBuilder):
         # to read from flash while simultaneously programming it.
         progress = self._scan_pages_for_same(progress_cb)
 
-
         if self.region.is_erasable:
             # Erase all sectors up front.
             self.flash.init(self.flash.Operation.ERASE)
             for sector in self.sector_list:
                 if sector.are_any_pages_not_same():
                     # Erase the sector
-                    self.flash.erase_sector(sector.addr)
+                    for addr in self.sector.addrs:
+                        self.flash.erase_sector(addr)
 
                     # Update progress
                     progress += sector.erase_weight


### PR DESCRIPTION
# Problem Description
Currently, `FlashBuilder`, used by `FileProgrammer`, makes the reasonable assertion that sector size must be larger than program size. However, on the `STM32H7B0`, the sector size is 8KB, while the program size is 32KB. Here's the relevant definition from `Keil.STM32H7xx_DFP.3.1.1.pack`.

```
struct FlashDevice const FlashDevice  =  {
   FLASH_DRV_VERS,             // Driver Version, do not modify!
   "STM32H7B0_Flash_128k",     // Device Name 
   ONCHIP,                     // Device Type
   0x08000000,                 // Device Start Address
   0x00020000,                 // Device Size in Bytes (128kB)
   0x8000,                       // Programming Page Size
   0,                          // Reserved, must be 0
   0xFF,                       // Initial Content of Erased Memory
   100,                        // Program Page Timeout 100 mSec
   6000,                       // Erase Sector Timeout 6000 mSec

// Specify Size and Address of Sectors
   0x2000, 0x000000,          // Sector Size  8kB (16 Sectors)
   SECTOR_END
};
```

# Solution
The goal of this PR is to allow the STM32H7B0 to be programmed, while making the smallest change possible to pyOCD. This is my first PR and don't understand the code base super well, so super open to feedback and if we would like to address this in a different manner.

I added a new field, `n_subsectors` to the `_FlashSector` class. This allows the `_FlashSector` to represent an integer number of actual sectors (defaults to 1). The attribute `size` is now a property thats the total size of all subsectors. A new property, `addrs`, represents all the addresses of the subsectors. Upon `_FlashSector` creation, we first check to see if `_FlashSector` is smaller than `_FlashPage`, and if so, assign a >1 number of subsectors.

Finally, when `FlashBuilder` erases sectors, we now erase all subsectors of each `_FlashSector` object.