### PR TITLE
dependencies: remove capstone

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,6 @@ python_requires = >=3.7.0
 # importlib_resources is used instead of stdlib importlib.resources because we
 # want the selectable entry_points API, which is not present until Python 3.10.
 install_requires =
-    capstone>=4.0,<5.0
     cmsis-pack-manager>=0.5.2,<1.0
     colorama<1.0
     hidapi>=0.10.1,<1.0; platform_system != "Linux"
@@ -75,6 +74,7 @@ pemicro =
 test =
     pytest>=6.2
     pytest-cov
+    capstone>=4.0,<5.0
     coverage
     flake8
     pylint
@@ -111,4 +111,3 @@ exclude =
     test_user_script.py,
     # Ignore gdb test script for similar reasons.
     gdb_test_script.py
-


### PR DESCRIPTION
the implementation already supports that capstone may not be installed. capstone is somewhat slow to install on some platforms (e.g. raspberry pi), and not always needed.