### PR TITLE
target: refine state handling (RUNNING, SLEEPING, HALTED)

### DIFF
--- a/pyocd/cache/memory.py
+++ b/pyocd/cache/memory.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2020 Arm Limited
+# Copyright (c) 2016-2020,2026 Arm Limited
 # Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,7 +31,7 @@ class MemoryCache(object):
     will be used to fill the cache.
 
     The cache is invalidated whenever the target has run since the last cache operation (based on run
-    tokens). If the target is currently running, all accesses cause the cache to be invalidated.
+    tokens). If the target is currently not halted, all accesses cause the cache to be invalidated.
 
     The target's memory map is referenced. All memory accesses must be fully contained within a single
     memory region, or a TransferFaultError will be raised. However, if an access is outside of all regions,
@@ -51,8 +51,8 @@ class MemoryCache(object):
 
     def _check_cache(self):
         """@brief Invalidates the cache if appropriate."""
-        if self._core.is_running():
-            LOG.debug("core is running; invalidating cache")
+        if not self._core.is_halted():
+            LOG.debug("core is not halted; invalidating cache")
             self._reset_cache()
         elif self._run_token != self._core.run_token:
             self._dump_metrics()

--- a/pyocd/cache/register.py
+++ b/pyocd/cache/register.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2016-2020,2025 Arm Limited
+# Copyright (c) 2016-2020,2025-2026 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -74,9 +74,9 @@ class RegisterCache(object):
             LOG.debug("no accesses")
 
     def _check_cache(self):
-        """@brief Invalidates the cache if needed and returns whether the core is running."""
-        if self._core.is_running():
-            LOG.debug("core is running; invalidating cache")
+        """@brief Invalidates the cache if needed and returns whether the core is not halted."""
+        if not self._core.is_halted():
+            LOG.debug("core is not halted; invalidating cache")
             self._reset_cache()
             return True
         elif self._run_token != self._core.run_token:
@@ -93,7 +93,7 @@ class RegisterCache(object):
         return reg_list
 
     def read_core_registers_raw(self, reg_list):
-        # Invalidate the cache. If the core is still running, just read directly from it.
+        # Invalidate the cache. If the core is not halted, just read directly from it.
         if self._check_cache():
             return self._context.read_core_registers_raw(reg_list)
 
@@ -163,7 +163,7 @@ class RegisterCache(object):
 
     # TODO only write dirty registers to target right before running.
     def write_core_registers_raw(self, reg_list, data_list):
-        # Check and invalidate the cache. If the core is still running, just pass the writes
+        # Check and invalidate the cache. If the core is not halted, just pass the writes
         # to our context.
         if self._check_cache():
             self._context.write_core_registers_raw(reg_list, data_list)

--- a/pyocd/coresight/cortex_m.py
+++ b/pyocd/coresight/cortex_m.py
@@ -1131,7 +1131,7 @@ class CortexM(CoreTarget, CoreSightCoreComponent): # lgtm[py/multiple-calls-to-i
         if reset_type is not Target.ResetType.EMULATED:
             with timeout.Timeout(self.session.options.get('reset.halt_timeout')) as t_o:
                 while t_o.check():
-                    if self.get_state() not in (Target.State.RESET, Target.State.RUNNING):
+                    if self.get_state() == Target.State.HALTED:
                         break
                     sleep(0.01)
                 else:

--- a/pyocd/flash/flash.py
+++ b/pyocd/flash/flash.py
@@ -649,7 +649,7 @@ class Flash:
             while time_out.check():
                 try:
                     state = self.target.get_state()
-                    if state != Target.State.RUNNING:
+                    if state == Target.State.HALTED:
                         break
                 except exceptions.TransferTimeoutError:
                     LOG.debug("target.get_state probe timeout")

--- a/pyocd/target/builtin/target_K32W042S1M2xxx.py
+++ b/pyocd/target/builtin/target_K32W042S1M2xxx.py
@@ -207,7 +207,7 @@ class K32W042S(Kinetis):
             self.mdm_ap.write_reg(MDM_CTRL, 0)
 
             # sanity check that the target is still halted
-            if self.get_state() == Target.State.RUNNING:
+            if self.get_state() != Target.State.HALTED:
                 raise exceptions.DebugError("Target failed to stay halted during init sequence")
 
     def post_connect_hook(self):

--- a/pyocd/target/builtin/target_s5js100.py
+++ b/pyocd/target/builtin/target_s5js100.py
@@ -253,7 +253,7 @@ class CortexM_S5JS100(CortexM):
         with Timeout(5.0) as t_o:
             while t_o.check():
                 try:
-                    if not self.is_running():
+                    if self.is_halted():
                         break
                 except exceptions.TransferError:
                     self.flush()

--- a/pyocd/target/family/target_kinetis.py
+++ b/pyocd/target/family/target_kinetis.py
@@ -1,6 +1,6 @@
 # pyOCD debugger
 # Copyright (c) 2020 NXP
-# Copyright (c) 2006-2018 Arm Limited
+# Copyright (c) 2006-2018,2026 Arm Limited
 # Copyright (c) 2021 Chris Reed
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -216,7 +216,7 @@ class Kinetis(CoreSightTarget):
             self.mdm_ap.write_reg(MDM_CTRL, 0)
 
             # sanity check that the target is still halted
-            if self.get_state() == Target.State.RUNNING:
+            if self.get_state() != Target.State.HALTED:
                 raise exceptions.DebugError("Target failed to stay halted during init sequence")
 
     def is_locked(self):

--- a/pyocd/target/family/target_lpc5500.py
+++ b/pyocd/target/family/target_lpc5500.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019-2020,2025 Arm Limited
+# Copyright (c) 2019-2020,2025-2026 Arm Limited
 # Copyright (C) 2020 Ted Tawara
 # Copyright (c) 2021 Chris Reed
 # Copyright (c) 2021 Matthias Wauer
@@ -332,7 +332,7 @@ class CortexM_LPC5500(CortexM_v8M):
         # wait until the unit resets
         with timeout.Timeout(1.0) as t_o:
             while t_o.check():
-                if self.get_state() not in (Target.State.RESET, Target.State.RUNNING):
+                if self.get_state() == Target.State.HALTED:
                     break
                 sleep(0.01)
 

--- a/pyocd/target/family/target_psoc6.py
+++ b/pyocd/target/family/target_psoc6.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2013-2019,2025 Arm Limited
+# Copyright (c) 2013-2019,2025-2026 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -75,7 +75,7 @@ class CortexM_PSoC6(CortexM):
         with Timeout(5.0) as t_o:
             while t_o.check():
                 try:
-                    if not self.is_running():
+                    if self.is_halted():
                         break
                 except exceptions.TransferError:
                     self.flush()
@@ -225,7 +225,7 @@ class CortexM_PSoC64(CortexM):
         with Timeout(5.0) as t_o:
             while t_o.check():
                 try:
-                    if not self.is_running():
+                    if self.is_halted():
                         break
                 except exceptions.TransferError:
                     self.flush()

--- a/test/connect_test.py
+++ b/test/connect_test.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2017-2020,2025 Arm Limited
+# Copyright (c) 2017-2020,2025-2026 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,11 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 import sys
 import traceback
 import argparse
-from collections import namedtuple
 import logging
 
 from pyocd.core.helpers import ConnectHelper
@@ -39,8 +37,8 @@ STATE_NAMES = {
     Target.State.LOCKUP : "lockup",
     }
 
-RUNNING = Target.State.RUNNING
-HALTED = Target.State.HALTED
+RUNNING = (Target.State.RUNNING, Target.State.SLEEPING)
+HALTED = (Target.State.HALTED,)
 
 class ConnectTestCase(object):
     def __init__(self, prev_exit_state, connect_mode, expected_state, disconnect_resume, exit_state):
@@ -89,6 +87,9 @@ def connect_test(board):
     rom_region = memory_map.get_boot_memory()
     rom_start = rom_region.start
 
+    def format_state_names(states):
+        return "/".join(STATE_NAMES.get(state, "unknown") for state in states)
+
     def test_connect(connect_mode, expected_state, resume):
         print("Connecting with connect_mode=%s" % connect_mode)
         live_session = ConnectHelper.session_with_chosen_probe(
@@ -99,19 +100,18 @@ def connect_test(board):
                         **get_session_options())
         live_session.open()
         live_board = live_session.board
-        print("Verifying target is", STATE_NAMES.get(expected_state, "unknown"))
+        expected_state_name = format_state_names(expected_state)
+        print("Verifying target is", expected_state_name)
         actualState = live_board.target.get_state()
-        # Accept sleeping for running, as a hack to work around nRF52840-DK test binary.
-        # TODO remove sleeping hack.
-        if (actualState == expected_state) \
-                or (expected_state == RUNNING and actualState == Target.State.SLEEPING):
+        # Check if the actual state matches the expected state.
+        if actualState in expected_state:
             passed = 1
             print("TEST PASSED")
         else:
             passed = 0
             print("TEST FAILED (state={}, expected={})".format(
                 STATE_NAMES.get(actualState, "unknown"),
-                STATE_NAMES.get(expected_state, "unknown")))
+                expected_state_name))
         print("Disconnecting with resume=%s" % resume)
         live_session.close()
         live_session = None
@@ -140,11 +140,11 @@ def connect_test(board):
     test_count += 1
     print("Verifying target is running")
     current_state = live_board.target.get_state()
-    if live_board.target.is_running() or current_state == Target.State.SLEEPING:
+    if current_state in RUNNING:
         test_pass_count += 1
         print("TEST PASSED")
     else:
-        print("State=%s" % current_state)
+        print("State=%s" % STATE_NAMES.get(current_state, "unknown"))
         print("TEST FAILED")
     print("Disconnecting with resume=True")
     live_session.options['resume_on_disconnect'] = True
@@ -164,16 +164,16 @@ def connect_test(board):
         case.passed=did_pass
 
     print("\n\nTest Summary:")
-    print("\n{:<4}{:<12}{:<19}{:<12}{:<21}{:<11}{:<10}".format(
+    print("\n{:<4}{:<18}{:<19}{:<18}{:<21}{:<18}{:<10}".format(
         "#", "Prev Exit", "Connect Mode", "Expected", "Disconnect Resume", "Exit", "Passed"))
     for i, case in enumerate(test_cases):
-        print("{:<4}{:<12}{:<19}{:<12}{:<21}{:<11}{:<10}".format(
+        print("{:<4}{:<18}{:<19}{:<18}{:<21}{:<18}{:<10}".format(
             i,
-            STATE_NAMES[case.prev_exit_state],
+            format_state_names(case.prev_exit_state),
             case.connect_mode,
-            STATE_NAMES[case.expected_state],
+            format_state_names(case.expected_state),
             repr(case.disconnect_resume),
-            STATE_NAMES[case.exit_state],
+            format_state_names(case.exit_state),
             "PASS" if case.passed else "FAIL"))
     print("\nPass count %i of %i tests" % (test_pass_count, test_count))
     if test_pass_count == test_count:

--- a/test/unit/mockcore.py
+++ b/test/unit/mockcore.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2017-2019,2025 Arm Limited
+# Copyright (c) 2017-2019,2025-2026 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,6 +64,9 @@ class MockCore(CoreSightCoreComponent, MemoryInterface):
 
     def is_running(self):
         return False
+
+    def is_halted(self):
+        return True
 
     def read_core_registers_raw(self, reg_list):
         reg_list = [CortexMCoreRegisterInfo.register_name_to_index(reg) for reg in reg_list]

--- a/test/unit/test_rom_table.py
+++ b/test/unit/test_rom_table.py
@@ -1,5 +1,5 @@
 # pyOCD debugger
-# Copyright (c) 2019-2020 Arm Limited
+# Copyright (c) 2019-2020,2026 Arm Limited
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,6 +44,9 @@ class MockCoreForMemCache(CoreSightCoreComponent):
 
     def is_running(self):
         return False
+
+    def is_halted(self):
+        return True
 
 MockDebugContext = mock.Mock(spec=DebugContext)
 


### PR DESCRIPTION
Target.State.RUNNING / is_running() does not cover SLEEPING mode.

Target.State.HALTED / is_halted() is used to identify that the target is halted.

Required also for memory/register cache invalidate.