### PR TITLE
coresight: Add fault tolerance for secured AP component scanning

### DIFF
--- a/pyocd/coresight/ap.py
+++ b/pyocd/coresight/ap.py
@@ -897,6 +897,7 @@ class MEM_AP(AccessPort, memory_interface.MemoryInterface):
         except exceptions.TransferError as error:
             LOG.error("Transfer error while reading %s ROM table: %s", self.short_description, error,
                 exc_info=self.dp.session.log_tracebacks)
+            raise
 
     @property
     def implemented_hprot_mask(self) -> int:

--- a/pyocd/coresight/discovery.py
+++ b/pyocd/coresight/discovery.py
@@ -175,9 +175,25 @@ class ADIv5Discovery(CoreSightDiscovery):
         seq = CallSequence()
         for ap in [x for x in self.dp.aps.values() if x.has_rom_table]:
             seq.append(
-                ('init_ap.{}'.format(ap.address.apsel), ap.find_components)
+                ('init_ap.{}'.format(ap.address.apsel), lambda _ap=ap: self._safe_find_components(_ap))
                 )
         return seq
+
+    def _safe_find_components(self, ap):
+        """@brief Wrapper around AP component discovery with fault tolerance.
+        If an AP returns a transfer fault (e.g. a secured/locked HSM AP),
+        the error is logged and discovery continues with remaining APs.
+        This prevents a single inaccessible AP from blocking discovery of
+        all cores on other, accessible APs.
+        """
+        try:
+            return ap.find_components()
+        except exceptions.TransferFaultError as e:
+            LOG.warning("AP#%s returned FAULT during component scan, skipping: %s", ap.address, e)
+        except exceptions.TransferError as e:
+            LOG.warning("Transfer error scanning AP#%s, skipping: %s", ap.address, e)
+        except exceptions.Error as e:
+            LOG.error("Error scanning AP#%s components: %s", ap.address, e, exc_info=self.session.log_tracebacks)
 
 class ADIv6Discovery(CoreSightDiscovery):
     """@brief Component discovery process for ADIv6.
@@ -277,9 +293,33 @@ class ADIv6Discovery(CoreSightDiscovery):
         seq = CallSequence()
         for ap in [x for x in self.dp.aps.values() if x.has_rom_table]:
             seq.append(
-                ('init_ap.{}'.format(str(ap.address)), ap.find_components)
+                ('init_ap.{}'.format(str(ap.address)), lambda _ap=ap: self._safe_find_components_v6(_ap))
                 )
         return seq
+
+    def _safe_find_components_v6(self, ap):
+        """@brief Wrapper around AP component discovery with fault tolerance for ADIv6.
+        Same rationale as ADIv5Discovery._safe_find_components -- prevents a
+        single secured/locked AP from blocking discovery on other APs.
+        """
+        try:
+            return ap.find_components()
+        except exceptions.TransferFaultError as e:
+            LOG.warning(
+                "AP#%s returned FAULT during component scan, skipping: %s",
+                ap.address,
+                e,
+            )
+        except exceptions.TransferError as e:
+            LOG.warning("Transfer error scanning AP#%s, skipping: %s", ap.address, e)
+        except exceptions.Error as e:
+            LOG.error(
+                "Error scanning AP#%s components: %s",
+                ap.address,
+                e,
+                exc_info=self.session.log_tracebacks,
+            )
+
 
 ## Map from ADI version to the discovery class.
 ADI_DISCOVERY_CLASS_MAP = {


### PR DESCRIPTION
Add fault-tolerant handling for secured/locked Access Ports that return FAULT when their ROM table is accessed during CoreSight discovery.

Fixes #[1921](https://github.com/pyocd/pyOCD/issues/1921)

## Changes

**`pyocd/coresight/ap.py`**
* Re-raise `TransferError` in `MEM_AP.find_components()` after logging, so callers can handle it.

**`pyocd/coresight/discovery.py`**
* Add `_safe_find_components()` wrapper in `ADIv5Discovery`.
* Add `_safe_find_components_v6()` wrapper in `ADIv6Discovery`.
* Both wrappers catch `TransferFaultError`/`TransferError`, log a warning, and continue discovery.

## Testing

* **Device:** Microchip PIC32CK2051SG01144 (Cortex-M33 with HSM)
* **Board:** EV33A17A (PIC32CK SG Curiosity Ultra)

**Before (upstream):**
```text
0001603 E Transfer error while reading AHB-AP#1 ROM table: Memory transfer fault ...
0001604 E Error while initing target: No cores were discovered!
```

**After (patched):**
```text
0001979 E Transfer error while reading AHB-AP#1 ROM table: Memory transfer fault ...
0001979 W AP#1 returned FAULT during component scan, skipping: Memory transfer fault ...
```

AP#1's FAULT is now caught and logged as a WARNING, allowing discovery to continue.