### PR TITLE
subcommands: pack_cmd: fix pattern matching

### DIFF
--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -54,7 +54,7 @@ class PackSubcommandBase(SubcommandBase):
         matches = set()
         for pattern in self._args.patterns:
             # Using fnmatch.fnmatch() was failing to match correctly.
-            pat = re.compile(fnmatch.translate(pattern).rsplit('\\Z')[0], re.IGNORECASE)
+            pat = re.compile(fnmatch.translate(pattern).rsplit('\\Z')[0].rsplit('\\z')[0], re.IGNORECASE)
             results = {name for name in cache.index.keys() if pat.search(name)}
             matches.update(results)
 
@@ -367,4 +367,3 @@ class PackSubcommand(PackSubcommandBase):
                 print()
 
         return 0
-


### PR DESCRIPTION
This PR fixes pattern matching e.g. for pack find subcommand due to a change of fnmatch.translate behavior in Python 3.14.

Since Python 3.14 the behavior of `fnmatch.translate` differs from the older versions. The returned string ends with `\z` instead of `\Z` on Python versions <3.14. (https://docs.python.org/3.14/library/fnmatch.html)

This leads to the `pack find` command not working as documented (https://pyocd.io/docs/target_support.html#cmsis-packs), as searches need to have an asterisks at the end. The command is documented without the need for an asterisks.

My patch aims for making pyocd compatible with both versions, `\z` and `\Z`, by simply adding another `.rsplit()`

Without patch:
```
$ pyocd pack find MCXN947
0000441 W No matching devices. Please make sure the pack index is up to date. [pack_cmd]
```
```
$ pyocd pack find "MCXN947*"
  Part          Vendor   Pack               Version    Installed
------------------------------------------------------------------
  MCXN947TVAB   NXP      NXP.MCXN947T_DFP   26.06.00   False
  MCXN947VAB    NXP      NXP.MCXN947_DFP    26.06.00   False
```

With patch:
```
$ pyocd pack find MCXN947
  Part          Vendor   Pack               Version    Installed
------------------------------------------------------------------
  MCXN947TVAB   NXP      NXP.MCXN947T_DFP   26.06.00   False
  MCXN947VAB    NXP      NXP.MCXN947_DFP    26.06.00   False
[...]
  ```



