### PR TITLE
add support for EG6832 mcu

### DIFF
--- a/pyocd/debug/svd/data/EG32M0x.svd
+++ b/pyocd/debug/svd/data/EG32M0x.svd
@@ -1,0 +1,15400 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<device schemaVersion="1.1" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="CMSIS-SVD_Schema_1_1.xsd">
+    <vendor>EGmicro Ltd.</vendor>
+    <!-- device vendor name -->
+    <vendorID>EGmicro</vendorID>
+    <!-- device vendor short name -->
+    <name>EG32M0x</name>
+    <!-- name of part-->
+    <series>EG32M0x</series>
+    <!-- device series the device belongs to -->
+    <version>1.0</version>
+    <!-- version of this description, adding CMSIS-SVD 1.1 tags -->
+    <description>EGmicro 32-bit Cortex-M0 Microcontroller based device, CPU clock up to 72MHz, etc. </description>
+    <licenseText>
+        <!-- this license text will appear in header file. \n force line breaks -->
+        EGmicro Limited (EGmicro) is supplying this software for use with Cortex-M0!
+    </licenseText>
+    <cpu>
+        <!-- details about the cpu embedded in the device -->
+        <name>CM0</name>
+        <revision>r0p0</revision>
+        <endian>little</endian>
+        <mpuPresent>false</mpuPresent>
+        <fpuPresent>false</fpuPresent>
+        <nvicPrioBits>3</nvicPrioBits>
+        <vendorSystickConfig>false</vendorSystickConfig>
+    </cpu>
+    <addressUnitBits>8</addressUnitBits>
+    <!-- byte addressable memory -->
+    <width>32</width>
+    <!-- bus width is 32 bits -->
+    <!-- default settings implicitly inherited by subsequent sections -->
+    <size>32</size>
+    <!-- this is the default size (number of bits) of all peripherals
+                                                                       and register that do not define "size" themselves -->
+    <access>read-write</access>
+    <!-- default access permission for all subsequent registers -->
+    <resetValue>0x00000000</resetValue>
+    <!-- by default all bits of the registers are initialized to 0 on reset -->
+    <resetMask>0xFFFFFFFF</resetMask>
+    <!-- by default all 32Bits of the registers are used -->
+
+    <peripherals>   
+        <!-- FLASH -->
+        <peripheral>
+            <name>FLASH</name>
+            <description>FLASH unit</description>
+            <groupName>FLASH</groupName>
+            <baseAddress>0x40020240</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x50</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+                <register>
+                    <name>CTRL0</name>
+                    <displayName>CTRL0</displayName>
+                    <description>CTRL0</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00001000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EMIE</name>
+                            <description>multiple bit error interrpution enable</description>
+                        </field>
+                        <field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EDIE</name>
+                            <description>one bit error interrpution enable</description>
+                        </field>
+                        <field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FWUP</name>
+                            <description>EFLASH fast wake-up enable</description>
+                        </field>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PCS</name>
+                            <description>FLASH burning clock source selection</description>
+                        </field>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PRCE</name>
+                            <description>Add CRC value at the end when moving RAM data to FLASH</description>
+                        </field>
+                        <field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LPS</name>
+                            <description>Is it allowed to interrupt FLASH programming and erase except</description>
+                        </field>
+						 <field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PRM</name>
+                            <description>Directly write RAM data to FLASH</description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>KST</name>
+                    <displayName>KST</displayName>
+                    <description>KST</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CKE</name>
+                            <description>CRC trigger enable of FLASH</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CK</name>
+                            <description>CRC check trigger of FLASH</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DONE</name>
+                    <displayName>DONE</displayName>
+                    <description>DONE</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00001c53</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEOF</name>
+                            <description>Chip erases results</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>POF</name>
+                            <description>As a result of programming</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CD</name>
+                            <description>CRC completion flag of FLASH</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD</name>
+                            <description>End of program flag</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CED</name>
+                            <description>The Main field is fully erased</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SED</name>
+                            <description>Sector erase flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PROG_ADDR</name>
+                    <displayName>PROG_ADDR</displayName>
+                    <description>PROG_ADDR</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x80000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PNS</name>
+                            <description>Choose MAIN/NVR as the programming address</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ADDR</name>
+                            <description>FLASH programming logical address </description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PROG_DATA</name>
+                    <displayName>PROG_DATA</displayName>
+                    <description>PROG_DATA</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DATA</name>
+                            <description>Configure PROG_DATA to start programming or display data when going to FLASH programming</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>ERASE_CTRL</name>
+                    <displayName>ERASE_CTRL</displayName>
+                    <description>ERASE_CTRL</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEK</name>
+                            <description>Trigger for Chip erase</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SEK</name>
+                            <description>Trigger for sector erase </description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NSE</name>
+                            <description>Sector enable bit of the NVR</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>SEA</name>
+                            <description>Erase the sector selection </description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TIME_REG0</name>
+                    <displayName>TIME_REG0</displayName>
+                    <description>TIME_REG0</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x7efdfbf2</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>PGH</name>
+                            <description>WE high to PROG2 high hold min time is 500ns</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>ADS</name>
+                            <description>BYTE/Address/data setup min time is 500ns </description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>ADH</name>
+                            <description>BYTE/Address/data hold min time is 500ns</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>RW</name>
+                            <description>Latency to next operation after PROG/sector ERASE low min time is 500ns </description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RC</name>
+                            <description>Read flash cycle </description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TIME_REG1</name>
+                    <displayName>TIME_REG1</displayName>
+                    <description>TIME_REG1</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0003e810</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>11</bitWidth>
+                            <name>MCS</name>
+                            <description>1ms Time configuration value, in the unit of 1us</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>UCS</name>
+                            <description>The clock frequency is 32MHz by default 2 frequency division </description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>NVR_PWD</name>
+                    <displayName>NVR_PWD</displayName>
+                    <description>NVR_PWD</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>NPW</name>
+                            <description>NVR area password</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>MAIN_PWD</name>
+                    <displayName>MAIN_PWD</displayName>
+                    <description>MAIN_PWD</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>MPW</name>
+                            <description>MAIN area password</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CRC_ADDR</name>
+                    <displayName>CRC_ADDR</displayName>
+                    <description>CRC_ADDR</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NS</name>
+                            <description>Whether the address is an NVR zone</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>27</bitWidth>
+                            <name>CA</name>
+                            <description>Set this parameter to the start address of the CRC check</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CRC_LEN</name>
+                    <displayName>CRC_LEN</displayName>
+                    <description>CRC_LEN</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>15</bitWidth>
+                            <name>CL</name>
+                            <description>FLASH verifies the data length of the CRC</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CRC_OUT</name>
+                    <displayName>CRC_OUT</displayName>
+                    <description>CRC_OUT</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x5a5a55aa</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>CO</name>
+                            <description>CRC results</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CFG_SECTOR</name>
+                    <displayName>CFG_SECTOR</displayName>
+                    <description>CFG_SECTOR</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000380</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>RS</name>
+                            <description>Size of RAM</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>MSN</name>
+                            <description>sector number of the EFLASH MAIN</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>       
+		
+		
+		<!-- CRC -->
+        <peripheral>
+            <name>CRC</name>
+            <description>CRC unit</description>
+            <groupName>CRC</groupName>
+            <baseAddress>0x40020210</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x20</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CFG</name>
+                    <displayName>CFG</displayName>
+                    <description>CFG</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000100</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PW</name>
+                            <description>Polynomial width</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BO</name>
+                            <description>Check order of input data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EN</name>
+                            <description>CRC enablement</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>INIT</name>
+                    <displayName>INIT</displayName>
+                    <description>INIT</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0xffffffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>INITV</name>
+                            <description>CRC initial value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>INV</name>
+                    <displayName>INV</displayName>
+                    <description>INV</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0xffffffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>INVV</name>
+                            <description>CRC output takes reverse control</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>POLY</name>
+                    <displayName>POLY</displayName>
+                    <description>POLY</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0xedb88320</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>PV</name>
+                            <description>CRC polynomial value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BUSY</name>
+                            <description>CRC busy state</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DATA</name>
+                    <displayName>DATA</displayName>
+                    <description>DATA</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DATA</name>
+                            <description>CRC data register</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LEN</name>
+                    <displayName>LEN</displayName>
+                    <description>LEN</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>LENGTH</name>
+                            <description>CRC Indicates the byte length of the verification data</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- HWDIV -->
+        <peripheral>
+            <name>HWDIV</name>
+            <description>HWDIV unit</description>
+            <groupName>HWDIV</groupName>
+            <baseAddress>0x400203A0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x20</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>DR</name>
+                    <displayName>DR</displayName>
+                    <description>DR</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DIVDR</name>
+                            <description>Dividend data</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DIVSR</name>
+                            <description>Divisor data</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>QUO</name>
+                    <displayName>QUO</displayName>
+                    <description>QUO</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DIVQUO</name>
+                            <description>Quotient result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>REM</name>
+                    <displayName>REM</displayName>
+                    <description>REM</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DIVREM</name>
+                            <description>Remainder result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CR</name>
+                    <displayName>CR</displayName>
+                    <description>CR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UNSIGN</name>
+                            <description>Operation symbol bit control</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIE</name>
+                            <description>End of operation interrupt control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIV0IE</name>
+                            <description>Divisor is 0 interrupt control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DP</name>
+                            <description>End of operation flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIV0P</name>
+                            <description>The divisor is 0</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- POWER MANAGEMENT -->
+        <peripheral>
+		<name>POWER_MAN</name>
+            <description>POWER MANAGEMENT unit</description>
+            <groupName>POWER MANAGEMENT</groupName>
+            <baseAddress>0x40020120</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>LVDCON</name>
+                    <displayName>LVDCON</displayName>
+                    <description>LVDCON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000e15</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VDDP</name>
+                            <description>When the VDD voltage is lower than the threshold, the PEND is triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCCP</name>
+                            <description>When the VCC voltage is lower than the threshold, the PEND is triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VDDLAOD</name>
+                            <description>VDD_LVD Analog signal output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>DLLS</name>
+                            <description>Low level burr filter width for PMU_LVD_VDD signal The degree of</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>DHLS</name>
+                            <description>High level burr filter width for PMU_LVD_VDD signal The degree of</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VSD</name>
+                            <description>VCC_LVD Indicates whether to wake up the CPU in interrupt mode The system clock must be synchronized first</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VDDSDE</name>
+                            <description>Mask the filtering processing of PMU_VDD_LVD signal</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCCSDE</name>
+                            <description>Mask the filtering processing of PMU_VCC_LVD signal</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LDE</name>
+                            <description>LVD digital switch</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VDDRE</name>
+                            <description>The system reset function is enabled after the VDD threshold is triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCCRE</name>
+                            <description>The system reset function is enabled after the VCC threshold is triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCCLAOD</name>
+                            <description>VCC_LVD Analog signal output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>VDDLS</name>
+                            <description>VDD_LVD Voltage detection Setting</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VDDLE</name>
+                            <description>VDD_LVD analog switch</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>VCCLS</name>
+                            <description>VCC_LVD Voltage detection Setting</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCCLE</name>
+                            <description>VCC_LVD analog switch</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LVDCON1</name>
+                    <displayName>LVDCON1</displayName>
+                    <description>LVDCON1</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>VDLL</name>
+                            <description>Low level burr filter width for PMU_LVD_VCC signal The degree of</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>VDHL</name>
+                            <description>High level burr filter width for PMU_LVD_VCC signal The degree of</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- GPIOA -->
+        <peripheral>
+            <name>GPIOA</name>
+            <description>GPIOA unit</description>
+            <groupName>GPIOA</groupName>
+            <baseAddress>0x400200A0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x40</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>MODE</name>
+                    <displayName>MODE</displayName>
+                    <description>MODE</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER15</name>
+                            <description>The mode bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER14</name>
+                            <description>The mode bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER13</name>
+                            <description>The mode bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER12</name>
+                            <description>The mode bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER11</name>
+                            <description>The mode bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER10</name>
+                            <description>The mode bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER9</name>
+                            <description>The mode bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER8</name>
+                            <description>The mode bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER7</name>
+                            <description>The mode bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER6</name>
+                            <description>The mode bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER5</name>
+                            <description>The mode bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER4</name>
+                            <description>The mode bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER3</name>
+                            <description>The mode bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER2</name>
+                            <description>The mode bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER1</name>
+                            <description>The mode bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER0</name>
+                            <description>The mode bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OTYPE</name>
+                    <displayName>OTYPE</displayName>
+                    <description>OTYPE</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE15</name>
+                            <description>The output type selection bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE14</name>
+                            <description>The output type selection bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE13</name>
+                            <description>The output type selection bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE12</name>
+                            <description>The output type selection bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE11</name>
+                            <description>The output type selection bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE10</name>
+                            <description>The output type selection bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE9</name>
+                            <description>The output type selection bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE8</name>
+                            <description>The output type selection bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE7</name>
+                            <description>The output type selection bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE6</name>
+                            <description>The output type selection bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE5</name>
+                            <description>The output type selection bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE4</name>
+                            <description>The output type selection bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE3</name>
+                            <description>The output type selection bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE2</name>
+                            <description>The output type selection bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE1</name>
+                            <description>The output type selection bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE0</name>
+                            <description>The output type selection bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OSPEED</name>
+                    <displayName>OSPEED</displayName>
+                    <description>OSPEED</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED15</name>
+                            <description>The Speed gear selection bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED14</name>
+                            <description>The Speed gear selection bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED13</name>
+                            <description>The Speed gear selection bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED12</name>
+                            <description>The Speed gear selection bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED11</name>
+                            <description>The Speed gear selection bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED10</name>
+                            <description>The Speed gear selection bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED9</name>
+                            <description>The Speed gear selection bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED8</name>
+                            <description>The Speed gear selection bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED7</name>
+                            <description>The Speed gear selection bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED6</name>
+                            <description>The Speed gear selection bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED5</name>
+                            <description>The Speed gear selection bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED4</name>
+                            <description>The Speed gear selection bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED3</name>
+                            <description>The Speed gear selection bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED2</name>
+                            <description>The Speed gear selection bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED1</name>
+                            <description>The Speed gear selection bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED0</name>
+                            <description>The Speed gear selection bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>PUPD</name>
+                    <displayName>PUPD</displayName>
+                    <description>PUPD</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD15</name>
+                            <description>The drop-down enable bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD14</name>
+                            <description>The drop-down enable bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD13</name>
+                            <description>The drop-down enable bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD12</name>
+                            <description>The drop-down enable bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD11</name>
+                            <description>The drop-down enable bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD10</name>
+                            <description>The drop-down enable bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD9</name>
+                            <description>The drop-down enable bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD8</name>
+                            <description>The drop-down enable bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD7</name>
+                            <description>The drop-down enable bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD6</name>
+                            <description>The drop-down enable bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD5</name>
+                            <description>The drop-down enable bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD4</name>
+                            <description>The drop-down enable bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD3</name>
+                            <description>The drop-down enable bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD2</name>
+                            <description>The drop-down enable bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD1</name>
+                            <description>The drop-down enable bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD0</name>
+                            <description>The drop-down enable bit of GPIOA PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU15</name>
+                            <description>The pull-up enable bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU14</name>
+                            <description>The pull-up enable bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU13</name>
+                            <description>The pull-up enable bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU12</name>
+                            <description>The pull-up enable bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU11</name>
+                            <description>The pull-up enable bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU10</name>
+                            <description>The pull-up enable bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU9</name>
+                            <description>The pull-up enable bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU8</name>
+                            <description>The pull-up enable bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU7</name>
+                            <description>The pull-up enable bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU6</name>
+                            <description>The pull-up enable bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU5</name>
+                            <description>The pull-up enable bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU4</name>
+                            <description>The pull-up enable bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU3</name>
+                            <description>The pull-up enable bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU2</name>
+                            <description>The pull-up enable bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU1</name>
+                            <description>The pull-up enable bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU0</name>
+                            <description>The pull-up enable bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IDAT</name>
+                    <displayName>IDAT</displayName>
+                    <description>IDAT</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT15</name>
+                            <description>The Input data bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT14</name>
+                            <description>The Input data bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT13</name>
+                            <description>The Input data bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT12</name>
+                            <description>The Input data bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT11</name>
+                            <description>The Input data bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT10</name>
+                            <description>The Input data bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT9</name>
+                            <description>The Input data bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT8</name>
+                            <description>The Input data bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT7</name>
+                            <description>The Input data bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT6</name>
+                            <description>The Input data bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT5</name>
+                            <description>The Input data bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT4</name>
+                            <description>The Input data bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT3</name>
+                            <description>The Input data bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT2</name>
+                            <description>The Input data bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT1</name>
+                            <description>The Input data bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT0</name>
+                            <description>The Input data bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ODAT</name>
+                    <displayName>ODAT</displayName>
+                    <description>ODAT</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT15</name>
+                            <description>The output data bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT14</name>
+                            <description>The output data bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT13</name>
+                            <description>The output data bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT12</name>
+                            <description>The output data bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT11</name>
+                            <description>The output data bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT10</name>
+                            <description>The output data bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT9</name>
+                            <description>The output data bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT8</name>
+                            <description>The output data bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT7</name>
+                            <description>The output data bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT6</name>
+                            <description>The output data bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT5</name>
+                            <description>The output data bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT4</name>
+                            <description>The output data bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT3</name>
+                            <description>The output data bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT2</name>
+                            <description>The output data bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT1</name>
+                            <description>The output data bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT0</name>
+                            <description>The output data bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BSR</name>
+                    <displayName>BSR</displayName>
+                    <description>BSR</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR15</name>
+                            <description>The Clear bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR14</name>
+                            <description>The Clear bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR13</name>
+                            <description>The Clear bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR12</name>
+                            <description>The Clear bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR11</name>
+                            <description>The Clear bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR10</name>
+                            <description>The Clear bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR9</name>
+                            <description>The Clear bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR8</name>
+                            <description>The Clear bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR7</name>
+                            <description>The Clear bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR6</name>
+                            <description>The Clear bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR5</name>
+                            <description>The Clear bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR4</name>
+                            <description>The Clear bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR3</name>
+                            <description>The Clear bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR2</name>
+                            <description>The Clear bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR1</name>
+                            <description>The Clear bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR0</name>
+                            <description>The Clear bit of GPIOA PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS15</name>
+                            <description>The setting bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS14</name>
+                            <description>The setting bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS13</name>
+                            <description>The setting bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS12</name>
+                            <description>The setting bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS11</name>
+                            <description>The setting bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS10</name>
+                            <description>The setting bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS9</name>
+                            <description>The setting bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS8</name>
+                            <description>The setting bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS7</name>
+                            <description>The setting bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS6</name>
+                            <description>The setting bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS5</name>
+                            <description>The setting bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS4</name>
+                            <description>The setting bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS3</name>
+                            <description>The setting bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS2</name>
+                            <description>The setting bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS1</name>
+                            <description>The setting bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS0</name>
+                            <description>The setting bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LCK</name>
+                    <displayName>LCK</displayName>
+                    <description>LCK</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+					    <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCKK</name>
+                            <description>The locking mechanism valid bit of GPIOA</description>
+                        </field>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK15</name>
+                            <description>The lock enable bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK14</name>
+                            <description>The lock enable bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK13</name>
+                            <description>The lock enable bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK12</name>
+                            <description>The lock enable bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK11</name>
+                            <description>The lock enable bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK10</name>
+                            <description>The lock enable bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK9</name>
+                            <description>The lock enable bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK8</name>
+                            <description>The lock enable bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK7</name>
+                            <description>The lock enable bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK6</name>
+                            <description>The lock enable bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK5</name>
+                            <description>The lock enable bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK4</name>
+                            <description>The lock enable bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK3</name>
+                            <description>The lock enable bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK2</name>
+                            <description>The lock enable bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK1</name>
+                            <description>The lock enable bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK0</name>
+                            <description>The lock enable bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>AFRL</name>
+                    <displayName>AFRL</displayName>
+                    <description>AFRL</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR7</name>
+                            <description>GPIOA[7] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR6</name>
+                            <description>GPIOA[6] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR5</name>
+                            <description>GPIOA[5] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR4</name>
+                            <description>GPIOA[4] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR3</name>
+                            <description>GPIOA[3] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR2</name>
+                            <description>GPIOA[2] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR1</name>
+                            <description>GPIOA[1] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR0</name>
+                            <description>GPIOA[0] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>AFRH</name>
+                    <displayName>AFRH</displayName>
+                    <description>AFRH</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR15</name>
+                            <description>GPIOA[15] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR14</name>
+                            <description>GPIOA[14] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR13</name>
+                            <description>GPIOA[13] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR12</name>
+                            <description>GPIOA[12] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR11</name>
+                            <description>GPIOA[11] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR10</name>
+                            <description>GPIOA[10] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR9</name>
+                            <description>GPIOA[9] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR8</name>
+                            <description>GPIOA[8] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>TGL</name>
+                    <displayName>TGL</displayName>
+                    <description>TGL</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG15</name>
+                            <description>The flip bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG14</name>
+                            <description>The flip bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG13</name>
+                            <description>The flip bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG12</name>
+                            <description>The flip bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG11</name>
+                            <description>The flip bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG10</name>
+                            <description>The flip bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG9</name>
+                            <description>The flip bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG8</name>
+                            <description>The flip bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG7</name>
+                            <description>The flip bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG6</name>
+                            <description>The flip bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG5</name>
+                            <description>The flip bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG4</name>
+                            <description>The flip bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG3</name>
+                            <description>The flip bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG2</name>
+                            <description>The flip bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG1</name>
+                            <description>The flip bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG0</name>
+                            <description>The flip bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IMK</name>
+                    <displayName>IMK</displayName>
+                    <description>IMK</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK15</name>
+                            <description>The Interrupt enable bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK14</name>
+                            <description>The Interrupt enable bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK13</name>
+                            <description>The Interrupt enable bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK12</name>
+                            <description>The Interrupt enable bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK11</name>
+                            <description>The Interrupt enable bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK10</name>
+                            <description>The Interrupt enable bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK9</name>
+                            <description>The Interrupt enable bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK8</name>
+                            <description>The Interrupt enable bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK7</name>
+                            <description>The Interrupt enable bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK6</name>
+                            <description>The Interrupt enable bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK5</name>
+                            <description>The Interrupt enable bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK4</name>
+                            <description>The Interrupt enable bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK3</name>
+                            <description>The Interrupt enable bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK2</name>
+                            <description>The Interrupt enable bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK1</name>
+                            <description>The Interrupt enable bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK0</name>
+                            <description>The Interrupt enable bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TGPEND</name>
+                    <displayName>TGPEND</displayName>
+                    <description>TGPEND</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP15</name>
+                            <description>The input edge detection flag bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP14</name>
+                            <description>The input edge detection flag bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP13</name>
+                            <description>The input edge detection flag bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP12</name>
+                            <description>The input edge detection flag bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP11</name>
+                            <description>The input edge detection flag bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP10</name>
+                            <description>The input edge detection flag bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP9</name>
+                            <description>The input edge detection flag bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP8</name>
+                            <description>The input edge detection flag bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP7</name>
+                            <description>The input edge detection flag bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP6</name>
+                            <description>The input edge detection flag bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP5</name>
+                            <description>The input edge detection flag bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP4</name>
+                            <description>The input edge detection flag bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP3</name>
+                            <description>The input edge detection flag bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP2</name>
+                            <description>The input edge detection flag bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP1</name>
+                            <description>The input edge detection flag bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP0</name>
+                            <description>The input edge detection flag bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IE_EN</name>
+                    <displayName>IE_EN</displayName>
+                    <description>IE_EN</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA15IEE</name>
+                            <description>The input force enable bit of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA14IEE</name>
+                            <description>The input force enable bit of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA13IEE</name>
+                            <description>The input force enable bit of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA12IEE</name>
+                            <description>The input force enable bit of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA11IEE</name>
+                            <description>The input force enable bit of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA10IEE</name>
+                            <description>The input force enable bit of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA9IEE</name>
+                            <description>The input force enable bit of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA8IEE</name>
+                            <description>The input force enable bit of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA7IEE</name>
+                            <description>The input force enable bit of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA6IEE</name>
+                            <description>The input force enable bit of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA5IEE</name>
+                            <description>The input force enable bit of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA4IEE</name>
+                            <description>The input force enable bit of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA3IEE</name>
+                            <description>The input force enable bit of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA2IEE</name>
+                            <description>The input force enable bit of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA1IEE</name>
+                            <description>The input force enable bit of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GA0IEE</name>
+                            <description>The input force enable bit of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TG_EDGE</name>
+                    <displayName>TG_EDGE</displayName>
+                    <description>TG_EDGE</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD15</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD14</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD13</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD12</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD11</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD10</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD9</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD8</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD7</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD6</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD5</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD4</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD3</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD2</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD1</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD0</name>
+                            <description>Detection control bit of the input edge of GPIOA PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral> 
+
+
+		<!-- GPIOB -->
+        <peripheral>
+            <name>GPIOB</name>
+            <description>GPIOB unit</description>
+            <groupName>GPIOB</groupName>
+            <baseAddress>0x400200E0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x40</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>MODE</name>
+                    <displayName>MODE</displayName>
+                    <description>MODE</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER15</name>
+                            <description>The mode bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER14</name>
+                            <description>The mode bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER13</name>
+                            <description>The mode bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER12</name>
+                            <description>The mode bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER11</name>
+                            <description>The mode bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER10</name>
+                            <description>The mode bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER9</name>
+                            <description>The mode bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER8</name>
+                            <description>The mode bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER7</name>
+                            <description>The mode bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER6</name>
+                            <description>The mode bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER5</name>
+                            <description>The mode bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER4</name>
+                            <description>The mode bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER3</name>
+                            <description>The mode bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER2</name>
+                            <description>The mode bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER1</name>
+                            <description>The mode bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER0</name>
+                            <description>The mode bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OTYPE</name>
+                    <displayName>OTYPE</displayName>
+                    <description>OTYPE</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE15</name>
+                            <description>The output type selection bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE14</name>
+                            <description>The output type selection bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE13</name>
+                            <description>The output type selection bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE12</name>
+                            <description>The output type selection bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE11</name>
+                            <description>The output type selection bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE10</name>
+                            <description>The output type selection bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE9</name>
+                            <description>The output type selection bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE8</name>
+                            <description>The output type selection bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE7</name>
+                            <description>The output type selection bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE6</name>
+                            <description>The output type selection bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE5</name>
+                            <description>The output type selection bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE4</name>
+                            <description>The output type selection bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE3</name>
+                            <description>The output type selection bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE2</name>
+                            <description>The output type selection bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE1</name>
+                            <description>The output type selection bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE0</name>
+                            <description>The output type selection bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OSPEED</name>
+                    <displayName>OSPEED</displayName>
+                    <description>OSPEED</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED15</name>
+                            <description>The Speed gear selection bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED14</name>
+                            <description>The Speed gear selection bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED13</name>
+                            <description>The Speed gear selection bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED12</name>
+                            <description>The Speed gear selection bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED11</name>
+                            <description>The Speed gear selection bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED10</name>
+                            <description>The Speed gear selection bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED9</name>
+                            <description>The Speed gear selection bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED8</name>
+                            <description>The Speed gear selection bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED7</name>
+                            <description>The Speed gear selection bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED6</name>
+                            <description>The Speed gear selection bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED5</name>
+                            <description>The Speed gear selection bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED4</name>
+                            <description>The Speed gear selection bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED3</name>
+                            <description>The Speed gear selection bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED2</name>
+                            <description>The Speed gear selection bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED1</name>
+                            <description>The Speed gear selection bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED0</name>
+                            <description>The Speed gear selection bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>PUPD</name>
+                    <displayName>PUPD</displayName>
+                    <description>PUPD</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD15</name>
+                            <description>The drop-down enable bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD14</name>
+                            <description>The drop-down enable bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD13</name>
+                            <description>The drop-down enable bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD12</name>
+                            <description>The drop-down enable bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD11</name>
+                            <description>The drop-down enable bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD10</name>
+                            <description>The drop-down enable bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD9</name>
+                            <description>The drop-down enable bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD8</name>
+                            <description>The drop-down enable bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD7</name>
+                            <description>The drop-down enable bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD6</name>
+                            <description>The drop-down enable bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD5</name>
+                            <description>The drop-down enable bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD4</name>
+                            <description>The drop-down enable bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD3</name>
+                            <description>The drop-down enable bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD2</name>
+                            <description>The drop-down enable bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD1</name>
+                            <description>The drop-down enable bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD0</name>
+                            <description>The drop-down enable bit of GPIOB PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU15</name>
+                            <description>The pull-up enable bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU14</name>
+                            <description>The pull-up enable bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU13</name>
+                            <description>The pull-up enable bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU12</name>
+                            <description>The pull-up enable bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU11</name>
+                            <description>The pull-up enable bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU10</name>
+                            <description>The pull-up enable bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU9</name>
+                            <description>The pull-up enable bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU8</name>
+                            <description>The pull-up enable bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU7</name>
+                            <description>The pull-up enable bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU6</name>
+                            <description>The pull-up enable bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU5</name>
+                            <description>The pull-up enable bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU4</name>
+                            <description>The pull-up enable bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU3</name>
+                            <description>The pull-up enable bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU2</name>
+                            <description>The pull-up enable bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU1</name>
+                            <description>The pull-up enable bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU0</name>
+                            <description>The pull-up enable bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IDAT</name>
+                    <displayName>IDAT</displayName>
+                    <description>IDAT</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT15</name>
+                            <description>The Input data bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT14</name>
+                            <description>The Input data bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT13</name>
+                            <description>The Input data bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT12</name>
+                            <description>The Input data bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT11</name>
+                            <description>The Input data bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT10</name>
+                            <description>The Input data bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT9</name>
+                            <description>The Input data bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT8</name>
+                            <description>The Input data bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT7</name>
+                            <description>The Input data bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT6</name>
+                            <description>The Input data bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT5</name>
+                            <description>The Input data bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT4</name>
+                            <description>The Input data bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT3</name>
+                            <description>The Input data bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT2</name>
+                            <description>The Input data bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT1</name>
+                            <description>The Input data bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT0</name>
+                            <description>The Input data bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ODAT</name>
+                    <displayName>ODAT</displayName>
+                    <description>ODAT</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT15</name>
+                            <description>The output data bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT14</name>
+                            <description>The output data bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT13</name>
+                            <description>The output data bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT12</name>
+                            <description>The output data bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT11</name>
+                            <description>The output data bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT10</name>
+                            <description>The output data bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT9</name>
+                            <description>The output data bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT8</name>
+                            <description>The output data bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT7</name>
+                            <description>The output data bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT6</name>
+                            <description>The output data bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT5</name>
+                            <description>The output data bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT4</name>
+                            <description>The output data bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT3</name>
+                            <description>The output data bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT2</name>
+                            <description>The output data bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT1</name>
+                            <description>The output data bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT0</name>
+                            <description>The output data bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BSR</name>
+                    <displayName>BSR</displayName>
+                    <description>BSR</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR15</name>
+                            <description>The Clear bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR14</name>
+                            <description>The Clear bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR13</name>
+                            <description>The Clear bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR12</name>
+                            <description>The Clear bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR11</name>
+                            <description>The Clear bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR10</name>
+                            <description>The Clear bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR9</name>
+                            <description>The Clear bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR8</name>
+                            <description>The Clear bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR7</name>
+                            <description>The Clear bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR6</name>
+                            <description>The Clear bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR5</name>
+                            <description>The Clear bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR4</name>
+                            <description>The Clear bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR3</name>
+                            <description>The Clear bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR2</name>
+                            <description>The Clear bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR1</name>
+                            <description>The Clear bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR0</name>
+                            <description>The Clear bit of GPIOB PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS15</name>
+                            <description>The setting bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS14</name>
+                            <description>The setting bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS13</name>
+                            <description>The setting bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS12</name>
+                            <description>The setting bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS11</name>
+                            <description>The setting bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS10</name>
+                            <description>The setting bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS9</name>
+                            <description>The setting bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS8</name>
+                            <description>The setting bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS7</name>
+                            <description>The setting bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS6</name>
+                            <description>The setting bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS5</name>
+                            <description>The setting bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS4</name>
+                            <description>The setting bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS3</name>
+                            <description>The setting bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS2</name>
+                            <description>The setting bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS1</name>
+                            <description>The setting bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS0</name>
+                            <description>The setting bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LCK</name>
+                    <displayName>LCK</displayName>
+                    <description>LCK</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+					    <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCKK</name>
+                            <description>The locking mechanism valid bit of GPIOB</description>
+                        </field>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK15</name>
+                            <description>The lock enable bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK14</name>
+                            <description>The lock enable bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK13</name>
+                            <description>The lock enable bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK12</name>
+                            <description>The lock enable bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK11</name>
+                            <description>The lock enable bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK10</name>
+                            <description>The lock enable bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK9</name>
+                            <description>The lock enable bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK8</name>
+                            <description>The lock enable bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK7</name>
+                            <description>The lock enable bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK6</name>
+                            <description>The lock enable bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK5</name>
+                            <description>The lock enable bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK4</name>
+                            <description>The lock enable bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK3</name>
+                            <description>The lock enable bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK2</name>
+                            <description>The lock enable bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK1</name>
+                            <description>The lock enable bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK0</name>
+                            <description>The lock enable bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>AFRL</name>
+                    <displayName>AFRL</displayName>
+                    <description>AFRL</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR7</name>
+                            <description>GPIOB[7] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR6</name>
+                            <description>GPIOB[6] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR5</name>
+                            <description>GPIOB[5] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR4</name>
+                            <description>GPIOB[4] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR3</name>
+                            <description>GPIOB[3] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR2</name>
+                            <description>GPIOB[2] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR1</name>
+                            <description>GPIOB[1] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR0</name>
+                            <description>GPIOB[0] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>AFRH</name>
+                    <displayName>AFRH</displayName>
+                    <description>AFRH</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR15</name>
+                            <description>GPIOB[15] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR14</name>
+                            <description>GPIOB[14] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR13</name>
+                            <description>GPIOB[13] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR12</name>
+                            <description>GPIOB[12] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR11</name>
+                            <description>GPIOB[11] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR10</name>
+                            <description>GPIOB[10] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR9</name>
+                            <description>GPIOB[9] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR8</name>
+                            <description>GPIOB[8] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>TGL</name>
+                    <displayName>TGL</displayName>
+                    <description>TGL</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG15</name>
+                            <description>The flip bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG14</name>
+                            <description>The flip bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG13</name>
+                            <description>The flip bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG12</name>
+                            <description>The flip bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG11</name>
+                            <description>The flip bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG10</name>
+                            <description>The flip bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG9</name>
+                            <description>The flip bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG8</name>
+                            <description>The flip bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG7</name>
+                            <description>The flip bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG6</name>
+                            <description>The flip bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG5</name>
+                            <description>The flip bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG4</name>
+                            <description>The flip bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG3</name>
+                            <description>The flip bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG2</name>
+                            <description>The flip bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG1</name>
+                            <description>The flip bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG0</name>
+                            <description>The flip bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IMK</name>
+                    <displayName>IMK</displayName>
+                    <description>IMK</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK15</name>
+                            <description>The Interrupt enable bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK14</name>
+                            <description>The Interrupt enable bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK13</name>
+                            <description>The Interrupt enable bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK12</name>
+                            <description>The Interrupt enable bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK11</name>
+                            <description>The Interrupt enable bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK10</name>
+                            <description>The Interrupt enable bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK9</name>
+                            <description>The Interrupt enable bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK8</name>
+                            <description>The Interrupt enable bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK7</name>
+                            <description>The Interrupt enable bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK6</name>
+                            <description>The Interrupt enable bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK5</name>
+                            <description>The Interrupt enable bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK4</name>
+                            <description>The Interrupt enable bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK3</name>
+                            <description>The Interrupt enable bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK2</name>
+                            <description>The Interrupt enable bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK1</name>
+                            <description>The Interrupt enable bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK0</name>
+                            <description>The Interrupt enable bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TGPEND</name>
+                    <displayName>TGPEND</displayName>
+                    <description>TGPEND</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP15</name>
+                            <description>The input edge detection flag bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP14</name>
+                            <description>The input edge detection flag bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP13</name>
+                            <description>The input edge detection flag bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP12</name>
+                            <description>The input edge detection flag bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP11</name>
+                            <description>The input edge detection flag bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP10</name>
+                            <description>The input edge detection flag bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP9</name>
+                            <description>The input edge detection flag bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP8</name>
+                            <description>The input edge detection flag bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP7</name>
+                            <description>The input edge detection flag bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP6</name>
+                            <description>The input edge detection flag bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP5</name>
+                            <description>The input edge detection flag bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP4</name>
+                            <description>The input edge detection flag bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP3</name>
+                            <description>The input edge detection flag bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP2</name>
+                            <description>The input edge detection flag bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP1</name>
+                            <description>The input edge detection flag bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP0</name>
+                            <description>The input edge detection flag bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IE_EN</name>
+                    <displayName>IE_EN</displayName>
+                    <description>IE_EN</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB15IEE</name>
+                            <description>The input force enable bit of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB14IEE</name>
+                            <description>The input force enable bit of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB13IEE</name>
+                            <description>The input force enable bit of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB12IEE</name>
+                            <description>The input force enable bit of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB11IEE</name>
+                            <description>The input force enable bit of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB10IEE</name>
+                            <description>The input force enable bit of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB9IEE</name>
+                            <description>The input force enable bit of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB8IEE</name>
+                            <description>The input force enable bit of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB7IEE</name>
+                            <description>The input force enable bit of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB6IEE</name>
+                            <description>The input force enable bit of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB5IEE</name>
+                            <description>The input force enable bit of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB4IEE</name>
+                            <description>The input force enable bit of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB3IEE</name>
+                            <description>The input force enable bit of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB2IEE</name>
+                            <description>The input force enable bit of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB1IEE</name>
+                            <description>The input force enable bit of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GB0IEE</name>
+                            <description>The input force enable bit of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TG_EDGE</name>
+                    <displayName>TG_EDGE</displayName>
+                    <description>TG_EDGE</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD15</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD14</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD13</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD12</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD11</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD10</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD9</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD8</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD7</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD6</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD5</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD4</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD3</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD2</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD1</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD0</name>
+                            <description>Detection control bit of the input edge of GPIOB PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>  
+
+
+		<!-- GPIOC -->
+        <peripheral>
+            <name>GPIOC</name>
+            <description>GPIOC unit</description>
+            <groupName>GPIOC</groupName>
+            <baseAddress>0x400201B0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x40</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>MODE</name>
+                    <displayName>MODE</displayName>
+                    <description>MODE</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER15</name>
+                            <description>The mode bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER14</name>
+                            <description>The mode bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER13</name>
+                            <description>The mode bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER12</name>
+                            <description>The mode bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER11</name>
+                            <description>The mode bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER10</name>
+                            <description>The mode bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER9</name>
+                            <description>The mode bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER8</name>
+                            <description>The mode bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER7</name>
+                            <description>The mode bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER6</name>
+                            <description>The mode bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER5</name>
+                            <description>The mode bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER4</name>
+                            <description>The mode bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER3</name>
+                            <description>The mode bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER2</name>
+                            <description>The mode bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER1</name>
+                            <description>The mode bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>MODER0</name>
+                            <description>The mode bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OTYPE</name>
+                    <displayName>OTYPE</displayName>
+                    <description>OTYPE</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE15</name>
+                            <description>The output type selection bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE14</name>
+                            <description>The output type selection bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE13</name>
+                            <description>The output type selection bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE12</name>
+                            <description>The output type selection bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE11</name>
+                            <description>The output type selection bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE10</name>
+                            <description>The output type selection bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE9</name>
+                            <description>The output type selection bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE8</name>
+                            <description>The output type selection bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE7</name>
+                            <description>The output type selection bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE6</name>
+                            <description>The output type selection bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE5</name>
+                            <description>The output type selection bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE4</name>
+                            <description>The output type selection bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE3</name>
+                            <description>The output type selection bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE2</name>
+                            <description>The output type selection bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE1</name>
+                            <description>The output type selection bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OTYPE0</name>
+                            <description>The output type selection bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>OSPEED</name>
+                    <displayName>OSPEED</displayName>
+                    <description>OSPEED</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED15</name>
+                            <description>The Speed gear selection bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED14</name>
+                            <description>The Speed gear selection bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED13</name>
+                            <description>The Speed gear selection bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED12</name>
+                            <description>The Speed gear selection bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED11</name>
+                            <description>The Speed gear selection bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED10</name>
+                            <description>The Speed gear selection bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED9</name>
+                            <description>The Speed gear selection bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED8</name>
+                            <description>The Speed gear selection bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED7</name>
+                            <description>The Speed gear selection bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED6</name>
+                            <description>The Speed gear selection bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED5</name>
+                            <description>The Speed gear selection bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED4</name>
+                            <description>The Speed gear selection bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED3</name>
+                            <description>The Speed gear selection bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED2</name>
+                            <description>The Speed gear selection bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED1</name>
+                            <description>The Speed gear selection bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>OSPEED0</name>
+                            <description>The Speed gear selection bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>PUPD</name>
+                    <displayName>PUPD</displayName>
+                    <description>PUPD</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD15</name>
+                            <description>The drop-down enable bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD14</name>
+                            <description>The drop-down enable bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD13</name>
+                            <description>The drop-down enable bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD12</name>
+                            <description>The drop-down enable bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD11</name>
+                            <description>The drop-down enable bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD10</name>
+                            <description>The drop-down enable bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD9</name>
+                            <description>The drop-down enable bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD8</name>
+                            <description>The drop-down enable bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD7</name>
+                            <description>The drop-down enable bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD6</name>
+                            <description>The drop-down enable bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD5</name>
+                            <description>The drop-down enable bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD4</name>
+                            <description>The drop-down enable bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD3</name>
+                            <description>The drop-down enable bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD2</name>
+                            <description>The drop-down enable bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD1</name>
+                            <description>The drop-down enable bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PD0</name>
+                            <description>The drop-down enable bit of GPIOC PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU15</name>
+                            <description>The pull-up enable bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU14</name>
+                            <description>The pull-up enable bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU13</name>
+                            <description>The pull-up enable bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU12</name>
+                            <description>The pull-up enable bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU11</name>
+                            <description>The pull-up enable bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU10</name>
+                            <description>The pull-up enable bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU9</name>
+                            <description>The pull-up enable bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU8</name>
+                            <description>The pull-up enable bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU7</name>
+                            <description>The pull-up enable bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU6</name>
+                            <description>The pull-up enable bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU5</name>
+                            <description>The pull-up enable bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU4</name>
+                            <description>The pull-up enable bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU3</name>
+                            <description>The pull-up enable bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU2</name>
+                            <description>The pull-up enable bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU1</name>
+                            <description>The pull-up enable bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PU0</name>
+                            <description>The pull-up enable bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IDAT</name>
+                    <displayName>IDAT</displayName>
+                    <description>IDAT</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT15</name>
+                            <description>The Input data bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT14</name>
+                            <description>The Input data bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT13</name>
+                            <description>The Input data bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT12</name>
+                            <description>The Input data bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT11</name>
+                            <description>The Input data bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT10</name>
+                            <description>The Input data bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT9</name>
+                            <description>The Input data bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT8</name>
+                            <description>The Input data bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT7</name>
+                            <description>The Input data bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT6</name>
+                            <description>The Input data bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT5</name>
+                            <description>The Input data bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT4</name>
+                            <description>The Input data bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT3</name>
+                            <description>The Input data bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT2</name>
+                            <description>The Input data bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT1</name>
+                            <description>The Input data bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IDAT0</name>
+                            <description>The Input data bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ODAT</name>
+                    <displayName>ODAT</displayName>
+                    <description>ODAT</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT15</name>
+                            <description>The output data bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT14</name>
+                            <description>The output data bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT13</name>
+                            <description>The output data bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT12</name>
+                            <description>The output data bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT11</name>
+                            <description>The output data bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT10</name>
+                            <description>The output data bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT9</name>
+                            <description>The output data bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT8</name>
+                            <description>The output data bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT7</name>
+                            <description>The output data bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT6</name>
+                            <description>The output data bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT5</name>
+                            <description>The output data bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT4</name>
+                            <description>The output data bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT3</name>
+                            <description>The output data bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT2</name>
+                            <description>The output data bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT1</name>
+                            <description>The output data bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ODAT0</name>
+                            <description>The output data bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BSR</name>
+                    <displayName>BSR</displayName>
+                    <description>BSR</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR15</name>
+                            <description>The Clear bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR14</name>
+                            <description>The Clear bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR13</name>
+                            <description>The Clear bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR12</name>
+                            <description>The Clear bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR11</name>
+                            <description>The Clear bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR10</name>
+                            <description>The Clear bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR9</name>
+                            <description>The Clear bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR8</name>
+                            <description>The Clear bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR7</name>
+                            <description>The Clear bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR6</name>
+                            <description>The Clear bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR5</name>
+                            <description>The Clear bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR4</name>
+                            <description>The Clear bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR3</name>
+                            <description>The Clear bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR2</name>
+                            <description>The Clear bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR1</name>
+                            <description>The Clear bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BR0</name>
+                            <description>The Clear bit of GPIOC PIN0</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS15</name>
+                            <description>The setting bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS14</name>
+                            <description>The setting bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS13</name>
+                            <description>The setting bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS12</name>
+                            <description>The setting bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS11</name>
+                            <description>The setting bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS10</name>
+                            <description>The setting bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS9</name>
+                            <description>The setting bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS8</name>
+                            <description>The setting bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS7</name>
+                            <description>The setting bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS6</name>
+                            <description>The setting bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS5</name>
+                            <description>The setting bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS4</name>
+                            <description>The setting bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS3</name>
+                            <description>The setting bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS2</name>
+                            <description>The setting bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS1</name>
+                            <description>The setting bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BS0</name>
+                            <description>The setting bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LCK</name>
+                    <displayName>LCK</displayName>
+                    <description>LCK</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+					    <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCKK</name>
+                            <description>The locking mechanism valid bit of GPIOC</description>
+                        </field>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK15</name>
+                            <description>The lock enable bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK14</name>
+                            <description>The lock enable bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK13</name>
+                            <description>The lock enable bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK12</name>
+                            <description>The lock enable bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK11</name>
+                            <description>The lock enable bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK10</name>
+                            <description>The lock enable bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK9</name>
+                            <description>The lock enable bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK8</name>
+                            <description>The lock enable bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK7</name>
+                            <description>The lock enable bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK6</name>
+                            <description>The lock enable bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK5</name>
+                            <description>The lock enable bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK4</name>
+                            <description>The lock enable bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK3</name>
+                            <description>The lock enable bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK2</name>
+                            <description>The lock enable bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK1</name>
+                            <description>The lock enable bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LCK0</name>
+                            <description>The lock enable bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>AFRL</name>
+                    <displayName>AFRL</displayName>
+                    <description>AFRL</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR7</name>
+                            <description>GPIOC[7] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR6</name>
+                            <description>GPIOC[6] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR5</name>
+                            <description>GPIOC[5] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR4</name>
+                            <description>GPIOC[4] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR3</name>
+                            <description>GPIOC[3] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR2</name>
+                            <description>GPIOC[2] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR1</name>
+                            <description>GPIOC[1] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR0</name>
+                            <description>GPIOC[0] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>AFRH</name>
+                    <displayName>AFRH</displayName>
+                    <description>AFRH</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR15</name>
+                            <description>GPIOC[15] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR14</name>
+                            <description>GPIOC[14] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR13</name>
+                            <description>GPIOC[13] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR12</name>
+                            <description>GPIOC[12] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR11</name>
+                            <description>GPIOC[11] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR10</name>
+                            <description>GPIOC[10] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR9</name>
+                            <description>GPIOC[9] multiplexed channel selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>AFR8</name>
+                            <description>GPIOC[8] multiplexed channel selection bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>TGL</name>
+                    <displayName>TGL</displayName>
+                    <description>TGL</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG15</name>
+                            <description>The flip bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG14</name>
+                            <description>The flip bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG13</name>
+                            <description>The flip bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG12</name>
+                            <description>The flip bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG11</name>
+                            <description>The flip bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG10</name>
+                            <description>The flip bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG9</name>
+                            <description>The flip bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG8</name>
+                            <description>The flip bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG7</name>
+                            <description>The flip bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG6</name>
+                            <description>The flip bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG5</name>
+                            <description>The flip bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG4</name>
+                            <description>The flip bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG3</name>
+                            <description>The flip bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG2</name>
+                            <description>The flip bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG1</name>
+                            <description>The flip bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG0</name>
+                            <description>The flip bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IMK</name>
+                    <displayName>IMK</displayName>
+                    <description>IMK</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK15</name>
+                            <description>The Interrupt enable bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK14</name>
+                            <description>The Interrupt enable bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK13</name>
+                            <description>The Interrupt enable bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK12</name>
+                            <description>The Interrupt enable bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK11</name>
+                            <description>The Interrupt enable bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK10</name>
+                            <description>The Interrupt enable bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK9</name>
+                            <description>The Interrupt enable bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK8</name>
+                            <description>The Interrupt enable bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK7</name>
+                            <description>The Interrupt enable bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK6</name>
+                            <description>The Interrupt enable bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK5</name>
+                            <description>The Interrupt enable bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK4</name>
+                            <description>The Interrupt enable bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK3</name>
+                            <description>The Interrupt enable bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK2</name>
+                            <description>The Interrupt enable bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK1</name>
+                            <description>The Interrupt enable bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IMK0</name>
+                            <description>The Interrupt enable bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TGPEND</name>
+                    <displayName>TGPEND</displayName>
+                    <description>TGPEND</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP15</name>
+                            <description>The input edge detection flag bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP14</name>
+                            <description>The input edge detection flag bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP13</name>
+                            <description>The input edge detection flag bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP12</name>
+                            <description>The input edge detection flag bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP11</name>
+                            <description>The input edge detection flag bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP10</name>
+                            <description>The input edge detection flag bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP9</name>
+                            <description>The input edge detection flag bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP8</name>
+                            <description>The input edge detection flag bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP7</name>
+                            <description>The input edge detection flag bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP6</name>
+                            <description>The input edge detection flag bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP5</name>
+                            <description>The input edge detection flag bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP4</name>
+                            <description>The input edge detection flag bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP3</name>
+                            <description>The input edge detection flag bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP2</name>
+                            <description>The input edge detection flag bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP1</name>
+                            <description>The input edge detection flag bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TP0</name>
+                            <description>The input edge detection flag bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>IE_EN</name>
+                    <displayName>IE_EN</displayName>
+                    <description>IE_EN</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC15IEE</name>
+                            <description>The input force enable bit of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC14IEE</name>
+                            <description>The input force enable bit of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC13IEE</name>
+                            <description>The input force enable bit of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC12IEE</name>
+                            <description>The input force enable bit of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC11IEE</name>
+                            <description>The input force enable bit of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC10IEE</name>
+                            <description>The input force enable bit of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC9IEE</name>
+                            <description>The input force enable bit of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC8IEE</name>
+                            <description>The input force enable bit of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC7IEE</name>
+                            <description>The input force enable bit of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC6IEE</name>
+                            <description>The input force enable bit of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC5IEE</name>
+                            <description>The input force enable bit of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC4IEE</name>
+                            <description>The input force enable bit of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC3IEE</name>
+                            <description>The input force enable bit of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC2IEE</name>
+                            <description>The input force enable bit of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC1IEE</name>
+                            <description>The input force enable bit of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GC0IEE</name>
+                            <description>The input force enable bit of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>TG_EDGE</name>
+                    <displayName>TG_EDGE</displayName>
+                    <description>TG_EDGE</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD15</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN15</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD14</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN14</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD13</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN13</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD12</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN12</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD11</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN11</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD10</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN10</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD9</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN9</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD8</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN8</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD7</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN7</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD6</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN6</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD5</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN5</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD4</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN4</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD3</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN3</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD2</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN2</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD1</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>TGD0</name>
+                            <description>Detection control bit of the input edge of GPIOC PIN0</description>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral>  
+
+
+		<!-- SPI -->
+        <peripheral>
+            <name>SPI</name>
+            <description>SPI unit</description>
+            <groupName>SPI</groupName>
+            <baseAddress>0x400202C0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x20</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON0</name>
+                    <displayName>CON0</displayName>
+                    <description>CON0</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>FS</name>
+                            <description>SPI data frame length</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CPIE</name>
+                            <description>Enable SPI rising edge interrupt from machine mode CS</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SCE</name>
+                            <description>SPI_CS pin enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SC</name>
+                            <description>SPI CS pins control the output</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MCD</name>
+                            <description>SPI host mode delay sampling data</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SSE</name>
+                            <description>Enable SPI to synchronize input data in slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSE</name>
+                            <description>Enable SPI to synchronize input data in master mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LSBDE</name>
+                            <description>The SPI transmits the lower-level function first</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WM</name>
+                            <description>SPI communication mode</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>SM</name>
+                            <description>SPI interface clock polarity and sampling phase</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CON1</name>
+                    <displayName>CON1</displayName>
+                    <description>CON1</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>Receive DMA enablement control</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TE</name>
+                            <description>Send DMA enable control</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BOIE</name>
+                            <description>Enable receive buffer overflow interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RNIE</name>
+                            <description>The receive buffer is not broken in the air</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TNIE</name>
+                            <description>The send buffer unsatisfactory interrupt function was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIE</name>
+                            <description>Enable data interruption after sending/receiving a frame</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SFD</name>
+                            <description>Select the full duplex mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TR</name>
+                            <description>Interface send/receive enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSS</name>
+                            <description>The interface master/slave mode is set</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SIS</name>
+                            <description>SPI/IIC mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SE</name>
+                            <description>The SPI and IIC modules were enabled</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CMD_DATA</name>
+                    <displayName>CMD_DATA</displayName>
+                    <description>CMD_DATA</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>CD</name>
+                            <description>Read and write data registers</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BAUD</name>
+                    <displayName>BAUD</displayName>
+                    <description>BAUD</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>BAUD</name>
+                            <description>SSP baud rate</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000804</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>STATE</name>
+                            <description>IIC states</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SA</name>
+                            <description>IIC slave mode is addressed flag</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CBC</name>
+                            <description>The software writes 1 to the bit to clear TBUF_CNT and RBUF_CNT to zero</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RO</name>
+                            <description>Receive buffer overflow</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TC</name>
+                            <description>Indicates how many bytes of valid data are in the send buffer</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>RC</name>
+                            <description>Indicates how many bytes of valid data are in the receive buffer</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MRB</name>
+                            <description>Indicates whether to read what needs to be read data length</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IRN</name>
+                            <description>The reply signal received at 9bit</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ISR</name>
+                            <description>The read and write flag received</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IBB</name>
+                            <description>The IIC detects that the line is busy</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SSC</name>
+                            <description>CS level state received by SPI from machine mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SB</name>
+                            <description>The status of the SPI/IIC when it is in host or slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AP</name>
+                            <description>Quorum loss is detected in the IIC host mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SP</name>
+                            <description>The IIC detects that the STOP bit is generated on the line</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AMP</name>
+                            <description>Received the correct slave address from the host</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IBP</name>
+                            <description>Broadcast address flag bit detected</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SCPP</name>
+                            <description>SPI detects CS pin rising edge from machine mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TE</name>
+                            <description>Send buffer empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TF</name>
+                            <description>Send buffer full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>Receive buffer empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RF</name>
+                            <description>Receive buffer full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SD</name>
+                            <description>Data transmission completion mark</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RONLY_CNT</name>
+                    <displayName>RONLY_CNT</displayName>
+                    <description>RONLY_CNT</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>RC</name>
+                            <description>Length of data received by the SPI in half-duplex read-only mode</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- IIC -->
+        <peripheral>
+            <name>IIC</name>
+            <description>IIC unit</description>
+            <groupName>IIC</groupName>
+            <baseAddress>0x400202E0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x20</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON0</name>
+                    <displayName>CON0</displayName>
+                    <description>CON0</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RNIE</name>
+                            <description>The NACK interrupt was received</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AIE</name>
+                            <description>The host quorum loss interrupt function was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SIE</name>
+                            <description>The STOP signal was detected online. The STOP signal was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AMIE</name>
+                            <description>The slave address matching interrupt was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>FM</name>
+                            <description>IIC Each IIC_FILTER_CNT Indicates the clock of an IIC module</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIE</name>
+                            <description>The IIC is disabled from receiving a broadcast address</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BE</name>
+                            <description>Enable the IIC to receive the broadcast address from the host</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>10</bitWidth>
+                            <name>SA</name>
+                            <description>IIC slave address</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TN</name>
+                            <description>Whether the IIC responds to the NACK when receiving data or the ACK select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AW</name>
+                            <description>IIC slave IP address width</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CON1</name>
+                    <displayName>CON1</displayName>
+                    <description>CON1</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>Receive DMA enablement control</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TE</name>
+                            <description>Send DMA enable control</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BOIE</name>
+                            <description>Enable receive buffer overflow interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RNIE</name>
+                            <description>The receive buffer is not broken in the air</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TNIE</name>
+                            <description>The send buffer unsatisfactory interrupt function was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIE</name>
+                            <description>Enable data interruption after sending/receiving a frame</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SFD</name>
+                            <description>Select the full duplex mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TR</name>
+                            <description>Interface send/receive enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSS</name>
+                            <description>The interface master/slave mode is set</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SIS</name>
+                            <description>SPI/IIC mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SE</name>
+                            <description>The SPI and IIC modules were enabled</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CMD_DATA</name>
+                    <displayName>CMD_DATA</displayName>
+                    <description>CMD_DATA</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>CD</name>
+                            <description>Read and write data registers</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BAUD</name>
+                    <displayName>BAUD</displayName>
+                    <description>BAUD</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>BAUD</name>
+                            <description>SSP baud rate</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000804</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>STATE</name>
+                            <description>IIC states</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SA</name>
+                            <description>IIC slave mode is addressed flag</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CBC</name>
+                            <description>The software writes 1 to the bit to clear TBUF_CNT and RBUF_CNT to zero</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RO</name>
+                            <description>Receive buffer overflow</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TC</name>
+                            <description>Indicates how many bytes of valid data are in the send buffer</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>RC</name>
+                            <description>Indicates how many bytes of valid data are in the receive buffer</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MRB</name>
+                            <description>Indicates whether to read what needs to be read data length</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IRN</name>
+                            <description>The reply signal received at 9bit</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ISR</name>
+                            <description>The read and write flag received</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IBB</name>
+                            <description>The IIC detects that the line is busy</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SSC</name>
+                            <description>CS level state received by SPI from machine mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SB</name>
+                            <description>The status of the SPI/IIC when it is in host or slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AP</name>
+                            <description>Quorum loss is detected in the IIC host mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SP</name>
+                            <description>The IIC detects that the STOP bit is generated on the line</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AMP</name>
+                            <description>Received the correct slave address from the host</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IBP</name>
+                            <description>Broadcast address flag bit detected</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SCPP</name>
+                            <description>SPI detects CS pin rising edge from machine mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TE</name>
+                            <description>Send buffer empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TF</name>
+                            <description>Send buffer full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>Receive buffer empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RF</name>
+                            <description>Receive buffer full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SD</name>
+                            <description>Data transmission completion mark</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RONLY_CNT</name>
+                    <displayName>RONLY_CNT</displayName>
+                    <description>RONLY_CNT</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>RC</name>
+                            <description>Length of data received by the SPI in half-duplex read-only mode</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- UART0 -->
+        <peripheral>
+            <name>UART0</name>
+            <description>UART0 unit</description>
+            <groupName>UART0</groupName>
+            <baseAddress>0x40020290</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00360000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>DMA receive request enable configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>DMA send request enable configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>14</bitWidth>
+                            <name>TBL</name>
+                            <description>Timeout configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE</name>
+                            <description>The UART send completion interrupt was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TPE</name>
+                            <description>The TX of UART has TMR PWM carrier</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOIE</name>
+                            <description>TIME OUT Indicates the interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOE</name>
+                            <description>TIME OUT detects the enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIE</name>
+                            <description>Frame error interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TBEIE</name>
+                            <description>Send buffer air break enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBNIE</name>
+                            <description>Receive buffer non - air break enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TI</name>
+                            <description>Send the output signal to take the inverse selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RI</name>
+                            <description>Receive the input signal to take the inverse selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OE</name>
+                            <description>Parity check selection</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PE</name>
+                            <description>Parity check is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BE</name>
+                            <description>UART transmits 9bit data mode selection bits</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SB</name>
+                            <description>UART stop bit selection</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RCE</name>
+                            <description>Disable the UART receiving function</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WM</name>
+                            <description>UART working mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UE</name>
+                            <description>The UART module enabled bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BAUD</name>
+                    <displayName>BAUD</displayName>
+                    <description>BAUD</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x000009c3</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>18</bitWidth>
+                            <name>BAUD</name>
+                            <description>UART Baud rate control register</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DATA</name>
+                    <displayName>DATA</displayName>
+                    <description>DATA</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <name>DATA</name>
+                            <description>UART data register</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000001</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCP</name>
+                            <description>UART Send completion flag</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOP</name>
+                            <description>TIME OUT flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>PERR</name>
+                            <description>UART Parity check flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>RC</name>
+                            <description>The number of cached data received by UART</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FERR</name>
+                            <description>Frame error</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBO</name>
+                            <description>UART receive cache full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBNE</name>
+                            <description>Receive buffer non-empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TBE</name>
+                            <description>UART sends cache empty flag</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- UART1 -->
+        <peripheral>
+            <name>UART1</name>
+            <description>UART1 unit</description>
+            <groupName>UART1</groupName>
+            <baseAddress>0x400202A0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00360000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>DMA receive request enable configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>DMA send request enable configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>14</bitWidth>
+                            <name>TBL</name>
+                            <description>Timeout configuration</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE</name>
+                            <description>The UART send completion interrupt was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TPE</name>
+                            <description>The TX of UART has TMR PWM carrier</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOIE</name>
+                            <description>TIME OUT Indicates the interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOE</name>
+                            <description>TIME OUT detects the enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIE</name>
+                            <description>Frame error interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TBEIE</name>
+                            <description>Send buffer air break enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBNIE</name>
+                            <description>Receive buffer non - air break enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TI</name>
+                            <description>Send the output signal to take the inverse selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RI</name>
+                            <description>Receive the input signal to take the inverse selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OE</name>
+                            <description>Parity check selection</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PE</name>
+                            <description>Parity check is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BE</name>
+                            <description>UART transmits 9bit data mode selection bits</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SB</name>
+                            <description>UART stop bit selection</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RCE</name>
+                            <description>Disable the UART receiving function</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WM</name>
+                            <description>UART working mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UE</name>
+                            <description>The UART module enabled bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BAUD</name>
+                    <displayName>BAUD</displayName>
+                    <description>BAUD</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x000009c3</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>18</bitWidth>
+                            <name>BAUD</name>
+                            <description>UART Baud rate control register</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DATA</name>
+                    <displayName>DATA</displayName>
+                    <description>DATA</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>9</bitWidth>
+                            <name>DATA</name>
+                            <description>UART data register</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000001</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCP</name>
+                            <description>UART Send completion flag</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TOP</name>
+                            <description>TIME OUT flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>PERR</name>
+                            <description>UART Parity check flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>RC</name>
+                            <description>The number of cached data received by UART</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FERR</name>
+                            <description>Frame error</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBO</name>
+                            <description>UART receive cache full flag</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RBNE</name>
+                            <description>Receive buffer non-empty flag</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TBE</name>
+                            <description>UART sends cache empty flag</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- TIMER1 -->
+        <peripheral>
+            <name>TIMER1</name>
+            <description>TIMER1 unit</description>
+            <groupName>TIMER1</groupName>
+            <baseAddress>0x40020400</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EKE</name>
+                            <description>External IO brake input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SYSE</name>
+                            <description>System error brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BP</name>
+                            <description>Comparator 1 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BE</name>
+                            <description>Comparator 1 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BP</name>
+                            <description>Comparator 0 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BE</name>
+                            <description>Comparator 0 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ADCBKEN</name>
+                            <description>ADC brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS4</name>
+                            <description>Output idle status 4</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS3N</name>
+                            <description>Output idle status 3</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS3</name>
+                            <description>Output idle status 3</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS2N</name>
+                            <description>Output idle status 2</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS2</name>
+                            <description>Output idle status 2</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1N</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TI1S</name>
+                            <description>TI1 selection</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCUS</name>
+                            <description>Capture/compare control update selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCPC</name>
+                            <description>Capture/compare preloaded control bits</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ETP</name>
+                            <description>External trigger polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ECE</name>
+                            <description>External clock enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>ETPS</name>
+                            <description>External trigger predivision</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>ETF</name>
+                            <description>External trigger filtering</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMDE</name>
+                            <description>DMA requests for COM are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4DE</name>
+                            <description>DMA requests for capture/compare 4 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3DE</name>
+                            <description>DMA requests for capture/compare 3 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIE</name>
+                            <description>Allow brake break</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIE</name>
+                            <description>Allow COM interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IE</name>
+                            <description>Allows capture/compare 4 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IE</name>
+                            <description>Allows capture/compare 3 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4OF</name>
+                            <description>Capture 4 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3OF</name>
+                            <description>Capture 3 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIF</name>
+                            <description>Brake interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIF</name>
+                            <description>COM interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IF</name>
+                            <description>Capture/compare 4 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IF</name>
+                            <description>Capture/compare 3 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BG</name>
+                            <description>Generating brake event</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMG</name>
+                            <description>Capture/compare event generation control updates</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4G</name>
+                            <description>Generate the capture/Compare 4 event</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3G</name>
+                            <description>Generate the capture/Compare 3 event</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2CE</name>
+                            <description>Output comparison 2 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1CE</name>
+                            <description>Output comparison 1 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR2</name>
+                    <displayName>CCMR2</displayName>
+                    <description>CCMR2</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4CE</name>
+                            <description>Output comparison 4 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC4M</name>
+                            <description>Output comparison 4 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4PE</name>
+                            <description>Output comparison 4 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4FE</name>
+                            <description>Compare the output 4 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC4S</name>
+                            <description>Capture/Compare 4 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3CE</name>
+                            <description>Output comparison 3 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC3M</name>
+                            <description>Output comparison 3 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3PE</name>
+                            <description>Output comparison 3 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3FE</name>
+                            <description>Compare the output 3 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC3S</name>
+                            <description>Capture/Compare 3 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4P</name>
+                            <description>Input/Capture 4 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4E</name>
+                            <description>Input/Capture 4 Enable the output</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3NP</name>
+                            <description>Input/Capture 3 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3NE</name>
+                            <description>Input/Capture 3 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3P</name>
+                            <description>Input/Capture 3 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3E</name>
+                            <description>Input/Capture 3 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NE</name>
+                            <description>Input/Capture 2 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NE</name>
+                            <description>Input/Capture 1 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RCR</name>
+                    <displayName>RCR</displayName>
+                    <description>RCR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>REP</name>
+                            <description>Repeat the value of the counter</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR3</name>
+                    <displayName>CCR3</displayName>
+                    <description>CCR3</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR3</name>
+                            <description>Capture/compare values for channel 3</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR4</name>
+                    <displayName>CCR4</displayName>
+                    <description>CCR4</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR4</name>
+                            <description>Capture/compare values for channel 4</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BDTR</name>
+                    <displayName>BDTR</displayName>
+                    <description>BDTR</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MOE</name>
+                            <description>Master output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AOE</name>
+                            <description>Automatic output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKP</name>
+                            <description>External IO brake input polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKE</name>
+                            <description>The brake function is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSR</name>
+                            <description>Off state in run mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSI</name>
+                            <description>Off state in idle mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>LOCK</name>
+                            <description>Lock setting</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>DTG</name>
+                            <description>Dead zone generator setting</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ALLCON</name>
+                    <displayName>ALLCON</displayName>
+                    <description>ALLCON</description>
+                    <addressOffset>0x5C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TES</name>
+                            <description>TIM4/5/6 External IO brake signal selection</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TS</name>
+                            <description>TIM1 to TIM6 stops counting</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TC</name>
+                            <description>The TIM1 to TIM6 counters were cleared to zero</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TK</name>
+                            <description>TIM1 to TIM6 counters are enabled</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- TIMER2 -->
+        <peripheral>
+            <name>TIMER2</name>
+            <description>TIMER2 unit</description>
+            <groupName>TIMER2</groupName>
+            <baseAddress>0x40020460</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TI1S</name>
+                            <description>TI1 selection</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ETP</name>
+                            <description>External trigger polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ECE</name>
+                            <description>External clock enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>ETPS</name>
+                            <description>External trigger predivision</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>ETF</name>
+                            <description>External trigger filtering</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4DE</name>
+                            <description>DMA requests for capture/compare 4 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3DE</name>
+                            <description>DMA requests for capture/compare 3 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IE</name>
+                            <description>Allows capture/compare 4 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IE</name>
+                            <description>Allows capture/compare 3 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4OF</name>
+                            <description>Capture 4 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3OF</name>
+                            <description>Capture 3 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IF</name>
+                            <description>Capture/compare 4 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IF</name>
+                            <description>Capture/compare 3 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4G</name>
+                            <description>Generate the capture/Compare 4 event</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3G</name>
+                            <description>Generate the capture/Compare 3 event</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2CE</name>
+                            <description>Output comparison 2 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1CE</name>
+                            <description>Output comparison 1 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR2</name>
+                    <displayName>CCMR2</displayName>
+                    <description>CCMR2</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4CE</name>
+                            <description>Output comparison 4 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC4M</name>
+                            <description>Output comparison 4 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4PE</name>
+                            <description>Output comparison 4 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4FE</name>
+                            <description>Compare the output 4 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC4S</name>
+                            <description>Capture/Compare 4 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3CE</name>
+                            <description>Output comparison 3 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC3M</name>
+                            <description>Output comparison 3 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3PE</name>
+                            <description>Output comparison 3 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3FE</name>
+                            <description>Compare the output 3 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC3S</name>
+                            <description>Capture/Compare 3 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4P</name>
+                            <description>Input/Capture 4 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4E</name>
+                            <description>Input/Capture 4 Enable the output</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3NP</name>
+                            <description>Input/Capture 3 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3P</name>
+                            <description>Input/Capture 3 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3E</name>
+                            <description>Input/Capture 3 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR3</name>
+                    <displayName>CCR3</displayName>
+                    <description>CCR3</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR3</name>
+                            <description>Capture/compare values for channel 3</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR4</name>
+                    <displayName>CCR4</displayName>
+                    <description>CCR4</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR4</name>
+                            <description>Capture/compare values for channel 4</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- TIMER3 -->
+        <peripheral>
+            <name>TIMER3</name>
+            <description>TIMER3 unit</description>
+            <groupName>TIMER3</groupName>
+            <baseAddress>0x400204C0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TI1S</name>
+                            <description>TI1 selection</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ETP</name>
+                            <description>External trigger polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ECE</name>
+                            <description>External clock enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>ETPS</name>
+                            <description>External trigger predivision</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>ETF</name>
+                            <description>External trigger filtering</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4DE</name>
+                            <description>DMA requests for capture/compare 4 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3DE</name>
+                            <description>DMA requests for capture/compare 3 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IE</name>
+                            <description>Allows capture/compare 4 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IE</name>
+                            <description>Allows capture/compare 3 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4OF</name>
+                            <description>Capture 4 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3OF</name>
+                            <description>Capture 3 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4IF</name>
+                            <description>Capture/compare 4 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3IF</name>
+                            <description>Capture/compare 3 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4G</name>
+                            <description>Generate the capture/Compare 4 event</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3G</name>
+                            <description>Generate the capture/Compare 3 event</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2CE</name>
+                            <description>Output comparison 2 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1CE</name>
+                            <description>Output comparison 1 Clear 0 enable</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR2</name>
+                    <displayName>CCMR2</displayName>
+                    <description>CCMR2</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4CE</name>
+                            <description>Output comparison 4 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC4M</name>
+                            <description>Output comparison 4 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4PE</name>
+                            <description>Output comparison 4 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC4FE</name>
+                            <description>Compare the output 4 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC4S</name>
+                            <description>Capture/Compare 4 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3CE</name>
+                            <description>Output comparison 3 clear 0 enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC3M</name>
+                            <description>Output comparison 3 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3PE</name>
+                            <description>Output comparison 3 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC3FE</name>
+                            <description>Compare the output 3 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC3S</name>
+                            <description>Capture/Compare 3 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4P</name>
+                            <description>Input/Capture 4 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC4E</name>
+                            <description>Input/Capture 4 Enable the output</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3NP</name>
+                            <description>Input/Capture 3 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3P</name>
+                            <description>Input/Capture 3 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC3E</name>
+                            <description>Input/Capture 3 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR3</name>
+                    <displayName>CCR3</displayName>
+                    <description>CCR3</description>
+                    <addressOffset>0x3C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR3</name>
+                            <description>Capture/compare values for channel 3</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR4</name>
+                    <displayName>CCR4</displayName>
+                    <description>CCR4</description>
+                    <addressOffset>0x40</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR4</name>
+                            <description>Capture/compare values for channel 4</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>
+		
+		
+		<!-- TIMER4 -->
+        <peripheral>
+            <name>TIMER4</name>
+            <description>TIMER4 unit</description>
+            <groupName>TIMER4</groupName>
+            <baseAddress>0x40020520</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EKE</name>
+                            <description>External IO brake input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SYSE</name>
+                            <description>System error brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BP</name>
+                            <description>Comparator 1 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BE</name>
+                            <description>Comparator 1 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BP</name>
+                            <description>Comparator 0 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BE</name>
+                            <description>Comparator 0 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ADCBKEN</name>
+                            <description>ADC brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS2</name>
+                            <description>Output idle status 2</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1N</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCUS</name>
+                            <description>Capture/compare control update selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCPC</name>
+                            <description>Capture/compare preloaded control bits</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMDE</name>
+                            <description>DMA requests for COM are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIE</name>
+                            <description>Allow brake break</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIE</name>
+                            <description>Allow COM interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIF</name>
+                            <description>Brake interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIF</name>
+                            <description>COM interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BG</name>
+                            <description>Generating brake event</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMG</name>
+                            <description>Capture/compare event generation control updates</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NE</name>
+                            <description>Input/Capture 1 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RCR</name>
+                    <displayName>RCR</displayName>
+                    <description>RCR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>REP</name>
+                            <description>Repeat the value of the counter</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BDTR</name>
+                    <displayName>BDTR</displayName>
+                    <description>BDTR</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MOE</name>
+                            <description>Master output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AOE</name>
+                            <description>Automatic output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKP</name>
+                            <description>External IO brake input polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKE</name>
+                            <description>The brake function is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSR</name>
+                            <description>Off state in run mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSI</name>
+                            <description>Off state in idle mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>LOCK</name>
+                            <description>Lock setting</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>DTG</name>
+                            <description>Dead zone generator setting</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+		
+		
+		<!-- TIMER5 -->
+        <peripheral>
+            <name>TIMER5</name>
+            <description>TIMER5 unit</description>
+            <groupName>TIMER5</groupName>
+            <baseAddress>0x40020580</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EKE</name>
+                            <description>External IO brake input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SYSE</name>
+                            <description>System error brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BP</name>
+                            <description>Comparator 1 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BE</name>
+                            <description>Comparator 1 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BP</name>
+                            <description>Comparator 0 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BE</name>
+                            <description>Comparator 0 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ADCBKEN</name>
+                            <description>ADC brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS2</name>
+                            <description>Output idle status 2</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1N</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCUS</name>
+                            <description>Capture/compare control update selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCPC</name>
+                            <description>Capture/compare preloaded control bits</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMDE</name>
+                            <description>DMA requests for COM are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIE</name>
+                            <description>Allow brake break</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIE</name>
+                            <description>Allow COM interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIF</name>
+                            <description>Brake interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIF</name>
+                            <description>COM interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BG</name>
+                            <description>Generating brake event</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMG</name>
+                            <description>Capture/compare event generation control updates</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NE</name>
+                            <description>Input/Capture 1 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RCR</name>
+                    <displayName>RCR</displayName>
+                    <description>RCR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>REP</name>
+                            <description>Repeat the value of the counter</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BDTR</name>
+                    <displayName>BDTR</displayName>
+                    <description>BDTR</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MOE</name>
+                            <description>Master output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AOE</name>
+                            <description>Automatic output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKP</name>
+                            <description>External IO brake input polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKE</name>
+                            <description>The brake function is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSR</name>
+                            <description>Off state in run mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSI</name>
+                            <description>Off state in idle mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>LOCK</name>
+                            <description>Lock setting</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>DTG</name>
+                            <description>Dead zone generator setting</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+		
+		
+		<!-- TIMER6 -->
+        <peripheral>
+            <name>TIMER6</name>
+            <description>TIMER6 unit</description>
+            <groupName>TIMER6</groupName>
+            <baseAddress>0x400205E0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x60</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EKE</name>
+                            <description>External IO brake input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SYSE</name>
+                            <description>System error brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BP</name>
+                            <description>Comparator 1 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C1BE</name>
+                            <description>Comparator 1 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BP</name>
+                            <description>Comparator 0 brake polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>C0BE</name>
+                            <description>Comparator 0 brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CKD</name>
+                            <description>Clock frequency division factor</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CMS</name>
+                            <description>Select the center alignment mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DIR</name>
+                            <description>Counting direction</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ADCBKEN</name>
+                            <description>ADC brake switch</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS2</name>
+                            <description>Output idle status 2</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1N</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIS1</name>
+                            <description>Output idle status 1</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCDS</name>
+                            <description>DMA selection for capture/comparison</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCUS</name>
+                            <description>Capture/compare control update selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CCPC</name>
+                            <description>Capture/compare preloaded control bits</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SMCR</name>
+                    <displayName>SMCR</displayName>
+                    <description>SMCR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MSM</name>
+                            <description>Master/slave mode</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>TS</name>
+                            <description>Trigger selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SMS</name>
+                            <description>Mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TDE</name>
+                            <description>Allows DMA requests to be triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMDE</name>
+                            <description>DMA requests for COM are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2DE</name>
+                            <description>DMA requests for capture/compare 2 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1DE</name>
+                            <description>DMA requests for capture/compare 1 are allowed</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIE</name>
+                            <description>Allow brake break</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIE</name>
+                            <description>The interrupt function was triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIE</name>
+                            <description>Allow COM interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IE</name>
+                            <description>Allows capture/compare 2 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IE</name>
+                            <description>Allows capture/compare 1 interrupts</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2OF</name>
+                            <description>Capture 2 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1OF</name>
+                            <description>Capture 1 Repeat the capture tag</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BIF</name>
+                            <description>Brake interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TIF</name>
+                            <description>Trigger interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMIF</name>
+                            <description>COM interrupt flag</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2IF</name>
+                            <description>Capture/compare 2 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1IF</name>
+                            <description>Capture/compare 1 interrupt flags</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BG</name>
+                            <description>Generating brake event</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TG</name>
+                            <description>Generate trigger event</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMG</name>
+                            <description>Capture/compare event generation control updates</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2G</name>
+                            <description>Generate the capture/Compare 2 event</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1G</name>
+                            <description>Generate the capture/Compare 1 event</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCMR1</name>
+                    <displayName>CCMR1</displayName>
+                    <description>CCMR1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC2M</name>
+                            <description>Output comparison 2 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2PE</name>
+                            <description>Output comparison 2 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC2FE</name>
+                            <description>Output comparison 2 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC2S</name>
+                            <description>Capture/Compare 2 Select</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>OC1M</name>
+                            <description>Output comparison 1 mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1PE</name>
+                            <description>Output comparison 1 Preload enable</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OC1FE</name>
+                            <description>Output comparison 1 Fast enable</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CC1S</name>
+                            <description>Capture/Compare 1 Select</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCER</name>
+                    <displayName>CCER</displayName>
+                    <description>CCER</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2NP</name>
+                            <description>Input/Capture 2 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2P</name>
+                            <description>Input/Capture 2 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC2E</name>
+                            <description>Input/Capture 2 Output Enable</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NP</name>
+                            <description>Input/Capture 1 Complementary output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1NE</name>
+                            <description>Input/Capture 1 Enable complementary output</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1P</name>
+                            <description>Input/Capture 1 Output polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CC1E</name>
+                            <description>Input/Capture 1 Output Enable</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RCR</name>
+                    <displayName>RCR</displayName>
+                    <description>RCR</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>REP</name>
+                            <description>Repeat the value of the counter</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR1</name>
+                    <displayName>CCR1</displayName>
+                    <description>CCR1</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR1</name>
+                            <description>Capture/compare values for channel 1</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CCR2</name>
+                    <displayName>CCR2</displayName>
+                    <description>CCR2</description>
+                    <addressOffset>0x38</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CCR2</name>
+                            <description>Capture/compare values for channel 2</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BDTR</name>
+                    <displayName>BDTR</displayName>
+                    <description>BDTR</description>
+                    <addressOffset>0x44</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>MOE</name>
+                            <description>Master output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AOE</name>
+                            <description>Automatic output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKP</name>
+                            <description>External IO brake input polarity</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BKE</name>
+                            <description>The brake function is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSR</name>
+                            <description>Off state in run mode</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OSSI</name>
+                            <description>Off state in idle mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>LOCK</name>
+                            <description>Lock setting</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>DTG</name>
+                            <description>Dead zone generator setting</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+		
+		
+		<!-- TIMER7 -->
+        <peripheral>
+            <name>TIMER7</name>
+            <description>TIMER7 unit</description>
+            <groupName>TIMER7</groupName>
+            <baseAddress>0x40020310</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x30</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR1</name>
+                    <displayName>CR1</displayName>
+                    <description>CR1</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ARPE</name>
+                            <description>Automatic reloading preloading allows bits</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OPM</name>
+                            <description>Single pulse mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>URS</name>
+                            <description>Update request source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDIS</name>
+                            <description>Forbid updating</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CEN</name>
+                            <description>Enable counter</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CR2</name>
+                    <displayName>CR2</displayName>
+                    <description>CR2</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MMS</name>
+                            <description>Master mode selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DIER</name>
+                    <displayName>DIER</displayName>
+                    <description>DIER</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UDE</name>
+                            <description>DMA requests that allow updates</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIE</name>
+                            <description>Allow update interrupt</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UIF</name>
+                            <description>Update interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>EGR</name>
+                    <displayName>EGR</displayName>
+                    <description>EGR</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>UG</name>
+                            <description>Generate update event</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CNT</name>
+                    <displayName>CNT</displayName>
+                    <description>CNT</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CNT</name>
+                            <description>Counter value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PSC</name>
+                    <displayName>PSC</displayName>
+                    <description>PSC</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PSC</name>
+                            <description>The value of the pre-divider</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>ARR</name>
+                    <displayName>ARR</displayName>
+                    <description>ARR</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000ffff</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>ARR</name>
+                            <description>The value of automatic reloading</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+		
+		
+		<!-- ADC -->
+        <peripheral>
+            <name>ADC</name>
+            <description>ADC unit</description>
+            <groupName>ADC</groupName>
+            <baseAddress>0x40020140</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x50</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CFG</name>
+                    <displayName>CFG</displayName>
+                    <description>CFG</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x000040fe</resetValue>
+                    <fields>
+					    <field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCME</name>
+                            <description>Enable VCM in ADC register</description>
+                        </field>
+                        <field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LE</name>
+                            <description>Internal LDO of ADC module</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>SMPCYC</name>
+                            <description>The interval between transitions</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>PSC</name>
+                            <description>ADC predivision</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>VS</name>
+                            <description>ADC reference voltage selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EN</name>
+                            <description>ADC enablement</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CR</name>
+                    <displayName>CR</displayName>
+                    <description>CR</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00400000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SR</name>
+                            <description>The software resets the internal state machine of the module</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OIE</name>
+                            <description>Overrun Interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WIE</name>
+                            <description>Threshold Watchdog interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IEM</name>
+                            <description>A/D interrupt mode bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>JIE</name>
+                            <description>Injection channel A/D transition interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RIE</name>
+                            <description>Rule channel A/D transition interrupt enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CE</name>
+                            <description>Hardware data calibration enable bit</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>JDEN</name>
+                            <description>Injection channel DMA enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RDEN</name>
+                            <description>Enable regular channel DMA</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CTU</name>
+                            <description>Continuous conversion</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AJC</name>
+                            <description>Automatically starts the injection channel group conversion</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DS</name>
+                            <description>Data expansion bit selection</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ALIGN</name>
+                            <description>Data alignment</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>JK</name>
+                            <description>The transformation of the injection channel begins</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>JTD</name>
+                            <description>Delay sampling is triggered outside the injection channel</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JTS</name>
+                            <description>Trigger source selection for the injection channel</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RK</name>
+                            <description>The conversion of the regular channel begins</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>RTD</name>
+                            <description>Delayed sampling is triggered externally by a regular channel</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RTS</name>
+                            <description>Trigger source selection for a rule channel</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>CHANNEL</name>
+                            <description>Current transfer channel</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BUSY</name>
+                            <description>Busy/idle flag</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WP</name>
+                            <description>Threshold watchdog flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>JEIF</name>
+                            <description>Injection channel A/D conversion end flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>REIF</name>
+                            <description>Rule channel A/D conversion end flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JP</name>
+                            <description>Injection channel conversion complete flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>RP</name>
+                            <description>Regular channel conversion complete flag bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>WDGCFG0</name>
+                    <displayName>WDGCFG0</displayName>
+                    <description>WDGCFG0</description>
+                    <addressOffset>0x0C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>CHS</name>
+                            <description>Watchdog channel selector bit</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHM</name>
+                            <description>Watchdog channel selection mode</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RE</name>
+                            <description>Turn on the watchdog in the regular aisle</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>JE</name>
+                            <description>Enable watchdog on the injection channel</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>HTH</name>
+                            <description>Watchdog high threshold</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>WDGCFG1</name>
+                    <displayName>WDGCFG1</displayName>
+                    <description>WDGCFG1</description>
+                    <addressOffset>0x10</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>LTH</name>
+                            <description>Watchdog low threshold</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RSEQCFG0</name>
+                    <displayName>RSEQCFG0</displayName>
+                    <description>RSEQCFG0</description>
+                    <addressOffset>0x14</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ7</name>
+                            <description>Channel configuration for rule sequence index 7</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ6</name>
+                            <description>Channel configuration for rule sequence index 6</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ5</name>
+                            <description>Channel configuration for rule sequence index 5</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ4</name>
+                            <description>Channel configuration for rule sequence index 4</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ3</name>
+                            <description>Channel configuration for rule sequence index 3</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ2</name>
+                            <description>Channel configuration for rule sequence index 2</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ1</name>
+                            <description>Channel configuration for rule sequence index 1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ0</name>
+                            <description>Channel configuration for rule sequence index 0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RSEQCFG1</name>
+                    <displayName>RSEQCFG1</displayName>
+                    <description>RSEQCFG1</description>
+                    <addressOffset>0x18</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ15</name>
+                            <description>Channel configuration for rule sequence index 15</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ14</name>
+                            <description>Channel configuration for rule sequence index 14</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ13</name>
+                            <description>Channel configuration for rule sequence index 13</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ12</name>
+                            <description>Channel configuration for rule sequence index 12</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ11</name>
+                            <description>Channel configuration for rule sequence index 11</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ10</name>
+                            <description>Channel configuration for rule sequence index 10</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ9</name>
+                            <description>Channel configuration for rule sequence index 9</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RSEQ8</name>
+                            <description>Channel configuration for rule sequence index 8</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RSEQCFG2</name>
+                    <displayName>RSEQCFG2</displayName>
+                    <description>RSEQCFG2</description>
+                    <addressOffset>0x1C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RT</name>
+                            <description>Number of indexes for each conversion triggered by a rule sequence</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RE</name>
+                            <description>Regular sequence conversion ends index</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>RS</name>
+                            <description>Regular sequence converts start index</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>JSEQCFG</name>
+                    <displayName>JSEQCFG</displayName>
+                    <description>JSEQCFG</description>
+                    <addressOffset>0x20</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>JT</name>
+                            <description>The number of indexes for each conversion triggered by the injection sequence</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>JE</name>
+                            <description>The injection sequence converts the end index</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>JS</name>
+                            <description>The injection sequence converts the star index</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JSEQ3</name>
+                            <description>Channel configuration for injection sequence index 3</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JSEQ2</name>
+                            <description>Channel configuration for injection sequence index 2</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JSEQ1</name>
+                            <description>Channel configuration for injection sequence index 1</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>JSEQ0</name>
+                            <description>Channel configuration for injection sequence index 0</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>JDATA0</name>
+                    <displayName>JDATA0</displayName>
+                    <description>JDATA0</description>
+                    <addressOffset>0x24</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VALID</name>
+                            <description>DATA Indicates a valid flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP</name>
+                            <description>Data override flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>DC</name>
+                            <description>Displays the channel corresponding to the current data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>DATA</name>
+                            <description>12-bit A/D conversion result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>JDATA1</name>
+                    <displayName>JDATA1</displayName>
+                    <description>JDATA1</description>
+                    <addressOffset>0x28</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VALID</name>
+                            <description>DATA Indicates a valid flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP</name>
+                            <description>Data override flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>DC</name>
+                            <description>Displays the channel corresponding to the current data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>DATA</name>
+                            <description>12-bit A/D conversion result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>JDATA2</name>
+                    <displayName>JDATA2</displayName>
+                    <description>JDATA2</description>
+                    <addressOffset>0x2C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VALID</name>
+                            <description>DATA Indicates a valid flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP</name>
+                            <description>Data override flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>DC</name>
+                            <description>Displays the channel corresponding to the current data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>DATA</name>
+                            <description>12-bit A/D conversion result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>JDATA3</name>
+                    <displayName>JDATA3</displayName>
+                    <description>JDATA3</description>
+                    <addressOffset>0x30</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VALID</name>
+                            <description>DATA Indicates a valid flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP</name>
+                            <description>Data override flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>DC</name>
+                            <description>Displays the channel corresponding to the current data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>DATA</name>
+                            <description>12-bit A/D conversion result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>DATA</name>
+                    <displayName>DATA</displayName>
+                    <description>DATA</description>
+                    <addressOffset>0x34</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VALID</name>
+                            <description>DATA Indicates a valid flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP</name>
+                            <description>Data override flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>DC</name>
+                            <description>Displays the channel corresponding to the current data</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>DATA</name>
+                            <description>12-bit A/D conversion result</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>BUFCAL</name>
+                    <displayName>BUFCAL</displayName>
+                    <description>BUFCAL</description>
+                    <addressOffset>0x4C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>BUFCAL</name>
+                            <description>Simulates internal buffer offset calibration control</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+
+
+		<!-- COMP0 -->
+        <peripheral>
+            <name>COMP0</name>
+            <description>COMP0 unit</description>
+            <groupName>COMP0</groupName>
+            <baseAddress>0x40020370</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LOCK</name>
+                            <description>Register lock</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WKUPEN</name>
+                            <description>Comparator wake up</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>EDGSEL</name>
+                            <description>Edge detection selection</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>INTEN</name>
+                            <description>Interrupt switch</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>FILTNUM</name>
+                            <description>Filter coefficient</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>INVEN</name>
+                            <description>The output of the comparator is inverted</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>HYST</name>
+                            <description>Hysteresis voltage selection</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>ILPS</name>
+                            <description>Low power control</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MUXN</name>
+                            <description>Negative input</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MUXP</name>
+                            <description>Positive input</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>VSRS</name>
+                            <description>Internal 6bit DAC voltage gear</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSAO</name>
+                            <description>Internal 6bit DAC output via VRSAOUT</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSEL</name>
+                            <description>Internal 6bit DAC reference source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSEN</name>
+                            <description>Internal 6bit DAC switch</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AEN</name>
+                            <description>Comparator module switch</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PEND</name>
+                            <description>Comparator PEND bit</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+
+
+		<!-- COMP1 -->
+        <peripheral>
+            <name>COMP1</name>
+            <description>COMP1 unit</description>
+            <groupName>COMP1</groupName>
+            <baseAddress>0x40020380</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LOCK</name>
+                            <description>Register lock</description>
+                        </field>
+						<field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WKUPEN</name>
+                            <description>Comparator wake up</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>EDGSEL</name>
+                            <description>Edge detection selection</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>INTEN</name>
+                            <description>Interrupt switch</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>FILTNUM</name>
+                            <description>Filter coefficient</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>INVEN</name>
+                            <description>The output of the comparator is inverted</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>HYST</name>
+                            <description>Hysteresis voltage selection</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>ILPS</name>
+                            <description>Low power control</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MUXN</name>
+                            <description>Negative input</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>MUXP</name>
+                            <description>Positive input</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>VSRS</name>
+                            <description>Internal 6bit DAC voltage gear</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSAO</name>
+                            <description>Internal 6bit DAC output via VRSAOUT</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSEL</name>
+                            <description>Internal 6bit DAC reference source</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VRSEN</name>
+                            <description>Internal 6bit DAC switch</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AEN</name>
+                            <description>Comparator module switch</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>STA</name>
+                    <displayName>STA</displayName>
+                    <description>STA</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PEND</name>
+                            <description>Comparator PEND bit</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+		
+		
+		<!-- OPAM0 -->
+        <peripheral>
+            <name>OPAM0</name>
+            <description>OPAM0 unit</description>
+            <groupName>OPAM0</groupName>
+            <baseAddress>0x40020390</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x08</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LOCK</name>
+                            <description>Register lock</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>NEGSEL</name>
+                            <description>Negative input selection</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>POSSEL</name>
+                            <description>Positive input selection</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PGASEL</name>
+                            <description>Unipolar/differential internal gain selection</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CMODE</name>
+                            <description>Working mode</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NEGEN</name>
+                            <description>Negative input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP2VAEN</name>
+                            <description>The op amp outputs to the ADC switch</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP2VOEN</name>
+                            <description>The op amp outputs to the IO switch</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PGAEN</name>
+                            <description>Internal gain switch</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>POSEN</name>
+                            <description>Positive input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCMEN</name>
+                            <description>VCM voltage mode</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AEN</name>
+                            <description>OPAM module switch</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- OPAM1 -->
+        <peripheral>
+            <name>OPAM1</name>
+            <description>OPAM1 unit</description>
+            <groupName>OPAM1</groupName>
+            <baseAddress>0x40020398</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x08</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LOCK</name>
+                            <description>Register lock</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>NEGSEL</name>
+                            <description>Negative input selection</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>POSSEL</name>
+                            <description>Positive input selection</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PGASEL</name>
+                            <description>Unipolar/differential internal gain selection</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CMODE</name>
+                            <description>Working mode</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NEGEN</name>
+                            <description>Negative input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP2VAEN</name>
+                            <description>The op amp outputs to the ADC switch</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>OP2VOEN</name>
+                            <description>The op amp outputs to the IO switch</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PGAEN</name>
+                            <description>Internal gain switch</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>POSEN</name>
+                            <description>Positive input switch</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>VCMEN</name>
+                            <description>VCM voltage mode</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AEN</name>
+                            <description>OPAM module switch</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- WDT -->
+        <peripheral>
+            <name>WDT</name>
+            <description>WDT unit</description>
+            <groupName>WDT</groupName>
+            <baseAddress>0x40020190</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CON</name>
+                    <displayName>CON</displayName>
+                    <description>CON</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000018</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WE</name>
+                            <description>Wake up enable</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WPEND</name>
+                            <description>The guard dog counts up the signs</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IE</name>
+                            <description>Interrupt enablement</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WES</name>
+                            <description>Watchdog enabled status</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>WPSR</name>
+                            <description>Frequency division coefficient</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>KEY</name>
+                    <displayName>KEY</displayName>
+                    <description>KEY</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>KEY</name>
+                            <description>WDT key</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>  
+		
+		
+		<!-- WWDG -->
+        <peripheral>
+            <name>WWDG</name>
+            <description>WWDG unit</description>
+            <groupName>WWDG</groupName>
+            <baseAddress>0x400201A0</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x10</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CR</name>
+                    <displayName>CR</displayName>
+                    <description>CR</description>
+                    <addressOffset>0x00</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000007f</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WDGA</name>
+                            <description>Activation bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>T</name>
+                            <description>7-bit counter</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CFR</name>
+                    <displayName>CFR</displayName>
+                    <description>CFR</description>
+                    <addressOffset>0x04</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000007f</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EWI</name>
+                            <description>Wake up early interrupt</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>WDGTB</name>
+                            <description>Time base</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>W</name>
+                            <description>7 bit window value</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SR</name>
+                    <displayName>SR</displayName>
+                    <description>SR</description>
+                    <addressOffset>0x08</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x0000007f</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>EWIF</name>
+                            <description>Wake up early interrupt flag</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral> 
+
+
+		<!-- DMA -->
+        <peripheral>
+            <name>DMA</name>
+            <description>DMA unit</description>
+            <groupName>DMA</groupName>
+            <baseAddress>0x40030000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x200</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>CH0CR</name>
+                    <displayName>CH0CR</displayName>
+                    <description>CH0CR</description>
+                    <addressOffset>0x0000</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 0 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 0 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 0</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 0 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 0 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 0 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH1CR</name>
+                    <displayName>CH1CR</displayName>
+                    <description>CH1CR</description>
+                    <addressOffset>0x0018</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 1 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 1 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 1</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 1 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 1 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 1 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH2CR</name>
+                    <displayName>CH2CR</displayName>
+                    <description>CH2CR</description>
+                    <addressOffset>0x0030</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 2 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 2 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 2</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 2 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 2 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 2 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH3CR</name>
+                    <displayName>CH3CR</displayName>
+                    <description>CH3CR</description>
+                    <addressOffset>0x0048</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 3 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 3 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 3</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 3 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 3 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 3 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH4CR</name>
+                    <displayName>CH4CR</displayName>
+                    <description>CH4CR</description>
+                    <addressOffset>0x0060</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 4 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 4 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 4</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 4 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 4 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 4 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH5CR</name>
+                    <displayName>CH5CR</displayName>
+                    <description>CH5CR</description>
+                    <addressOffset>0x0078</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 5 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 5 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 5</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 5 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 5 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 5 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH6CR</name>
+                    <displayName>CH6CR</displayName>
+                    <description>CH6CR</description>
+                    <addressOffset>0x0090</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 6 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 6 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 6</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 6 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 6 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 6 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH7CR</name>
+                    <displayName>CH7CR</displayName>
+                    <description>CH7CR</description>
+                    <addressOffset>0x00A8</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>TRGSRC</name>
+                            <description>Hardware is sent from peripherals</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>AUTORL</name>
+                            <description>Channel 7 Automatic overload enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FIXAEN</name>
+                            <description>Channel 7 Fixed address enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>CHPRI</name>
+                            <description>Priority of channel 7</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCAMOD</name>
+                            <description>Channel 7 Source address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSTAMOD</name>
+                            <description>Channel 7 Destination address mode selection bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>DWIDTH</name>
+                            <description>Data bit width select bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWTRIG</name>
+                            <description>Software trigger control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CHEN</name>
+                            <description>Channel 7 Enable control bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH0SADR</name>
+                    <displayName>CH0SADR</displayName>
+                    <description>CH0SADR</description>
+                    <addressOffset>0x0004</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 0 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH1SADR</name>
+                    <displayName>CH1SADR</displayName>
+                    <description>CH1SADR</description>
+                    <addressOffset>0x001C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 1 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH2SADR</name>
+                    <displayName>CH2SADR</displayName>
+                    <description>CH2SADR</description>
+                    <addressOffset>0x0034</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 2 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH3SADR</name>
+                    <displayName>CH3SADR</displayName>
+                    <description>CH3SADR</description>
+                    <addressOffset>0x004C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 3 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH4SADR</name>
+                    <displayName>CH4SADR</displayName>
+                    <description>CH4SADR</description>
+                    <addressOffset>0x0064</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 4 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH5SADR</name>
+                    <displayName>CH5SADR</displayName>
+                    <description>CH5SADR</description>
+                    <addressOffset>0x007C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 5 Source address</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CH6SADR</name>
+                    <displayName>CH6SADR</displayName>
+                    <description>CH6SADR</description>
+                    <addressOffset>0x0094</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 6 Source address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH7SADR</name>
+                    <displayName>CH7SADR</displayName>
+                    <description>CH7SADR</description>
+                    <addressOffset>0x00AC</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SADR</name>
+                            <description>Channel 7 Source address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH0DADR</name>
+                    <displayName>CH0DADR</displayName>
+                    <description>CH0DADR</description>
+                    <addressOffset>0x0008</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 0 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH1DADR</name>
+                    <displayName>CH1DADR</displayName>
+                    <description>CH1DADR</description>
+                    <addressOffset>0x0020</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 1 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH2DADR</name>
+                    <displayName>CH2DADR</displayName>
+                    <description>CH2DADR</description>
+                    <addressOffset>0x0038</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 2 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH3DADR</name>
+                    <displayName>CH3DADR</displayName>
+                    <description>CH3DADR</description>
+                    <addressOffset>0x0050</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 3 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH4DADR</name>
+                    <displayName>CH4DADR</displayName>
+                    <description>CH4DADR</description>
+                    <addressOffset>0x0068</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 4 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH5DADR</name>
+                    <displayName>CH5DADR</displayName>
+                    <description>CH5DADR</description>
+                    <addressOffset>0x0080</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 5 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH6DADR</name>
+                    <displayName>CH6DADR</displayName>
+                    <description>CH6DADR</description>
+                    <addressOffset>0x0098</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 6 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH7DADR</name>
+                    <displayName>CH7DADR</displayName>
+                    <description>CH7DADR</description>
+                    <addressOffset>0x00B0</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>DADR</name>
+                            <description>Channel 7 Destination address</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH0TSR</name>
+                    <displayName>CH0TSR</displayName>
+                    <description>CH0TSR</description>
+                    <addressOffset>0x0010</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 0 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 0 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH1TSR</name>
+                    <displayName>CH1TSR</displayName>
+                    <description>CH1TSR</description>
+                    <addressOffset>0x0028</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 1 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 1 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH2TSR</name>
+                    <displayName>CH2TSR</displayName>
+                    <description>CH2TSR</description>
+                    <addressOffset>0x0040</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 2 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 2 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH3TSR</name>
+                    <displayName>CH3TSR</displayName>
+                    <description>CH3TSR</description>
+                    <addressOffset>0x0058</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 3 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 3 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH4TSR</name>
+                    <displayName>CH4TSR</displayName>
+                    <description>CH4TSR</description>
+                    <addressOffset>0x0070</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 4 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 4 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH5TSR</name>
+                    <displayName>CH5TSR</displayName>
+                    <description>CH5TSR</description>
+                    <addressOffset>0x0088</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 5 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 5 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH6TSR</name>
+                    <displayName>CH6TSR</displayName>
+                    <description>CH6TSR</description>
+                    <addressOffset>0x00A0</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 6 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 6 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH7TSR</name>
+                    <displayName>CH7TSR</displayName>
+                    <description>CH7TSR</description>
+                    <addressOffset>0x00B8</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>BLKCNT</name>
+                            <description>Number of channel 7 blocks processed</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>BLKLEN</name>
+                            <description>Length of the channel 7 block</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH0CTSR</name>
+                    <displayName>CH0CTSR</displayName>
+                    <description>CH0CTSR</description>
+                    <addressOffset>0x0014</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 0 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 0 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH1CTSR</name>
+                    <displayName>CH1CTSR</displayName>
+                    <description>CH1CTSR</description>
+                    <addressOffset>0x002C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 1 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 1 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH2CTSR</name>
+                    <displayName>CH2CTSR</displayName>
+                    <description>CH2CTSR</description>
+                    <addressOffset>0x0044</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 2 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 2 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH3CTSR</name>
+                    <displayName>CH3CTSR</displayName>
+                    <description>CH3CTSR</description>
+                    <addressOffset>0x005C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 3 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 3 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH4CTSR</name>
+                    <displayName>CH4CTSR</displayName>
+                    <description>CH4CTSR</description>
+                    <addressOffset>0x0074</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 4 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 4 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH5CTSR</name>
+                    <displayName>CH5CTSR</displayName>
+                    <description>CH5CTSR</description>
+                    <addressOffset>0x008C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 5 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 5 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH6CTSR</name>
+                    <displayName>CH6CTSR</displayName>
+                    <description>CH6CTSR</description>
+                    <addressOffset>0x00A4</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 6 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 6 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CH7CTSR</name>
+                    <displayName>CH7CTSR</displayName>
+                    <description>CH7CTSR</description>
+                    <addressOffset>0x00BC</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>CBLKCNT</name>
+                            <description>Channel 7 Indicates the number of blocks</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>CBLKLEN</name>
+                            <description>Channel 7 Indicates the current block length</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>ISR0</name>
+                    <displayName>ISR0</displayName>
+                    <description>ISR0</description>
+                    <addressOffset>0x0120</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA5</name>
+                            <description>Channel 5 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA5</name>
+                            <description>Channel 5 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA5</name>
+                            <description>Channel 5 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA5</name>
+                            <description>Channel 5 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA4</name>
+                            <description>Channel 4 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA4</name>
+                            <description>Channel 4 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA4</name>
+                            <description>Channel 4 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA4</name>
+                            <description>Channel 4 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA3</name>
+                            <description>Channel 3 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA3</name>
+                            <description>Channel 3 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA3</name>
+                            <description>Channel 3 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA3</name>
+                            <description>Channel 3 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA2</name>
+                            <description>Channel 2 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA2</name>
+                            <description>Channel 2 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA2</name>
+                            <description>Channel 2 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA2</name>
+                            <description>Channel 2 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA1</name>
+                            <description>Channel 1 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA1</name>
+                            <description>Channel 1 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA1</name>
+                            <description>Channel 1 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA1</name>
+                            <description>Channel 1 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA0</name>
+                            <description>Channel 0 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA0</name>
+                            <description>Channel 0 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA0</name>
+                            <description>Channel 0 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA0</name>
+                            <description>Channel 0 block processing end interrupt status bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>ISR1</name>
+                    <displayName>ISR1</displayName>
+                    <description>ISR1</description>
+                    <addressOffset>0x0124</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA7</name>
+                            <description>Channel 7 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA7</name>
+                            <description>Channel 7 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA7</name>
+                            <description>Channel 7 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA7</name>
+                            <description>Channel 7 block processing end interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEISTA6</name>
+                            <description>Channel 6 Transmission error interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCISTA6</name>
+                            <description>Channel 6 Transmission completion interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTISTA6</name>
+                            <description>Channel 6 half transmission interrupt status bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEISTA6</name>
+                            <description>Channel 6 block processing end interrupt status bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>IER0</name>
+                    <displayName>IER0</displayName>
+                    <description>IER0</description>
+                    <addressOffset>0x0130</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>29</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE5</name>
+                            <description>Channel 5 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>28</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE5</name>
+                            <description>Channel 5 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE5</name>
+                            <description>Channel 5 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE5</name>
+                            <description>Channel 5 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE4</name>
+                            <description>Channel 4 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE4</name>
+                            <description>Channel 4 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE4</name>
+                            <description>Channel 4 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE4</name>
+                            <description>Channel 4 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE3</name>
+                            <description>Channel 3 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE3</name>
+                            <description>Channel 3 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE3</name>
+                            <description>Channel 3 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE3</name>
+                            <description>Channel 3 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE2</name>
+                            <description>Channel 2 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE2</name>
+                            <description>Channel 2 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE2</name>
+                            <description>Channel 2 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE2</name>
+                            <description>Channel 2 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE1</name>
+                            <description>Channel 1 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE1</name>
+                            <description>Channel 1 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE1</name>
+                            <description>Channel 1 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE1</name>
+                            <description>Channel 1 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE0</name>
+                            <description>Channel 0 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE0</name>
+                            <description>Channel 0 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE0</name>
+                            <description>Channel 0 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE0</name>
+                            <description>Channel 0 block processing end interrupt enable control bit</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>IER1</name>
+                    <displayName>IER1</displayName>
+                    <description>IER1</description>
+                    <addressOffset>0x0134</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE7</name>
+                            <description>Channel 7 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE7</name>
+                            <description>Channel 7 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE7</name>
+                            <description>Channel 7 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE7</name>
+                            <description>Channel 7 block processing end interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TEIE6</name>
+                            <description>Channel 6 Transmission error interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TCIE6</name>
+                            <description>Channel 6 Transmission complete interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HTIE6</name>
+                            <description>Channel 6 half transmission interrupt enable control bit</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>BEIE6</name>
+                            <description>Channel 6 block processing end interrupt enable control bit</description>
+                        </field>
+                    </fields>
+                </register>
+            </registers>
+        </peripheral> 
+
+
+		<!-- SYSTEM -->
+        <peripheral>
+            <name>SYSTEM</name>
+            <description>SYSTEM unit</description>
+            <groupName>SYSTEM</groupName>
+            <baseAddress>0x40020000</baseAddress>
+            <addressBlock>
+                <offset>0x0</offset>
+                <size>0x80</size>
+                <usage>registers</usage>
+            </addressBlock>
+            <registers>
+				<register>
+                    <name>SYSKEY</name>
+                    <displayName>SYSKEY</displayName>
+                    <description>SYSKEY</description>
+                    <addressOffset>0x0000</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000001</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>32</bitWidth>
+                            <name>SK</name>
+                            <description>System register write is enabled</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>SYSCON0</name>
+                    <displayName>SYSCON0</displayName>
+                    <description>SYSCON0</description>
+                    <addressOffset>0x0004</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x069f9040</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FRE</name>
+                            <description>Quick release reset</description>
+                        </field>
+						<field>
+                            <bitOffset>30</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SGE</name>
+                            <description>Reset when the system wakes up</description>
+                        </field>
+						<field>
+                            <bitOffset>27</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>SDC</name>
+                            <description>IO wake up delay SLEEP_DLY_CNT system clock cycles</description>
+                        </field>
+						<field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DSR</name>
+                            <description>IO buffeting circuit software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CRCSR</name>
+                            <description>CRC computing unit software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HSR</name>
+                            <description>HWDIV software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>GSR</name>
+                            <description>GPIO related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>19</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>ASR</name>
+                            <description>ADC related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>U1SR</name>
+                            <description>UART1 related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>U0SR</name>
+                            <description>UART0 related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SI1SR</name>
+                            <description>SPI_IIC1 related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SI0SR</name>
+                            <description>SPI_IIC0 related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CMPSR</name>
+                            <description>COMP_OPAM related register software reset control</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>TSR</name>
+                            <description>TIMER related register software reset control</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>SYSCON1</name>
+                    <displayName>SYSCON1</displayName>
+                    <description>SYSCON1</description>
+                    <addressOffset>0x0008</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000300</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>STOF</name>
+                            <description>TIMER Output channel Output is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CMIS</name>
+                            <description>The MCLR function was enabled in CP mode</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WLGE</name>
+                            <description>The watchdog automatically turns off the clock when it enters sleep/stop mode</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>DE</name>
+                            <description>DEBUG enable</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>IRE</name>
+                            <description>Map interrupt entry from FLASH to SRAM</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NIS</name>
+                            <description>NMI pin polarity reverse selection</description>
+                        </field>
+						<field>
+                            <bitOffset>9</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CMSE</name>
+                            <description>Select the system clock in CP mode</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SWDE</name>
+                            <description>SWD Enables the control function</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LWE</name>
+                            <description>LVDVCC wakes up the system in interrupt mode</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SERE</name>
+                            <description>Returns an error signal to the CPU</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SEIE</name>
+                            <description>The NMI interrupt is triggered</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RXEVE</name>
+                            <description>The CPU received events was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>NIE</name>
+                            <description>PB5 triggers the NMI interrupt function</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LOCKE</name>
+                            <description>The system reset is triggered when an out-of-bounds address is accessed twice</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SYSCON2</name>
+                    <displayName>SYSCON2</displayName>
+                    <description>SYSCON2</description>
+                    <addressOffset>0x000C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PBDE</name>
+                            <description>PB antishudder control</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>PADE</name>
+                            <description>PA antishudder control</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SYSCON3</name>
+                    <displayName>SYSCON3</displayName>
+                    <description>SYSCON3</description>
+                    <addressOffset>0x0010</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>PCDE</name>
+                            <description>PC antishudder control</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CLKCON0</name>
+                    <displayName>CLKCON0</displayName>
+                    <description>CLKCON0</description>
+                    <addressOffset>0x0024</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>LDCS</name>
+                            <description>LVD anti-shake clock selection</description>
+                        </field>
+						<field>
+                            <bitOffset>6</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>GDCS</name>
+                            <description>GPIO anti-shake clock selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>SCS</name>
+                            <description>System clock selection</description>
+                        </field>
+                    </fields>
+                </register>
+                <register>
+                    <name>CLKCON1</name>
+                    <displayName>CLKCON1</displayName>
+                    <description>CLKCON1</description>
+                    <addressOffset>0x0028</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0xf8000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>6</bitWidth>
+                            <name>SCD</name>
+                            <description>System clock frequency division</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CLKCON2</name>
+                    <displayName>CLKCON2</displayName>
+                    <description>CLKCON2</description>
+                    <addressOffset>0x002C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x07878ff4</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>26</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>COMPCE</name>
+                            <description>The COMP_OPAM clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>CRCCE</name>
+                            <description>The CRC clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>FMCE</name>
+                            <description>The FLASH erase or write clock function is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HCE</name>
+                            <description>The HWDIV clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>U1CE</name>
+                            <description>The UART1 clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>U0CE</name>
+                            <description>The UART0 clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SI1CE</name>
+                            <description>The SPI_IIC1 clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>15</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SI0CE</name>
+                            <description>The SPI_IIC0 clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>11</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>WCE</name>
+                            <description>The WWDG clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>7</bitWidth>
+                            <name>TCE</name>
+                            <description>The TIMERx clock is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRCE</name>
+                            <description>The SRAM0 clock is enabled</description>
+                        </field>
+                    </fields>
+                </register>
+				<register>
+                    <name>CLKCON3</name>
+                    <displayName>CLKCON3</displayName>
+                    <description>CLKCON3</description>
+                    <addressOffset>0x0030</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x80020240</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>31</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HEF</name>
+                            <description>HIRC_CLK Enables the flag bit</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>12</bitWidth>
+                            <name>HFSC</name>
+                            <description>HIRC_CLK frequency control</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HE</name>
+                            <description>HIRC_CLK Enables control</description>
+                        </field>
+						<field>
+                            <bitOffset>10</bitOffset>
+                            <bitWidth>2</bitWidth>
+                            <name>HFSEL</name>
+                            <description>HIRC frequency selection</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>HFT</name>
+                            <description>HIRC temperature compensation coefficient</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>5</bitWidth>
+                            <name>HFFS</name>
+                            <description>HIRC fine tune control </description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HASEL</name>
+                            <description>HIRC simulation test selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HASEN</name>
+                            <description>Enable HIRC simulation test</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>SYSERR</name>
+                    <displayName>SYSERR</displayName>
+                    <description>SYSERR</description>
+                    <addressOffset>0x0048</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>0</bitWidth>
+                            <name>CE</name>
+                            <description>The clock uses an error flag</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SE</name>
+                            <description>System bus access out of bounds address error flag</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>WKUPCON</name>
+                    <displayName>WKUPCON</displayName>
+                    <description>WKUPCON</description>
+                    <addressOffset>0x004C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>24</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>CWP</name>
+                            <description>Software write 1 Clear WKUP_PEND</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>WP</name>
+                            <description>IO edge wake up flag</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>WEDGE</name>
+                            <description>Wake up edge selection</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>WEN</name>
+                            <description>IO edge detection wakes up</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>LPCON</name>
+                    <displayName>LPCON</displayName>
+                    <description>LPCON</description>
+                    <addressOffset>0x0050</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000020</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PLSE</name>
+                            <description>PMU_V2IEN is disabled</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PLHE</name>
+                            <description>The hardware automatically disables PMU_V2IEN</description>
+                        </field>
+						<field>
+                            <bitOffset>5</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RSE</name>
+                            <description>LIRC_256K is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>RAD</name>
+                            <description>LIRC_256K is automatically closed when you enter sleep mode</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HAD</name>
+                            <description>HIRC is automatically closed when you enter sleep mode</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SAD</name>
+                            <description>SRAM CE is automatically closed when you enter sleep mode</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SCM</name>
+                            <description>STOP mode</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SLEEP</name>
+                            <description>SLEEP mode</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>CHIPID_DCN</name>
+                    <displayName>CHIPID_DCN</displayName>
+                    <description>CHIPID_DCN</description>
+                    <addressOffset>0x005C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000008</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>8</bitWidth>
+                            <name>CDCN</name>
+                            <description>Record version changes</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>16</bitWidth>
+                            <name>CID</name>
+                            <description>Chip ID</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>MODE</name>
+                    <displayName>MODE</displayName>
+                    <description>MODE</description>
+                    <addressOffset>0x0060</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PMUCON0</name>
+                    <displayName>PMUCON0</displayName>
+                    <description>PMUCON0</description>
+                    <addressOffset>0x0064</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x10177800</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>25</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>PH</name>
+                            <description>Normal mode BG VREF voltage control</description>
+                        </field>
+						<field>
+                            <bitOffset>23</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PIS</name>
+                            <description>The internal temperature sensor was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>22</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>HPX</name>
+                            <description>Internal LDO configuration options</description>
+                        </field>
+						<field>
+                            <bitOffset>21</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PV</name>
+                            <description>VREFMOM Voltage output</description>
+                        </field>
+						<field>
+                            <bitOffset>20</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PHE</name>
+                            <description>Analog bias current enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PHLI</name>
+                            <description>VDD LDO weak pull-down resistance switch</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PHI</name>
+                            <description>VDD LDO pulldown resistance switch</description>
+                        </field>
+						<field>
+                            <bitOffset>14</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PLIS</name>
+                            <description>Low power reference current control</description>
+                        </field>
+						<field>
+                            <bitOffset>13</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PHL</name>
+                            <description>The LDO function in common mode is enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>12</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PHX</name>
+                            <description>Internal LDO was enabled</description>
+                        </field>
+						<field>
+                            <bitOffset>8</bitOffset>
+                            <bitWidth>4</bitWidth>
+                            <name>PLS</name>
+                            <description>ULPBG VREF voltage control</description>
+                        </field>
+						<field>
+                            <bitOffset>7</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PID</name>
+                            <description>Deep sleep current switch</description>
+                        </field>
+						<field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PLD</name>
+                            <description>Low power mode LDO voltage selection</description>
+                        </field>
+						<field>
+                            <bitOffset>3</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>PLSS</name>
+                            <description>PMU low power acceleration</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PHP</name>
+                            <description>Normal mode LDO voltage selection</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>RPCON</name>
+                    <displayName>RPCON</displayName>
+                    <description>RPCON</description>
+                    <addressOffset>0x0068</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000000</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>18</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LRC</name>
+                            <description>Software Write 1 Clear LOCK_RESET_PEND</description>
+                        </field>
+						<field>
+                            <bitOffset>17</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRC</name>
+                            <description>Software Write 1 Clear SOFT_RESET_PEND</description>
+                        </field>
+						<field>
+                            <bitOffset>16</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SSC</name>
+                            <description>Software Write 1 Clear SLEEP_PEND</description>
+                        </field>
+						<field>
+                            <bitOffset>2</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>LRP</name>
+                            <description>The CPU LOCK RESET flag bit occurs</description>
+                        </field>
+						<field>
+                            <bitOffset>1</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SRP</name>
+                            <description>The software writes 1 to the bit to trigger the system reset</description>
+                        </field>
+						<field>
+                            <bitOffset>0</bitOffset>
+                            <bitWidth>1</bitWidth>
+                            <name>SP</name>
+                            <description>Enter the sleep mode flag bit</description>
+                        </field>
+                    </fields>
+                </register> 
+				<register>
+                    <name>PMU_BK</name>
+                    <displayName>PMU_BK</displayName>
+                    <description>PMU_BK</description>
+                    <addressOffset>0x006C</addressOffset>
+                    <size>0x20</size>
+                    <access>read-write</access>
+                    <resetValue>0x00000010</resetValue>
+                    <fields>
+                        <field>
+                            <bitOffset>4</bitOffset>
+                            <bitWidth>3</bitWidth>
+                            <name>PL</name>
+                            <description>Low power mode LDO voltage tap selection</description>
+                        </field>
+                    </fields>
+                </register> 
+            </registers>
+        </peripheral>      
+    </peripherals>
+</device>

--- a/pyocd/target/builtin/__init__.py
+++ b/pyocd/target/builtin/__init__.py
@@ -138,6 +138,7 @@ from . import target_STM32H7B0xx
 from . import target_Air001
 from . import target_Air32F103xx
 from . import target_AMA3B1KK
+from . import target_EG6832
 
 ## @brief Dictionary of all builtin targets.
 #
@@ -314,6 +315,7 @@ BUILTIN_TARGETS = {
           'ytm32b1me0': target_ytm32b1me0.YTM32B1ME0,
           'ytm32b1md1': target_ytm32b1md1.YTM32B1MD1,
           'air001': target_Air001.Air001,
+          'eg6832': target_EG6832.EG6832,
           'air32f103xb': target_Air32F103xx.Air32F103xB,
           'air32f103xc': target_Air32F103xx.Air32F103xC,
           'air32f103xp': target_Air32F103xx.Air32F103xP,

--- a/pyocd/target/builtin/target_EG6832.py
+++ b/pyocd/target/builtin/target_EG6832.py
@@ -1,0 +1,120 @@
+# pyOCD debugger
+# Copyright (c) 2023 microcai
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...coresight.coresight_target import CoreSightTarget
+from ...core.memory_map import (FlashRegion, RamRegion, MemoryMap)
+from ...debug.svd.loader import SVDFile
+
+# pyOCD debugger
+# Copyright (c) 2024 PyOCD Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FLASH_ALGO = {
+    'load_address' : 0x20000000,
+
+    # Flash algorithm as a hex string
+    'instructions': [
+    0xe7fdbe00,
+    0x4770ba40, 0x4770ba40, 0x4770bac0, 0x4770bac0, 0x211ab508, 0x90004348, 0xd0012800, 0xe7fa1e40,
+    0x493bbd08, 0x22016188, 0xe00003d2, 0x69cb61ca, 0xd5fb041b, 0x0a404770, 0x47704770, 0xb5104770,
+    0x48344a35, 0x48326010, 0x69813840, 0x01090909, 0x61811cc9, 0x24016b10, 0x43a00464, 0x200a6310,
+    0xffd6f7ff, 0x43206b10, 0x200a6310, 0xffd0f7ff, 0x21036b10, 0x43880289, 0x184011a1, 0x6b106310,
+    0xdafc2800, 0xf7ff2032, 0x6a50ffc3, 0x00800880, 0x62501c80, 0xf7ff2032, 0x2000ffbb, 0xbd106010,
+    0xb672b500, 0x481e491d, 0x491e6141, 0xf7ff6141, 0x2000ffc6, 0x2000bd00, 0x48154770, 0x3840b510,
+    0xf8acf000, 0x49154816, 0x49166141, 0x20006141, 0x01c0bd10, 0x480e0c01, 0x3840b510, 0xf895f000,
+    0xbd102000, 0x1cc9b5f8, 0x4f09088c, 0x461500a4, 0x3f404606, 0x4632e008, 0x46382102, 0xf000682b,
+    0x1f24f831, 0x1d361d2d, 0xd1f42c00, 0xbdf82000, 0x40020280, 0x3fac87e4, 0x40020000, 0x0000aaaa,
+    0x40020180, 0x0000dddd, 0x04122201, 0x68012901, 0x4391d002, 0x47706001, 0xe7fb4311, 0x47706181,
+    0x6181496c, 0xe7ef2100, 0xd0012900, 0xe0002100, 0x62014969, 0x29004770, 0x2100d001, 0x4967e000,
+    0x47706241, 0x4604b510, 0x21004865, 0x46204002, 0xfff1f7ff, 0x612360e2, 0x064068a0, 0xbd10d5fc,
+    0x4604b510, 0x2100485e, 0x46204002, 0xffdcf7ff, 0x07402001, 0x60e01810, 0x68a06123, 0xd5fc0640,
+    0x2101bd10, 0x428a0409, 0x2102d201, 0x2102e7da, 0xb500e7e6, 0x4602460b, 0xd20f2980, 0x07c06890,
+    0x2100d0fc, 0xf7ff4610, 0x0658ffc6, 0x0e402101, 0x18400789, 0x68906150, 0xd0fc07c0, 0xb500bd00,
+    0x4602460b, 0xd20f2909, 0x07c06890, 0x2100d0fc, 0xf7ff4610, 0x0658ffa9, 0x0e402103, 0x18400749,
+    0x68906150, 0xd0fc07c0, 0x2980bd00, 0xe7d0d200, 0xd2022989, 0xb2893980, 0x4770e7e1, 0x4602b500,
+    0x07806890, 0x2100d5fc, 0xf7ff4610, 0x2001ff94, 0x615007c0, 0x07806890, 0xbd00d5fc, 0x42994b31,
+    0x425bd305, 0x4b3018c9, 0x1d1b4019, 0x628118c9, 0x684162c2, 0x43114a2d, 0x68816041, 0xd5fc0549,
+    0x47706b00, 0x4926b530, 0x400a9c03, 0x06496881, 0x6801d5fc, 0x02ad2501, 0x60014329, 0x628360c2,
+    0x684162c4, 0x43114a21, 0x68816041, 0xd5fc0549, 0x43a96801, 0xbd306001, 0x491bb530, 0x400a9c03,
+    0x06496881, 0x6801d5fc, 0x02ad2501, 0x60014329, 0x04eab291, 0x60c11889, 0x62c46283, 0x4a136841,
+    0x60414311, 0x05496881, 0x6801d5fc, 0x600143a9, 0x6801bd30, 0x03122201, 0x60014311, 0x68014770,
+    0x03122201, 0x60014391, 0x6b004770, 0x6c004770, 0x00004770, 0x00004041, 0x20150931, 0x20170230,
+    0x0000fffc, 0x1ff00000, 0x1ffffffc, 0x04000400, 0x00000000
+    ],
+
+    # Relative function addresses
+    'pc_init': 0x200000a5,
+    'pc_unInit': 0x200000bb,
+    'pc_program_page': 0x200000e9,
+    'pc_erase_sector': 0x200000d7,
+    'pc_eraseAll': 0x200000bf,
+
+    'static_base' : 0x20000000 + 0x00000004 + 0x00000310,
+    'begin_stack' : 0x20002000,
+    'end_stack' : 0x20001720,
+    'begin_data' : 0x20000000 + 0x1000,
+    'page_size' : 0x400,
+    'analyzer_supported' : False,
+    'analyzer_address' : 0x00000000,
+    # Enable double buffering
+    'page_buffers' : [
+        0x20000320,
+        0x20000b20
+    ],
+    'min_program_length' : 0x200,
+
+    # Relative region addresses and sizes
+    'ro_start': 0x4,
+    'ro_size': 0x310,
+    'rw_start': 0x314,
+    'rw_size': 0x4,
+    'zi_start': 0x318,
+    'zi_size': 0x0,
+
+    # Flash information
+    'flash_start': 0x0,
+    'flash_size': 0x10000,
+    'sector_sizes': (
+        (0x0, 0x200),
+    )
+}
+
+class EG6832(CoreSightTarget):
+
+    VENDOR = "EG6832"
+
+    MEMORY_MAP = MemoryMap(
+        FlashRegion(start=0x0000_0000, length=0x10000,
+                    blocksize=0x400,
+                    is_boot_memory=True, algo=FLASH_ALGO),
+        RamRegion(start=0x2000_0000,  length=0x1000)
+        )
+
+    def __init__(self, session):
+        super(EG6832, self).__init__(session, self.MEMORY_MAP)
+        self._svd_location = SVDFile.from_builtin("EG32M0x.svd")


### PR DESCRIPTION
EG6832 is made by EGmicro.com.
this little MCU has 8k sram +64k flash.
flash is located at 0x00000000 rather than 0x8000000 :)

must first use  pyocd erase -t eg6832 --chip, then pyocd load -t eg6832 xxx.hex

now tested by the eval board selled at [EG6832 eval board](https://item.taobao.com/item.htm?abbucket=6&id=724129170854&ns=1&skuId=5208082079091)
