### PR TITLE
probe: fix J-Link swo_read crash when swo_num_bytes() returns a negative value

### DIFF
--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2021-2022 Chris Reed
 # Copyright (c) 2023 Marian Muller Rebeyrol
 # Copyright (c) 2026 Christophe Dufaza
+# Copyright (c) 2026 Aditya Nikam
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -498,7 +499,10 @@ class JLinkProbe(DebugProbe):
 
     def swo_read(self):
         try:
-            return self._link.swo_read(0, self._link.swo_num_bytes(), True)
+            count = self._link.swo_num_bytes()
+            if count <= 0:
+                return bytearray()
+            return self._link.swo_read(0, count, True)
         except JLinkException as exc:
             raise self._convert_exception(exc) from exc
 

--- a/pyocd/probe/jlink_probe.py
+++ b/pyocd/probe/jlink_probe.py
@@ -500,7 +500,7 @@ class JLinkProbe(DebugProbe):
     def swo_read(self):
         try:
             count = self._link.swo_num_bytes()
-            if count <= 0:
+            if count == 0:
                 return bytearray()
             return self._link.swo_read(0, count, True)
         except JLinkException as exc:


### PR DESCRIPTION
Fixes #2019.

JLinkProbe.swo_read() passed self._link.swo_num_bytes() straight into swo_read() as the count.
pylink allocates a ctypes buffer sized to that count, so passing 0 -- which is normal when no SWO
data is available -- crashes with IndexError, which isn't a JLinkException and so isn't caught by
the existing except clause either; it kills the SWV reader thread outright.

self._link.swo_num_bytes() never returns a negative value (pylink validates and raises internally
if the underlying call fails), so the guard only needs to check for zero, not negative -- thanks to
@RobertRostohar for catching that in review.

Guards the count before the call and returns an empty bytearray() when it's zero, matching
DebugProbe.swo_read's documented return type.

No test added, JLinkProbe's constructor calls into the real J-Link DLL and raises ProbeError if it's
not present, so testing this cleanly would mean bypassing normal construction in a way nothing else
in this codebase does.
