### PR TITLE
Add missing return to UserScriptFunctionProxy

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -599,7 +599,7 @@ class UserScriptFunctionProxy:
         for arg in self._spec.args:
             if arg in kwargs:
                 args[arg] = kwargs[arg]
-        self._fn(**args)
+        return self._fn(**args)
 
 class UserScriptDelegateProxy:
     """@brief Delegate proxy for user scripts."""


### PR DESCRIPTION
Commit 4ece4ed introduced optional user script function arguments, but it looks like the `return` went missing.

Without it it is not possible to override `start_debug_core`, because return value is always `None`.