### PR TITLE
Update workflows following various deprecations

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -93,9 +93,9 @@ jobs:
         twine check dist/*
 
     - name: Upload pytest test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: pytest-results-${{ matrix.python-version }}
+        name: pytest-results-${{ matrix.python-version }}-${{ matrix.os }}
         path: |
           test-results-${{ matrix.os }}-${{ matrix.python-version }}.xml
           .coverage*

--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -27,14 +27,12 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
-        exclude:
-          - os: macos-latest
-            python-version: "3.7"
+        - "3.12"
+        - "3.13"
 
     steps:
     # Only check out HEAD. We don't need the full history.

--- a/.github/workflows/basic_test_skipped.yaml
+++ b/.github/workflows/basic_test_skipped.yaml
@@ -24,13 +24,12 @@ jobs:
         - macos-latest
         - windows-latest
         python-version:
-        - "3.7"
         - "3.8"
         - "3.9"
         - "3.10"
         - "3.11"
-        exclude:
-          - os: macos-latest
-            python-version: "3.7"
+        - "3.12"
+        - "3.13"
+
     steps:
       - run: 'echo "Skipped due to path filter."'

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -31,7 +31,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -40,7 +40,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/test/unit/test_autoflush.py
+++ b/test/unit/test_autoflush.py
@@ -21,9 +21,11 @@ from .conftest import mock
 from pyocd.core.exceptions import TransferError
 from pyocd.utility.autoflush import Autoflush
 
+
 @pytest.fixture(scope='function')
 def mock_obj():
     return mock.Mock()
+
 
 class TestAutoflush:
     def test_flushed(self, mock_obj):
@@ -35,5 +37,4 @@ class TestAutoflush:
         with pytest.raises(TransferError):
             with Autoflush(mock_obj):
                 raise TransferError("bad joojoo")
-        assert mock_obj.flush.not_called
-
+        mock_obj.flush.assert_not_called()


### PR DESCRIPTION
Updates the following:
- upload-artifact from v3 to v4
- codeql from v2 to v3
- drops tests for python 3.7
- Adds tests for python 3.12 and 3.13
- Fixes `AttributeError` on `AutoFlush` tests