### PR TITLE
rtt_cmd: add option to disable local echo

### DIFF
--- a/pyocd/subcommands/rtt_cmd.py
+++ b/pyocd/subcommands/rtt_cmd.py
@@ -61,6 +61,8 @@ class RTTSubcommand(SubcommandBase):
                                  help="Down channel ID.")
         rtt_options.add_argument("-d", "--log-file", type=str, default=None,
                                  help="Log file name. When specified, logging mode is enabled.")
+        rtt_options.add_argument("--echo", action=argparse.BooleanOptionalAction, default=True,
+                                 help="Echo locally typed characters. By default echo is on.")
 
         return [cls.CommonOptions.COMMON, cls.CommonOptions.CONNECT, rtt_parser]
 
@@ -191,8 +193,9 @@ class RTTSubcommand(SubcommandBase):
 
                 if ord(c) == 27: # process ESC
                     break
-                elif c.isprintable() or c == '\n':
-                    print(c, end="", flush=True)
+                if self._args.echo:
+                    if c.isprintable() or c == '\n':
+                        print(c, end="", flush=True)
 
                 # add char to buffer
                 cmd += c.encode("utf-8")


### PR DESCRIPTION
When using a remote shell (like from zephyr),
the character are echoed already, and sometimes even control characters are used to keep the typed command while also logging.

So the shell experience is improved when the remote host does the echoing.