### PR TITLE
target/lpc4088qsb: fix page_size mismatch causing silent flash corruption

### DIFF
--- a/pyocd/target/builtin/target_lpc4088qsb.py
+++ b/pyocd/target/builtin/target_lpc4088qsb.py
@@ -77,7 +77,7 @@ class LPC4088qsb(LPC4088):
                                                                 page_size=0x200,
                                                                 algo=INTERNAL_FLASH_ALGO),
         FlashRegion(    start=0x10000,     length=0x70000,      blocksize=0x8000,
-                                                                page_size=0x400,
+                                                                page_size=0x200,
                                                                 erase_sector_weight=LARGE_ERASE_SECTOR_WEIGHT,
                                                                 program_page_weight=LARGE_PROGRAM_PAGE_WEIGHT,
                                                                 algo=INTERNAL_FLASH_ALGO),


### PR DESCRIPTION
## Summary
`target_lpc4088qsb.py`'s `FlashRegion` for the main flash bank (start=0x10000,
&gt;64 KB) declares `page_size=0x400`, but the `INTERNAL_FLASH_ALGO` it uses
(shared with `target_LPC4088FBD144`, which correctly declares `page_size=0x200`
for the equivalent region) only implements 512-byte pages: its own
`page_size`/`min_program_length` are `0x200`/`512`, and `page_buffers` holds a
single 512-byte buffer.

With `page_size=0x400`, the flash loader chunks writes into 1 KB pages, but
`program_page()` only programs the first 512 bytes of each chunk and silently
drops the rest — no error is raised. Any image whose `.bin` crosses the 64 KB
boundary and isn't an exact multiple of 1 KB in that region ends up with
512-byte holes left at the erased value.

## How I found this
Debugging a board that ran fine until its firmware image grew past 64 KB,
after which it intermittently corrupted RAM depending on exact build layout.
Confirmed via readback (`pyocd commander` `savemem` + binary diff): a ~65.6 KB
image left a 512-byte hole unprogrammed (still `0xFF`) right at the boundary,
while `pyocd flash` reported success with no warning.

## Fix
Change `page_size` for that region from `0x400` to `0x200`, matching the
flash algo and the sibling target `target_LPC4088FBD144.py`.

## Testing
Re-flashed the same image after the fix; readback matched the source `.bin`
exactly, and the target (LPC4088-based board) now runs correctly.