### PR TITLE
Add memory interface for jlink AP 0

### DIFF
--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2020 Arm Limited
 # Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2023 Marian Muller Rebeyrol
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -587,7 +588,7 @@ class JLinkMemoryInterface(MemoryInterface):
         # write leading unaligned bytes
         unaligned_count = 3 & (4 - addr)
         if (size > unaligned_count > 0):
-            self._link.memory_write8(addr, data[:unaligned_count], self._apsel, csw)
+            self._link.memory_write8(addr, data[:unaligned_count])
             size -= unaligned_count
             addr += unaligned_count
             idx += unaligned_count


### PR DESCRIPTION
Hi :wave: 

This PR aims to improve (dramatically) transfer speeds with JLink probes by implementing a memory interface using pylink's high-level read/write commands.

I believe it's implemented the way it's described in issue #1258.

Memory interface is only enabled for AP 0 and if the probe is connected to the target (i.e. if the user specified the `jlink.device` option).

Memory interface is heavily inspired by the STLink implementation.

As I'm not fluent in python and the pyproject structure, could you give me some pointers on how to run the tests, and potentially add some (for instance dedicated tests with and without target connection)?

Thanks.