### PR TITLE
fix HC32L13x size and enable double buffering 

### DIFF
--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -59,7 +59,7 @@ FLASH_ALGO = {
     'page_size' : 0x200,
     'analyzer_supported' : False,
     'analyzer_address' : 0x00000000,
-    'page_buffers' : [0x20000800],   # Enable double buffering
+    'page_buffers' : [0x20000800, 0x20001000],   # Enable double buffering
     'min_program_length' : 0x200,
   }
 
@@ -91,7 +91,7 @@ class HC32L130(CoreSightTarget):
         FlashRegion( start=0x00000000, length=0x10000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
-        RamRegion(   start=0x20000000, length=0x1000)
+        RamRegion(   start=0x20000000, length=0x2000)
         )
 
     def __init__(self, session):
@@ -110,7 +110,7 @@ class HC32F030(CoreSightTarget):
         FlashRegion( start=0x00000000, length=0x10000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
-        RamRegion(   start=0x20000000, length=0x1000)
+        RamRegion(   start=0x20000000, length=0x2000)
         )
 
     def __init__(self, session):

--- a/pyocd/target/builtin/target_HC32L13x.py
+++ b/pyocd/target/builtin/target_HC32L13x.py
@@ -107,7 +107,7 @@ class HC32F030(CoreSightTarget):
     VENDOR = "HDSC"
 
     MEMORY_MAP = MemoryMap(
-        FlashRegion( start=0x00000000, length=0x8000, sector_size=0x200,
+        FlashRegion( start=0x00000000, length=0x10000, sector_size=0x200,
                         is_boot_memory=True,
                         algo=FLASH_ALGO),
         RamRegion(   start=0x20000000, length=0x1000)


### PR DESCRIPTION
All the mcus in this file have 8K(0x2000) ram, so the double buffering can be enabled.

 ![image](https://github.com/pyocd/pyOCD/assets/60053077/d800f4c8-6dfc-4e38-a6a9-23b384261b08)
![image](https://github.com/pyocd/pyOCD/assets/60053077/e20da931-82ca-44ec-8285-ea69d99a6c24)

