### PR TITLE
target: family: lpc5500: pre-reset via debug mailbox in reset_and_halt

### DIFF
--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -243,6 +243,20 @@ class CortexM_LPC5500(CortexM_v8M):
 
     def reset_and_halt(self, reset_type=None):
         """@brief Perform a reset and stop the core on the reset handler. """
+
+        # Reset the chip via the debug mailbox, re-enable debug access, and
+        # halt the core before any AHB-AP access. Running firmware can cause
+        # AHB bus contention that results in SWD WAIT/FAULT ACK failures.
+        # The debug mailbox has a dedicated path that bypasses the AHB bus.
+        target = self.session.target
+        dm_ap = target.aps.get(DM_AP)
+        if dm_ap is not None:
+            try:
+                target.unlock(dm_ap)
+                self.halt()
+            except exceptions.Error as err:
+                LOG.debug("debug mailbox pre-reset failed: %s", err)
+
         halt_only = False
         catch_mode = 0
 


### PR DESCRIPTION
On LPC55xx devices, running firmware can cause AHB bus contention that makes SWD accesses via the AHB-AP fail with WAIT ACK responses. This leads to transfer timeouts during the flash controller probing and SYSRESETREQ sequences that reset_and_halt performs before flash programming.

The debug mailbox (AP#2) has a dedicated path that does not go through the AHB bus. By issuing a chip reset through the debug mailbox and immediately halting the core at the start of reset_and_halt, all peripherals return to their power-on state and subsequent AHB-dependent operations proceed reliably.