### PR TITLE
sequences: add DAP delay to default ResetSystem debug sequence

### DIFF
--- a/pyocd/debug/sequences/default_sequences.yaml
+++ b/pyocd/debug/sequences/default_sequences.yaml
@@ -216,6 +216,8 @@ debug-sequences:
 
           // Execute SYSRESETREQ via AIRCR
           Write32(AIRCR_Addr, 0x05FA0004);
+          // Delay for 100ms
+          DAP_Delay(100000);
       - while: (Read32(DHCSR_Addr) & 0x02000000)
         timeout: 500000
   - name: ResetProcessor


### PR DESCRIPTION
Improve debug robustness by allowing bootloader initialization to complete before subsequent operations.