### PR TITLE
probe: jlink: open emulator before issuing commands

### DIFF
--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2020,2025 Arm Limited
 # Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2023 Marian Muller Rebeyrol
+# Copyright (c) 2026 Christophe Dufaza
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -187,11 +188,22 @@ class JLinkProbe(DebugProbe):
         try:
             # Configure UI usage. We must do this here rather than in the ctor because the ctor
             # doesn't have access to the session.
-            if self.session.options.get('jlink.non_interactive'):
+            non_interactive = self.session.options.get('jlink.non_interactive')
+
+            # With JLink DLL versions 9.14 and above, calling disable_dialog_boxes()
+            # before open() puts the pylink adapter into an inconsistent state.
+            # See:
+            # - #1925 "Jlink V9.22 No emulator with serial number"
+            # - #1927 "probe: jlink: open emulator before issuing commands"
+            # - square/pylink#259 "Fix exec command"
+            if non_interactive and self._link.version < "9.14":
                 self._link.disable_dialog_boxes()
 
             self._link.open(self._serial_number_int)
             self._is_open = True
+
+            if non_interactive and self._link.version >= "9.14":
+                self._link.disable_dialog_boxes()
 
             # Get available wire protocols.
             ifaces = self._link.supported_tifs()


### PR DESCRIPTION
## Problem description

Using a JLink probe (USB) with JLink DLL version 9.14a and above (latest immune version is 9.12), pyOCD will fail to connect to the emulator, raising  "No emulator with serial number XXXXXXXXXX" or "Could not connect to default emulator", depending on the command line arguments. 

I myself encountered this problem (programming/debugging an nRF52840-DK), as did at least one other pyOCD user [1], and one pylink user [2].
On my machine (Linux), pyOCD will additionally segfault in `JLINKARM_Close()` , probably on library unload (seen in coredump). 

## Proposed solution

It seems that the required emulator status (opened, connected) for executing some commands in  `JLink.disable_dialog_boxes()` have changed in the JLink SDK v9.14, triggering automatic connections the pylink interface does not take into account (yet ?).
They've started looking into it, but they're working (like most of us probably) without the JLink SDK documentation, and reverse engineering the state machine might not be straightforward: It is not even certain that `JLINKARM Open()` should not have to be called, in one way or another, before dispatching commands.

Proposed solution: in pyOCD `JLinkProbe.open()`, call `JLink.disable_dialog_boxes()` after `JLink.open()`.

This fix Works for me (TM), and `test/automated_test.py -d` succeeds, expect "Gdb Test" which is ignored (I don't have the right Python runtime for the versions of arm-none-eabi-gdb that I have at hand). 
Bellow is my `pyocd.yaml`:
``` yaml
probes:
  XXXXXXXXX # My probe's serial number.
    target_override:  nrf52
    test_binary:      l1_nrf52840-dk.bin
    frequency:        6000000
```

Hope this helps.

[1] pyocd/pyOCD#1925 Jlink V9.22 No emulator with serial number
[2] square/pylink#254 Can't connect to the emulator