### PR TITLE
rtos: Add hint for zephyr’s Thread Info configuration

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -32,6 +32,9 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
 
     steps:
     # Only check out HEAD. We don't need the full history.

--- a/.github/workflows/basic_test_skipped.yaml
+++ b/.github/workflows/basic_test_skipped.yaml
@@ -29,5 +29,8 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
     steps:
       - run: 'echo "Skipped due to path filter."'

--- a/pyocd/rtos/provider.py
+++ b/pyocd/rtos/provider.py
@@ -53,14 +53,15 @@ class ThreadProvider(object):
         self._last_run_token = -1
         self._read_from_target = False
 
-    def _lookup_symbols(self, symbolList, symbolProvider):
+    def _lookup_symbols(self, symbolList, symbolProvider, allowPartial = False):
         syms = {}
         for name in symbolList:
             addr = symbolProvider.get_symbol_value(name)
             LOG.debug("Value for symbol %s = %s", name, hex(addr) if addr is not None else "<none>")
-            if addr is None:
+            if addr is not None:
+                syms[name] = addr
+            elif not allowPartial:
                 return None
-            syms[name] = addr
         return syms
 
     def init(self, symbolProvider):

--- a/pyocd/rtos/zephyr.py
+++ b/pyocd/rtos/zephyr.py
@@ -274,8 +274,12 @@ class ZephyrThreadProvider(ThreadProvider):
 
     def init(self, symbolProvider):
         # Lookup required symbols.
-        self._symbols = self._lookup_symbols(self.ZEPHYR_SYMBOLS, symbolProvider)
+        self._symbols = self._lookup_symbols(self.ZEPHYR_SYMBOLS, symbolProvider, True)
         if self._symbols is None:
+            return False
+        if len(self._symbols) != len(self.ZEPHYR_SYMBOLS):
+            LOG.warning("Zephyr kernel detected. Build your Zephyr application with `CONFIG_DEBUG_THREAD_INFO=y` to " +
+                        "enable thread awareness.")
             return False
 
         self._update()


### PR DESCRIPTION
This should allow for easier discoverability of the `CONFIG_DEBUG_THREAD_INFO` parameter.