### PR TITLE
Verify flash contents after programming

### DIFF
--- a/pyocd/core/options.py
+++ b/pyocd/core/options.py
@@ -146,6 +146,8 @@ BUILTIN_OPTIONS = [
         "Name of test firmware binary."),
     OptionInfo('user_script', str, None,
         "Path of the user script file."),
+    OptionInfo('verify', bool, True,
+        "Controls whether a verify pass should be performed after flash programming has finished. Default is True"),
     OptionInfo('warning.cortex_m_default', bool, True,
         "Whether to show the warning about use of the cortex_m target type. Default is True."),
 

--- a/pyocd/flash/builder.py
+++ b/pyocd/flash/builder.py
@@ -132,6 +132,11 @@ class _FlashSector:
         for page in self.page_list:
             page.same = False
 
+    def mark_all_pages_unknown(self):
+        """@brief Sets the same flag to False for all pages in this sector."""
+        for page in self.page_list:
+            page.same = None
+
     def __repr__(self):
         return "<_FlashSector@%x addr=%x size=%x wgt=%g pages=%s, subsectors=%d>" % (
             id(self), self.addr, self.size, self.erase_weight, self.page_list, self.n_subsectors)
@@ -417,7 +422,7 @@ class FlashBuilder(MemoryBuilder):
                 page = add_page_with_existing_data()
                 sector_page_addr += page.size
 
-    def program(self, chip_erase=None, progress_cb=None, smart_flash=True, fast_verify=False, keep_unwritten=True, no_reset=False):
+    def program(self, chip_erase=None, progress_cb=None, smart_flash=True, fast_verify=False, keep_unwritten=True, no_reset=False, verify=True):
         """@brief Determine fastest method of flashing and then run flash programming.
 
         Data must have already been added with add_data().
@@ -443,6 +448,8 @@ class FlashBuilder(MemoryBuilder):
             data. This parameter sets whether the existing contents of those unwritten ranges will
             be read from memory and restored while programming.
         @param no_reset Boolean indicating whether if the device should not be reset after the
+            programming process has finished.
+        @param verify Boolean indicating whether a verify pass should be performed after the
             programming process has finished.
         """
 
@@ -535,12 +542,6 @@ class FlashBuilder(MemoryBuilder):
             else:
                 flash_operation = self._sector_erase_program(progress_cb)
 
-        # Cleanup flash algo and reset target after programming.
-        self.flash.cleanup()
-
-        if no_reset is not True:
-            self.flash.target.reset_and_halt()
-
         program_finish = time()
         self.perf.program_time = program_finish - program_start
         self.perf.program_type = flash_operation
@@ -570,6 +571,23 @@ class FlashBuilder(MemoryBuilder):
         self.perf.erase_sector_count = erase_sector_count
         self.perf.skipped_byte_count = skipped_byte_count
         self.perf.skipped_page_count = skipped_page_count
+
+        if verify:
+            LOG.info("Verifying")
+            # Reset same flag for all pages to enable rescanning
+            for sector in self.sector_list:
+                sector.mark_all_pages_unknown()
+            self._scan_pages_for_same(progress_cb)
+            failed_pages = [page for page in self.page_list if page.same is False]
+            if failed_pages:
+                LOG.debug("Verify failed for pages {}".format(failed_pages))
+                raise FlashProgramFailure('flash verify failure', address=failed_pages[0].addr)
+
+        # Cleanup flash algo and reset target after programming.
+        self.flash.cleanup()
+
+        if no_reset is not True:
+            self.flash.target.reset_and_halt()
 
         if self.log_performance:
             if chip_erase:
@@ -899,12 +917,6 @@ class FlashBuilder(MemoryBuilder):
                 if self.sector_erase_weight > 0:
                     progress_cb(float(progress) / float(self.sector_erase_weight))
 
-        # If we have to program any pages of a sector, then mark all pages of that sector
-        # as needing to be programmed, since the sector will be erased.
-        for sector in self.sector_list:
-            if sector.are_any_pages_not_same():
-                sector.mark_all_pages_not_same()
-
         return progress
 
     def _next_nonsame_page(self, i):
@@ -937,6 +949,8 @@ class FlashBuilder(MemoryBuilder):
             self.flash.init(self.flash.Operation.ERASE)
             for sector in self.sector_list:
                 if sector.are_any_pages_not_same():
+                    # If the sector is erased, all its pages must be programmed
+                    sector.mark_all_pages_not_same()
                     # Erase the sector
                     for addr in sector.addrs:
                         self.flash.erase_sector(addr)

--- a/pyocd/flash/file_programmer.py
+++ b/pyocd/flash/file_programmer.py
@@ -65,7 +65,8 @@ class FileProgrammer(object):
             smart_flash: Optional[bool] = None,
             trust_crc: Optional[bool] = None,
             keep_unwritten: Optional[bool] = None,
-            no_reset: Optional[bool] = None
+            no_reset: Optional[bool] = None,
+            verify: Optional[bool] = None
         ):
         """@brief Constructor.
 
@@ -88,6 +89,8 @@ class FileProgrammer(object):
             be read from memory and restored while programming.
         @param no_reset Boolean indicating whether if the device should not be reset after the
             programming process has finished.
+        @param verify Boolean indicating whether a verify pass should be performed after the
+            programming process has finished.
         """
         self._session = session
         self._chip_erase = chip_erase
@@ -95,6 +98,7 @@ class FileProgrammer(object):
         self._trust_crc = trust_crc
         self._keep_unwritten = keep_unwritten
         self._no_reset = no_reset
+        self._verify = verify
         self._progress = progress
         self._loader = None
 
@@ -154,7 +158,8 @@ class FileProgrammer(object):
                                     smart_flash=self._smart_flash,
                                     trust_crc=self._trust_crc,
                                     keep_unwritten=self._keep_unwritten,
-                                    no_reset=self._no_reset)
+                                    no_reset=self._no_reset,
+                                    verify=self._verify)
 
         # file_obj = None
         # Open the file if a path was provided.

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -146,6 +146,7 @@ class MemoryLoader:
     _trust_crc: Optional[bool]
     _keep_unwritten: Optional[bool]
     _no_reset: Optional[bool]
+    _verify: Optional[bool]
 
     def __init__(self,
             session: "Session",
@@ -154,7 +155,8 @@ class MemoryLoader:
             smart_flash: Optional[bool] = None,
             trust_crc: Optional[bool] = None,
             keep_unwritten: Optional[bool] = None,
-            no_reset: Optional[bool] = None
+            no_reset: Optional[bool] = None,
+            verify: Optional[bool] = None
         ):
         """@brief Constructor.
 
@@ -176,6 +178,8 @@ class MemoryLoader:
             data. This parameter sets whether the existing contents of those unwritten ranges will
             be read from memory and restored while programming.
         @param no_reset Boolean indicating whether if the device should not be reset after the
+            programming process has finished.
+        @param verify Boolean indicating whether a verify pass should be performed after the
             programming process has finished.
         """
         self._session = session
@@ -201,6 +205,8 @@ class MemoryLoader:
                             else self._session.options.get('keep_unwritten')
         self._no_reset = no_reset if (no_reset is not None) \
                             else self._session.options.get('no_reset')
+        self._verify = verify if (verify is not None) \
+                            else self._session.options.get('verify')
 
         self._reset_state()
 
@@ -297,7 +303,8 @@ class MemoryLoader:
                                     smart_flash=self._smart_flash,
                                     fast_verify=self._trust_crc,
                                     keep_unwritten=self._keep_unwritten,
-                                    no_reset=self._no_reset)
+                                    no_reset=self._no_reset,
+                                    verify=self._verify)
             perfList.append(perf)
             didChipErase = True
 

--- a/pyocd/subcommands/load_cmd.py
+++ b/pyocd/subcommands/load_cmd.py
@@ -101,7 +101,8 @@ class LoadSubcommand(SubcommandBase):
             programmer = FileProgrammer(session,
                             chip_erase=self._args.erase,
                             trust_crc=self._args.trust_crc,
-                            no_reset=self._args.no_reset)
+                            no_reset=self._args.no_reset,
+                            verify=self._args.verify)
             for filename in self._args.file:
                 # Get an initial path with the argument as-is.
                 file_path = Path(filename).expanduser()


### PR DESCRIPTION
Add an option, on by default, to read out flash contents after programming and compare it to the programmed data. Without it, bugs in flash loader algos and other problems will silently leave flash corrupted.

Ref: #1700, #1696 