### PR TITLE
SWO thread exit fix.

### DIFF
--- a/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
+++ b/pyocd/probe/pydapaccess/interface/pyusb_v2_backend.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2019-2021 Arm Limited
 # Copyright (c) 2021 mentha
 # Copyright (c) 2021-2023 Chris Reed
+# Copyright (c) 2025 Lars Häring
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
SWO thread exit was set in RX thread. Fixed now
by setting RX thread exit flag instead.

Closes #1755.