### PR TITLE
Adapt to fnmatch.translate() using \z instead of \Z in Python 3.14

### DIFF
--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -54,7 +54,7 @@ class PackSubcommandBase(SubcommandBase):
         matches = set()
         for pattern in self._args.patterns:
             # Using fnmatch.fnmatch() was failing to match correctly.
-            pat = re.compile(fnmatch.translate(pattern).rsplit('\\Z')[0], re.IGNORECASE)
+            pat = re.compile(fnmatch.translate(pattern).rsplit('\\', 1)[0], re.IGNORECASE)
             results = {name for name in cache.index.keys() if pat.search(name)}
             matches.update(results)
 


### PR DESCRIPTION
fnmatch.translate() returns slightly different result in Python 3.14 .

https://docs.python.org/3.13/library/fnmatch.html
> '(?s:.*\\.txt)\\Z'

https://docs.python.org/3.14/library/fnmatch.html
> '(?s:.*\\.txt)\\z'

this causes `pyocd pack find X` to only match device names ending with X .