### PR TITLE
Test (dupplicated PR) gdbserver: be stricter about qC

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -32,6 +32,9 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
 
     steps:
     # Only check out HEAD. We don't need the full history.

--- a/.github/workflows/basic_test_skipped.yaml
+++ b/.github/workflows/basic_test_skipped.yaml
@@ -29,5 +29,8 @@ jobs:
         - "3.9"
         - "3.10"
         - "3.11"
+        exclude:
+          - os: macos-latest
+            python-version: "3.7"
     steps:
       - run: 'echo "Skipped due to path filter."'

--- a/pyocd/gdbserver/gdbserver.py
+++ b/pyocd/gdbserver/gdbserver.py
@@ -954,7 +954,7 @@ class GDBServer(threading.Thread):
                 # Must return an empty packet for an unrecognized qXfer.
                 return self.create_rsp_packet(b"")
 
-        elif query[0].startswith(b'C'):
+        elif query[0] == b'C':
             if not self.is_threading_enabled():
                 return self.create_rsp_packet(b"QC1")
             else:


### PR DESCRIPTION
Don't match only the prefix of qC. Otherwise, compare-sections in gdb will fail, due to qCRC returning a thread ID.