### PR TITLE
probe: jlink: check if APv1 before accessing APSEL

### DIFF
--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2020 Arm Limited
+# Copyright (c) 2020,2025 Arm Limited
 # Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2023 Marian Muller Rebeyrol
 # SPDX-License-Identifier: Apache-2.0
@@ -28,6 +28,7 @@ from ..core.memory_interface import MemoryInterface
 from ..core import exceptions
 from ..core.plugin import Plugin
 from ..core.options import OptionInfo
+from ..coresight.ap import APVersion
 from ..utility import conversion
 from ..utility.compatibility import to_str_safe
 
@@ -457,10 +458,13 @@ class JLinkProbe(DebugProbe):
 
     def get_memory_interface_for_ap(self, ap_address):
         assert self._is_open
+        # JLink memory access commands only support an 8-bit APSEL
+        if ap_address.ap_version != APVersion.APv1:
+            return None
         # JLink memory access commands only support AP 0
         if ap_address.apsel != 0:
             return None
-        # JLink memory access commands require to be conneected to the target
+        # JLink memory access commands require to be connected to the target
         if not self._link.target_connected():
             return None
         apsel = ap_address.apsel


### PR DESCRIPTION
- JLink memory access commands only support an 8-bit APSEL