### PR TITLE
probe: CMSIS-DAP: fix no data returned from jtag_sequence

### DIFF
--- a/pyocd/probe/cmsis_dap_probe.py
+++ b/pyocd/probe/cmsis_dap_probe.py
@@ -371,7 +371,7 @@ class CMSISDAPProbe(DebugProbe):
         TRACE.debug("trace: jtag_sequence(cycles=%i, tms=%x, read_tdo=%s, tdi=%x)", cycles, tms, read_tdo, tdi)
 
         try:
-            self._link.jtag_sequence(cycles, tms, read_tdo, tdi)
+            return self._link.jtag_sequence(cycles, tms, read_tdo, tdi)
         except DAPAccess.Error as exc:
             raise self._convert_exception(exc) from exc
 

--- a/pyocd/probe/pydapaccess/cmsis_dap_core.py
+++ b/pyocd/probe/pydapaccess/cmsis_dap_core.py
@@ -485,7 +485,7 @@ class CMSISDAPProtocol(object):
             raise DAPAccessIntf.CommandError("DAP_JTAG_SEQUENCE failed")
 
         if len(resp) > 2:
-            return resp[2]
+            return resp[2:]
 
     def jtag_configure(self, devices_irlen=None):
         # Default to a single device with an IRLEN of 4.


### PR DESCRIPTION
-  CMSIS dap probe does not return response data within _cmsis_dap_probe.py_
- Within _cmsis_dap_core.py_ the full read data is not returned, but only single byte

Tested with a Cypress/Infineon Miniprog4 on a low level jtag interface implementation