### PR TITLE
Correct calculation of search size for RTT CB detection (fix #1729)

### DIFF
--- a/pyocd/debug/rtt.py
+++ b/pyocd/debug/rtt.py
@@ -434,7 +434,7 @@ class GenericRTTControlBlock(RTTControlBlock):
         offset: int = 0
 
         while search_size:
-            read_size = min(search_size, 32)
+            read_size = max(search_size, 32)
             data = self.target.read_memory_block8(addr, read_size)
 
             if not data:


### PR DESCRIPTION
To ensure a minimum size of 32 for the search range it is required to use max(search_size,32). Using min(search_size,32) reduces the given value for search size to a maximum of 32 - pretty much the opposite of the desired outcome.