### PR TITLE
Add Arduino UNO WiFi R4 CMSIS-DAP rule

### DIFF
--- a/udev/50-cmsis-dap.rules
+++ b/udev/50-cmsis-dap.rules
@@ -1,3 +1,6 @@
+# 2341:1002 Arduino UNO WiFi R4 CMSIS-DAP
+SUBSYSTEM=="usb", ATTR{idVendor}=="2341", ATTR{idProduct}=="1002", MODE:="666"
+
 # 04b4:f138 Cypress KitProg1/KitProg2 CMSIS-DAP mode
 SUBSYSTEM=="usb", ATTR{idVendor}=="04b4", ATTR{idProduct}=="f138", MODE:="666"
 


### PR DESCRIPTION
`dmesg` output from my machine for ID validation:

```
[ 1137.890377] usb 1-5: New USB device found, idVendor=2341, idProduct=1002, bcdDevice= 0.06
[ 1137.890394] usb 1-5: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[ 1137.890401] usb 1-5: Product: UNO WiFi R4 CMSIS-DAP
[ 1137.890407] usb 1-5: Manufacturer: Arduino
[ 1137.890412] usb 1-5: SerialNumber: F09E9E7B1E90
[ 1137.895515] hid-generic 0003:2341:1002.0007: hiddev96,hidraw1: USB HID v1.11 Device [Arduino UNO WiFi R4 CMSIS-DAP] on usb-0000:00:14.0-5/input0
```

`pyocd list` works on my machine with this rule added:
```
gary@fedora:~/Downloads/breathing_led$ pyocd list
  #   Probe/Board                     Unique ID      Target  
-------------------------------------------------------------
  0   Arduino UNO WiFi R4 CMSIS-DAP   F09E9E7B1E90   n/a 
```