### PR TITLE
probe: cmsis-dap: hidapi backend: fix HID report sizing

### DIFF
--- a/pyocd/probe/pydapaccess/interface/hidapi_backend.py
+++ b/pyocd/probe/pydapaccess/interface/hidapi_backend.py
@@ -205,6 +205,8 @@ class HidApiUSB(Interface):
             # Update report sizes
             self.report_in_size = in_report_size
             self.report_out_size = out_report_size
+            LOG.debug("Updated HID report sizes: IN=%s, OUT=%s",
+                      self.report_in_size, self.report_out_size)
             return True
 
         except Exception as e:


### PR DESCRIPTION
- General: Remove PyUSB-based EP size logic and the assumption that wMaxPacketSize == report_size. Do not use PyUSB, since mixing with hidapi can be problematic (PyUSB Find failed in some cases)
- MacOS: retrieve the HID report descriptor via hidapi and parse report sizes directly from that descriptor. Use actual report sizes for writes and reads. Apply padding/trimming manually since hidapi does not do it on macOS.
- Windows: Revert to using DAP packet_size for writes and reads. Rely on hidapi to handle padding/trimming.