### PR TITLE
Add udev rule for Raspberry Pi picoprobe 000c

### DIFF
--- a/udev/50-picoprobe.rules
+++ b/udev/50-picoprobe.rules
@@ -2,6 +2,10 @@
 # https://github.com/raspberrypi/picoprobe
 SUBSYSTEM=="usb", ATTR{idVendor}=="2e8a", ATTR{idProduct}=="0004", MODE:="666"
 
+# 2e8a:000c Raspberry Pi picoprobe
+# https://github.com/raspberrypi/picoprobe
+SUBSYSTEM=="usb", ATTR{idVendor}=="2e8a", ATTR{idProduct}=="000c", MODE:="666"
+
 # If you share your linux system with other users, or just don't like the
 # idea of write permission for everybody, you can replace MODE:="0666" with
 # OWNER:="yourusername" to create the device owned by you, or with


### PR DESCRIPTION
Added udev rule for Raspberry Pi picoprobe with idProduct 000c.

Both my Pico 2, and Debug Probe shows up with this product id.

```
┌─[ropi][ropi-desktop][~]
└─▪ lsusb | grep CMSIS
Bus 001 Device 006: ID 2e8a:000c Raspberry Pi Debugprobe on Pico (CMSIS-DAP)
Bus 001 Device 012: ID 2e8a:000c Raspberry Pi Debug Probe (CMSIS-DAP)
┌─[ropi][ropi-desktop][~]
└─▪ 
```