### PR TITLE
udev: Add Artery Technology CMSIS-DAP

### DIFF
--- a/udev/50-cmsis-dap.rules
+++ b/udev/50-cmsis-dap.rules
@@ -1,3 +1,6 @@
+# 2e3c:f000 Artery Technology CMSIS-DAP
+SUBSYSTEM=="usb", ATTR{idVendor}=="2e3c", ATTR{idProduct}=="f000", MODE:="666"
+
 # 04b4:f138 Cypress KitProg1/KitProg2 CMSIS-DAP mode
 SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="f138", MODE:="666"
 


### PR DESCRIPTION
This is used on the [AT-START-F405](https://kb.segger.com/ArteryTek_AT-START-F405) evaluation board which includes a AT-Link-EZ adapter.

```
$ lsusb | grep CMSIS
Bus 003 Device 084: ID 2e3c:f000 Artery Technology CMSIS-DAP
```