### PR TITLE
Remove deprecated github action command

### DIFF
--- a/.github/workflows/basic_test.yaml
+++ b/.github/workflows/basic_test.yaml
@@ -1,4 +1,5 @@
 # Copyright (c) 2021-2022 Chris Reed
+# Copyright (c) 2025 Antonio Chiu
 
 # pyocd workflow for:
 # - checking code with flake8


### PR DESCRIPTION
Basically we change 
`run: echo "::set-output name={name}::{value}"`
to
`run: echo "{name}={value}" >> $GITHUB_OUTPUT`