### PR TITLE
Avoid potential exception

### DIFF
--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2006-2020 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # Copyright (c) 2022 Harper Weigle
+# Copyright (c) 2025 Schneider-Electric
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -133,6 +134,8 @@ class HidApiUSB(Interface):
         boards = []
 
         for deviceInfo in devices:
+            if deviceInfo['product_string'] is None:
+                continue
             product_name = to_str_safe(deviceInfo['product_string'])
             known_cmsis_dap = is_known_cmsis_dap_vid_pid(deviceInfo['vendor_id'], deviceInfo['product_id'])
             if ("CMSIS-DAP" not in product_name) and (not known_cmsis_dap):


### PR DESCRIPTION
when 'product_name' is not specified
(a call to to_str_safe() will trigger an exception)