### PR TITLE
Fix CoreSight discovery

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2015-2020,2025 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -206,10 +206,11 @@ class APAddressBase:
     address format.
     """
 
-    def __init__(self, address: int, dp: int = 0) -> None:
+    def __init__(self, address: int, dp: int = 0, apid: int = 0) -> None:
         """@brief Constructor accepting the nominal address."""
         self._nominal_address = address
         self._dp = dp
+        self._apid = apid
 
     @property
     def ap_version(self) -> APVersion:
@@ -240,6 +241,11 @@ class APAddressBase:
     def dp_index(self) -> int:
         """@brief Index of the DP to which this AP is attached."""
         return self._dp
+
+    @property
+    def apid(self) -> int:
+        """@brief Unique AP identifier."""
+        return self._apid
 
     def __hash__(self) -> int:
         return hash(self.nominal_address | (self._dp << 64))

--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -794,6 +794,10 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
             LOG.debug("%s implemented HPROT=%x HNONSEC=%x", self.short_description, self._impl_hprot,
                     self._impl_hnonsec)
 
+            if (self._flags & AP_SPROT):
+                if (original_csw & CSW_SDEVICEEN) == 0:
+                    self._hnonsec = NONSECURE
+
             # Update current HPROT and HNONSEC, and the current base CSW value.
             self.hprot = self._hprot & self._impl_hprot
             self.hnonsec = self._hnonsec & self._impl_hnonsec
@@ -1361,6 +1365,7 @@ AP_4K_WRAP = 0x1 # The AP has a 4 kB auto-increment modulus.
 AP_ALL_TX_SZ = 0x2 # The AP is known to support 8-, 16-, and 32-bit transfers, *unless* Large Data is implemented.
 AP_MSTRTYPE = 0x4 # The AP is known to support the MSTRTYPE field.
 AP_DBGSWEN = 0x8 # The AP is known to support the DBGSWEN flag.
+AP_SPROT = 0x10 # The AP is known to support the SPROT field.
 
 ## Map from AP IDR fields to AccessPort subclass.
 #
@@ -1386,20 +1391,20 @@ AP_TYPE_MAP: Dict[Tuple[int, int, int, int], Tuple[str, Type[AccessPort], int]] 
 #   |JEP106        |Class              |Var|Type                    |Name      |Class
     (AP_JEP106_ARM, AP_CLASS_JTAG_AP,   0,  0):                     ("JTAG-AP", AccessPort, 0   ),
     (AP_JEP106_ARM, AP_CLASS_COM_AP,    0,  0):                     ("SDC-600", AccessPort, 0   ),
-    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ ),
+    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ|AP_SPROT ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    1,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ|AP_4K_WRAP|AP_MSTRTYPE ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    2,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    3,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    4,  AP_TYPE_AHB):           ("AHB-AP",  AHB_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_APB):           ("APB-AP",  MEM_AP,     AP_DBGSWEN   ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AXI):           ("AXI-AP",  MEM_AP,     AP_ALL_TX_SZ ),
-    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB5):          ("AHB5-AP", AHB_AP,     AP_ALL_TX_SZ ),
+    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB5):          ("AHB5-AP", AHB_AP,     AP_ALL_TX_SZ|AP_SPROT ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    1,  AP_TYPE_AHB5):          ("AHB5-AP", AHB_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    2,  AP_TYPE_AHB5):          ("AHB5-AP", AHB_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_APB4):          ("APB4-AP", MEM_AP,     0   ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AXI5):          ("AXI5-AP", MEM_AP,     AP_ALL_TX_SZ ),
     (AP_JEP106_ARM, AP_CLASS_MEM_AP,    1,  AP_TYPE_AXI5):          ("AXI5-AP", MEM_AP,     AP_ALL_TX_SZ ),
-    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB5_HPROT):    ("AHB5-AP", MEM_AP,     AP_ALL_TX_SZ ),
+    (AP_JEP106_ARM, AP_CLASS_MEM_AP,    0,  AP_TYPE_AHB5_HPROT):    ("AHB5-AP", MEM_AP,     AP_ALL_TX_SZ|AP_SPROT ),
     (AP_JEP106_ARM_CHINA,
                     AP_CLASS_MEM_AP,    1,  AP_TYPE_AHB5):          ("AHB5-AP", AHB_AP,     AP_ALL_TX_SZ ),
     }

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2019-2020,2025 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -258,8 +258,9 @@ class ADIv6Discovery(CoreSightDiscovery):
         """
         try:
             # Create a memory interface for this component.
-            ap_address = APv2Address(cmpid.address)
-            memif = APAccessMemoryInterface(self.dp, ap_address)
+            # ap_address = APv2Address(cmpid.address)
+            # memif = APAccessMemoryInterface(self.dp, ap_address)
+            memif = APAccessMemoryInterface(self.dp)
 
             # Instantiate the component and attach to the target.
             component = cmpid.factory(memif, cmpid, cmpid.address)

--- a/pyocd/debug/sequences/sequences.py
+++ b/pyocd/debug/sequences/sequences.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2020,2025 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -380,7 +380,7 @@ class DebugSequence(DebugSequenceNode):
             scope.set('__ap', default_ap_address.nominal_address
                                 if isinstance(default_ap_address, APv1Address)
                                 else 0)
-            scope.set('__apid',  default_ap_address.nominal_address
+            scope.set('__apid',  default_ap_address.apid
                                     if isinstance(default_ap_address, APv2Address)
                                     else 0)
 

--- a/pyocd/target/pack/cmsis_pack.py
+++ b/pyocd/target/pack/cmsis_pack.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pyOCD debugger
-# Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2019-2020,2025 Arm Limited
 # Copyright (c) 2020 Men Shiyun
 # Copyright (c) 2020 Fraunhofer-Gesellschaft zur Förderung der angewandten Forschung e.V.
 # Copyright (c) 2021-2023 Chris Reed
@@ -352,7 +352,7 @@ class CmsisPackDescription:
         return list(map.values())
 
     def _inherit_attributes(self, to_elem: Element, from_elem: Optional[Element]) -> Element:
-        """@brief Add attributes missing from an elemnt but present in another.
+        """@brief Add attributes missing from an element but present in another.
 
         Copy to `to_elem` any attributes defined in `from_elem` but not defined, and therefore overridden,
         in `to_elem`.
@@ -1157,20 +1157,22 @@ class CmsisPackDevice:
                             f"{self.pack_description.pack_name} DFP ({self.part_number}): <{accessport.tag}> "
                             f"'__dp' attribute is invalid ({ap_dp})")
 
+                # Get the __apid attribute.
+                apid = self._get_int_attribute(accessport, '__apid')
+
                 # APv1
                 if accessport.tag == 'accessportV1':
                     index = self._get_int_attribute(accessport, 'index')
-                    ap_address = APv1Address(index, ap_dp)
+                    ap_address = APv1Address(index, ap_dp, apid)
                 # APv2
                 elif accessport.tag == 'accessportV2':
                     address = self._get_int_attribute(accessport, 'address')
-                    ap_address = APv2Address(address, ap_dp)
+                    ap_address = APv2Address(address, ap_dp, apid)
                 else:
                     raise exceptions.InternalError(
                             f"unexpected element <{accessport.tag}> in access ports list")
 
-                # Save this AP address and the specified __apid.
-                apid = self._get_int_attribute(accessport, '__apid')
+                # Save this AP address.
                 self._apids[apid] = ap_address
             except MalformedCmsisPackError as err:
                 LOG.warning("%s", err)


### PR DESCRIPTION
This pull request addresses the following issues:
* Offset address in root component creation for devices with AccessPort V2 is applied twice, which results in wrong address (seen on Alif Enseble E7).
https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/127,
#1717
* AP access failure due to invalid security flags (SPROT).
https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/131
* Flash programming on devices with Access Port v2 causes an error during debug sequence execution, because an invalid `apid` is used.
https://github.com/Open-CMSIS-Pack/vscode-cmsis-debugger/issues/132