### PR TITLE
coresight: discovery: don't add cores not described in debug topology

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -243,6 +243,10 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         # Add the new core to the root target.
         root.add_core(core)
 
+        # Check if core was added to the root target.
+        if core.core_number not in root.cores:
+            return None
+
         root._new_core_num += 1
 
         return core

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -54,7 +54,9 @@ class CoreSightDiscovery(object):
         try:
             LOG.debug("Creating %s component", cmpid.name)
             cmp = cmpid.factory(cmpid.ap, cmpid, cmpid.address)
-            cmp.init()
+            # Call component's init method if it was created successfully
+            if cmp is not None:
+                cmp.init()
         except exceptions.Error as err:
             LOG.error("Error attempting to create component %s: %s", cmpid.name, err,
                     exc_info=self.session.log_tracebacks)

--- a/pyocd/target/pack/cbuild_run.py
+++ b/pyocd/target/pack/cbuild_run.py
@@ -172,9 +172,9 @@ class CbuildRunTargetMethods:
         proc = _self._cbuild_device.processors_ap_map.get(cast(CortexM, core).ap.address)
         if proc is not None:
             core.node_name = proc.name
+            CoreSightTarget.add_core(_self, core)
         else:
-            LOG.info("Found core without 'pname' description (core %s)", core.core_number)
-        CoreSightTarget.add_core(_self, core)
+            LOG.info("Skipping core not described in debug topology")
 
     @staticmethod
     def _cbuild_target_get_output(_self) -> Dict[str, Tuple[str, Optional[int]]]:

--- a/pyocd/target/pack/pack_target.py
+++ b/pyocd/target/pack/pack_target.py
@@ -432,9 +432,9 @@ class _PackTargetMethods:
         proc = _self._pack_device.processors_ap_map.get(cast(CortexM, core).ap.address)
         if proc is not None:
             core.node_name = proc.name
+            CoreSightTarget.add_core(_self, core)
         else:
-            LOG.info("Found core without 'pname' description (core %s)", core.core_number)
-        CoreSightTarget.add_core(_self, core)
+            LOG.info("Skipping core not described in debug topology")
 
     @staticmethod
     def _pack_target_add_target_command_groups(_self, command_set: CommandSet):


### PR DESCRIPTION
- When using cbuild-run/CMSIS-Pack targets, skip adding cores that are not present in the debug topology. These cores remain accessible through direct AP read/write operations, but are no longer inserted into the discovered core list.