### PR TITLE
Update GitHub Actions Workflows

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -21,26 +21,27 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os:
         - ubuntu-latest
         - macos-latest
         - windows-latest
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
 
     steps:
     # Only check out HEAD. We don't need the full history.
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -48,11 +49,12 @@ jobs:
     # Python versions on all OSes.
     - name: Get pip cache dir
       id: pip-cache
+      shell: bash
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Setup pip cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.cfg') }}
@@ -90,9 +92,9 @@ jobs:
         twine check dist/*
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pytest-results-${{ matrix.python-version }}
+        name: pytest-results-${{ matrix.os }}-${{ matrix.python-version }}
         path: |
           test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
           .coverage*

--- a/.github/workflows/basic_test_skipped.yaml
+++ b/.github/workflows/basic_test_skipped.yaml
@@ -24,10 +24,11 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
+        - "3.12"
+
     steps:
       - run: 'echo "Skipped due to path filter."'

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -27,11 +27,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,7 +40,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -14,7 +14,7 @@ jobs:
     environment: docs-deployment
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: 'pyocd/pyocd-website-source'
           token: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
### Update step output of pip-cache
Workflow commands via echo are now deprecated in favour of writing to special files instead.

### Change python versions to test against:
* Remove Python 3.7 which is now EOL
* Add Python 3.12 which is latest release version
    * Python 3.12 tests will fail until  #1710 is merged.

### Update all outdated GitHub Actions:
* [actions/checkout](https://github.com/actions/checkout) v3 -> v4
    * Update action runtime to Node 20
* [actions/setup-python](https://github.com/actions/setup-python) v4 -> v5
    * Update action runtime to Node 20
* [actions/upload-artifact](https://github.com/actions/upload-artifact) v3 -> v4
    * Update action runtime to Node 20
    * [Action now errors on duplicate artifacts so add OS name to test output artifacts](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact)
* [actions/cache](https://github.com/actions/cache) v3 -> v4
    * Update action runtime to Node 20
* [github/codeql-action](https://github.com/github/codeql-action) v2 -> v3
    * Update action runtime to Node 20