### PR TITLE
update_capstone_to_5.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ python_requires = >=3.8.0
 # importlib_resources is used instead of stdlib importlib.resources because we
 # want the selectable entry_points API, which is not present until Python 3.10.
 install_requires =
-    capstone>=4.0,<5.0
+    capstone>=5.0,<6.0
     cmsis-pack-manager>=0.5.2,<1.0
     colorama<1.0
     hidapi>=0.10.1,<1.0; platform_system != "Linux"


### PR DESCRIPTION
Just inorder to fix warning: 

capstone\__init__.py:267: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources


https://github.com/capstone-engine/capstone/issues/2341