### PR TITLE
Reset the offset in finding control block

### DIFF
--- a/pyocd/debug/rtt.py
+++ b/pyocd/debug/rtt.py
@@ -436,6 +436,7 @@ class GenericRTTControlBlock(RTTControlBlock):
         while search_size:
             read_size = min(search_size, 32)
             data = self.target.read_memory_block8(addr, read_size)
+            offset = 0
 
             if not data:
                 break


### PR DESCRIPTION
This commit fixes an issue where the control block id was not found in cases where the bytes spanned two read blocks.

Example data block causing the original issue:

`01:08:18.444,458] <dbg> SEGGER R`

In this case the code skips 24 bytes, making the next loop start with:

`SEGGER RTT\x00\x00\x00\x00…`

Unfortunately `offset` is still `8`, which the first byte does not match. The offset is then reset, but by that time the first byte has already been skipped over.

Re: #1553