### PR TITLE
Use first available RAM region for RTT CB search if device doesn't have default RAM

### DIFF
--- a/pyocd/debug/rtt.py
+++ b/pyocd/debug/rtt.py
@@ -409,6 +409,12 @@ class GenericRTTControlBlock(RTTControlBlock):
         if address is None:
             memory_map: MemoryMap = self.target.get_memory_map()
             ram_region: MemoryRegion = memory_map.get_default_region_of_type(MemoryType.RAM)
+            if ram_region is None:
+                ram_region = memory_map.get_first_matching_region(
+                    type=MemoryType.RAM)
+            if ram_region is None:
+                raise exceptions.RTTError(
+                    "No RAM region found for control block search")
 
             self._cb_search_address = ram_region.start
             if size is None:


### PR DESCRIPTION
Some devices do not have default RAM region marked in the CMSIS pack file.

For example, STM32U073CC has this problem in CMSIS pack ver `Keil::STM32U0xx_DFP@2.1.0`.

This fix will check if default region is None, then attempt to use first available RAM region.

