### PR TITLE
Memory map filtering by 'pname'

### DIFF
--- a/pyocd/core/memory_map.py
+++ b/pyocd/core/memory_map.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2019 Arm Limited
+# Copyright (c) 2015-2019,2025 Arm Limited
 # Copyright (c) 2021-2022 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -780,7 +780,7 @@ class MemoryMap(MemoryRangeBase, collections.abc.Sequence):
                 return r
         return None
 
-    def get_region_for_address(self, address: int) -> Optional[MemoryRegion]:
+    def get_region_for_address(self, address: int, pname: Optional[str] = None) -> Optional[MemoryRegion]:
         """@brief Returns the first region containing the given address.
 
         @param self
@@ -788,6 +788,8 @@ class MemoryMap(MemoryRangeBase, collections.abc.Sequence):
         @return MemoryRegion or None.
         """
         for r in self._regions:
+            if (pname is not None) and (r.attributes.get('pname') not in (None, pname)):
+                continue
             if r.contains_address(address):
                 return r
         return None

--- a/pyocd/coresight/coresight_target.py
+++ b/pyocd/coresight/coresight_target.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2015-2020 Arm Limited
+# Copyright (c) 2015-2020,2025 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -301,7 +301,13 @@ class CoreSightTarget(SoCTarget):
 
         # Update the memory map in each core.
         for core in self.cores.values():
-            core.memory_map = self.memory_map
+            pname_memory = []
+            for memory in self.memory_map:
+                pname = memory.attributes.get('pname')
+                if (pname is not None) and (pname != core.node_name):
+                    continue
+                pname_memory.append(memory)
+            core.memory_map = MemoryMap(pname_memory)
 
     def check_for_cores(self) -> None:
         """@brief Init task: verify that at least one core was discovered."""

--- a/pyocd/flash/loader.py
+++ b/pyocd/flash/loader.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2019 Arm Limited
+# Copyright (c) 2018-2019,2025 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -229,7 +229,7 @@ class MemoryLoader:
         """
         while len(data):
             # Look up the memory region for this address.
-            region = self._map.get_region_for_address(address)
+            region = self._map.get_region_for_address(address, self._session.target.selected_core.node_name)
             if region is None:
                 raise ValueError("no memory region defined for address 0x%08x" % address)
 


### PR DESCRIPTION
Changes in this pull request:
* On multi core devices the memory map is updated per core (filtered per `pname`).
* Memory region lookup is filtered by selected core (`pname`).