### PR TITLE
coresight: cortex_m: gracefully handle inaccessible core after reset

### DIFF
--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1047,9 +1047,12 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         # Unless this is a halting reset, make sure the core is not halted. Some DFP debug sequences
         # (or user scripts) can leave the core halted after a reset.
         if not is_halting:
-            if self.get_state() == Target.State.HALTED:
-                LOG.debug("reset: core was halted after non-halting reset; now resuming")
-                self.resume()
+            try:
+                if self.get_state() == Target.State.HALTED:
+                    LOG.debug("reset: core was halted after non-halting reset; now resuming")
+                    self.resume()
+            except exceptions.Error as e:
+                LOG.warning("Failed to check state or resume core %d after reset: %s", self.core_number, e)
 
         self.call_delegate('did_reset', core=self, reset_type=reset_type)
 


### PR DESCRIPTION
When performing a post-reset check in `_inner_reset` to ensure the core is not halted, `get_state()` reads the DHCSR register via SWD. On certain MCUs (like the LPC55S28), the SWD link may drop or become temporarily inaccessible immediately after a reset, causing `get_state()` to throw a TransferFaultError.

Previously, this unhandled exception would bubble up and cause the flash operation to crash with a fatal status 1 exit code, even if the flash and reset were otherwise successful.

This adds a `try/except` block around the state check in `_inner_reset()` to catch `exceptions.Error`. If the core state cannot be read or resumed, it logs a warning instead of aborting the entire command.