### PR TITLE
pack: return error when no devices match

### DIFF
--- a/pyocd/subcommands/pack_cmd.py
+++ b/pyocd/subcommands/pack_cmd.py
@@ -1,6 +1,7 @@
 # pyOCD debugger
 # Copyright (c) 2021 Chris Reed
 # Copyright (c) 2026 Arm Limited
+# Copyright (c) 2026 Giridhar
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -189,6 +190,9 @@ class PackFindSubcommand(PackSubcommandBase):
         # Look for matching part numbers.
         matches = self._get_matches(cache)
 
+        if not matches:
+            return 1
+
         if matches:
             # Get the list of installed pack targets.
             installed_targets = pack_target.ManagedPacks.get_installed_targets(cache=cache)
@@ -250,6 +254,9 @@ class PackInstallSubcommand(PackSubcommandBase):
 
         # Look for matching part numbers.
         matches = self._get_matches(cache)
+
+        if not matches:
+            return 1
 
         if matches:
             devices = [cache.index[dev] for dev in matches]
@@ -338,6 +345,9 @@ class PackSubcommand(PackSubcommandBase):
             self._args.patterns = self._args.find_devices or self._args.install_devices
 
             matches = self._get_matches(cache)
+
+            if not matches:
+                return 1
 
             if self._args.find_devices:
                 # Get the list of installed pack targets.

--- a/test/unit/test_pack_cmd.py
+++ b/test/unit/test_pack_cmd.py
@@ -1,0 +1,81 @@
+# pyOCD debugger
+# Copyright (c) 2026 Giridhar
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from argparse import Namespace
+from types import SimpleNamespace
+
+import pytest
+
+from pyocd.subcommands.pack_cmd import (
+    PackFindSubcommand,
+    PackInstallSubcommand,
+    PackSubcommand,
+    )
+
+
+@pytest.fixture
+def cache():
+    return SimpleNamespace(index={"KnownDevice": {}})
+
+
+def test_pack_find_returns_error_when_no_device_matches(monkeypatch, cache):
+    command = PackFindSubcommand(Namespace(
+        patterns=["MissingDevice"],
+        update=False,
+        clean=False,
+        no_header=False,
+        verbose=0,
+        quiet=0,
+        ))
+    monkeypatch.setattr(command, "_get_cache", lambda: cache)
+
+    assert command.invoke() == 1
+
+
+def test_pack_install_returns_error_when_no_device_matches(monkeypatch, cache):
+    command = PackInstallSubcommand(Namespace(
+        patterns=["MissingDevice"],
+        update=False,
+        clean=False,
+        no_download=False,
+        verbose=0,
+        quiet=0,
+        ))
+    monkeypatch.setattr(command, "_get_cache", lambda: cache)
+
+    assert command.invoke() == 1
+
+
+@pytest.mark.parametrize(("find_devices", "install_devices"), [
+    (["MissingDevice"], None),
+    (None, ["MissingDevice"]),
+    ])
+def test_deprecated_pack_options_return_error_when_no_device_matches(
+        monkeypatch, cache, find_devices, install_devices):
+    command = PackSubcommand(Namespace(
+        clean=False,
+        update=False,
+        show=False,
+        find_devices=find_devices,
+        install_devices=install_devices,
+        no_download=False,
+        no_header=False,
+        verbose=0,
+        quiet=0,
+        ))
+    monkeypatch.setattr(command, "_get_cache", lambda: cache)
+
+    assert command.invoke() == 1


### PR DESCRIPTION
Fixes #1130.

`pyocd pack find` and `pyocd pack install` currently return success when no device matches the requested pattern. This makes failed lookups indistinguishable from successful commands in scripts.

The modern subcommands and their deprecated `--find` / `--install` equivalents now return status 1 when the match set is empty. The behavior of `pack update` is unchanged because a metadata refresh can partially succeed, as discussed in the issue.

Tests:

* `pytest test/unit/test_pack_cmd.py -q` — 4 passed
* `pytest test/unit -q` — 1104 passed, 41 skipped
* `flake8 pyocd test --count --select=E9,F63,F7,F82 --show-source --statistics` — 0 errors
* `python test/import_all.py` — 372 modules imported
* `python -m build`
* `twine check dist/*` — wheel and source archive passed
* `git diff --check`
