### PR TITLE
doc: fix elf API example remove_breakpoint call

### DIFF
--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -84,7 +84,7 @@ with ConnectHelper.session_with_chosen_probe() as session:
     assert pc == addr & ~0x01                         # mask off LSB
 
     # Remove breakpoint.
-    target.remove_breakpoint()
+    target.remove_breakpoint(addr)
 ```
 
 Note that you currently need to manually remove a breakpoint in order to step or run over it.


### PR DESCRIPTION
Small fix to elf API example which was found while experimenting with the pyocd python API.

remove_breakpoint() expects the addr of the breakpoint to remove.