### PR TITLE
coresight: discovery: Avoid double offset in root component creation

### DIFF
--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -262,7 +262,7 @@ class ADIv6Discovery(CoreSightDiscovery):
             memif = APAccessMemoryInterface(self.dp, ap_address)
 
             # Instantiate the component and attach to the target.
-            component = cmpid.factory(memif, cmpid, cmpid.address)
+            component = cmpid.factory(memif, cmpid, 0)
             self.target.add_child(component)
             component.init()
         except exceptions.Error as e:


### PR DESCRIPTION
Because the APAccessMemoryInterface includes and offset and the component factory API includes an address base, the base address offset at cpmid.address was being applied twice.