### PR TITLE
Improve support for cbuild-run targets

### DIFF
--- a/pyocd/core/session.py
+++ b/pyocd/core/session.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2018-2020 Arm Limited
+# Copyright (c) 2018-2020,2025 Arm Limited
 # Copyright (c) 2021-2023 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -548,7 +548,11 @@ class Session(Notifier):
 
             self._probe.open()
             self._closed = False
-            self._probe.set_clock(self.options.get('frequency'))
+            frequency = self.options.get('frequency')
+            if self.options.is_set('cbuild_run'):
+                if self.target.debugger_clock is not None:
+                    frequency = self.target.debugger_clock
+            self._probe.set_clock(frequency)
             if init_board:
                 self._board.init()
                 self._inited = True

--- a/pyocd/target/pack/cbuild_run.py
+++ b/pyocd/target/pack/cbuild_run.py
@@ -118,7 +118,7 @@ class CbuildRunTargetMethods:
         """
         processors_map = {}
         for core in self.cores.values():
-            if core.node_name is None:
+            if core.node_name is None or core.node_name == 'Unknown':
                 core.node_name = core.name
 
             for proc in self._cbuild_device.processors_map.values():
@@ -250,8 +250,7 @@ class CbuildRunTargetMethods:
     def _cbuild_target_add_core(_self, core: CoreTarget) -> None:
         """@brief Override to set node name of added core to its pname."""
         pname = _self._cbuild_device.processors_ap_map[cast(CortexM, core).ap.address].name
-        if 'Unknown' not in pname:
-            core.node_name = pname
+        core.node_name = pname
         CoreSightTarget.add_core(_self, core)
 
     @staticmethod

--- a/pyocd/target/pack/cbuild_run.py
+++ b/pyocd/target/pack/cbuild_run.py
@@ -483,6 +483,11 @@ class CbuildRun:
         return {}
 
     @property
+    def debugger_clock(self) -> Optional[int]:
+        """@brief Debugger clock frequency in Hz."""
+        return self.debugger.get('clock', None)
+
+    @property
     def start_pname(self) -> Optional[str]:
         """@brief Selected start processor name."""
         pname = self.debugger.get('start-pname')
@@ -538,6 +543,7 @@ class CbuildRun:
         # Generate target subclass and install it.
         tgt = type(target.capitalize(), (CoreSightTarget,), {
                     "_cbuild_device": self,
+                    "debugger_clock": self.debugger_clock,
                     "__init__": CbuildRunTargetMethods._cbuild_target_init,
                     "create_init_sequence": CbuildRunTargetMethods._cbuild_target_create_init_sequence,
                     "update_processor_name" : CbuildRunTargetMethods._cbuild_target_update_processor_name,

--- a/pyocd/target/pack/cbuild_run.py
+++ b/pyocd/target/pack/cbuild_run.py
@@ -531,11 +531,9 @@ class CbuildRun:
         elif target != normalise_target_type_name(self.target):
             return
 
-        # Check if we're even going to populate this target.
+        # Check if we're overwriting an existing target.
         if target in TARGET:
-            LOG.debug("did not populate target from cbuild-run.yml for device %s because "
-                      "there is already a %s target installed", self.target, target)
-            return
+            LOG.info("Internal target %s already exists, overwriting with cbuild-run target", target)
 
         # Generate target subclass and install it.
         tgt = type(target.capitalize(), (CoreSightTarget,), {


### PR DESCRIPTION
Changes in this pull request:
- When using cbuild-run target the debug probe clock is set based on `debugger`:`clock` node in `cbuild-run.yml` file.
- Target defined with cbuild-run will overwrite internal target when `--cbuild-run` option is used.
- Always set `core.node_name` when cbuild-run target is used.