### PR TITLE
pyocd: core: helpers.py: reset colour for invalid choice

### DIFF
--- a/pyocd/core/helpers.py
+++ b/pyocd/core/helpers.py
@@ -202,7 +202,7 @@ class ConnectHelper:
                 except ValueError:
                     pass
                 if not valid:
-                    print(colorama.Fore.YELLOW + "Invalid choice: %s\n" % line)
+                    print(colorama.Fore.YELLOW + "Invalid choice: %s\n" % line + colorama.Style.RESET_ALL)
                     ConnectHelper._print_probe_list(allProbes)
                 else:
                     break


### PR DESCRIPTION
The yellow foreground of `Invalid choice` leaks into the `Probe/Board` selection

<img width="385" height="91" alt="Screenshot 2026-01-05 at 4 05 18 PM" src="https://github.com/user-attachments/assets/36824bbe-c867-4155-a6b8-2dea471ffadb" />
